### PR TITLE
Remove unneeded assert.

### DIFF
--- a/lib/src/summary.dart
+++ b/lib/src/summary.dart
@@ -29,7 +29,6 @@ class DartFileSummary {
     this.platform,
   ) {
     assert((platform == null) == (directLibs == null));
-    assert((platform == null) == (transitiveLibs == null));
   }
 
   factory DartFileSummary.fromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
It is possible that we drop the transitive libs, but still have the platform set.