### PR TITLE
Detecting some licenses.

### DIFF
--- a/lib/pana.dart
+++ b/lib/pana.dart
@@ -11,6 +11,7 @@ import 'package:pub_semver/pub_semver.dart';
 
 import 'src/analyzer_output.dart';
 import 'src/library_analyzer.dart';
+import 'src/license.dart';
 import 'src/logging.dart';
 import 'src/platform.dart';
 import 'src/pub_summary.dart';
@@ -20,6 +21,7 @@ import 'src/summary.dart';
 import 'src/utils.dart';
 
 export 'src/analyzer_output.dart';
+export 'src/license.dart';
 export 'src/platform.dart';
 export 'src/pub_summary.dart';
 export 'src/pubspec.dart';
@@ -204,8 +206,10 @@ class PackageAnalyzer {
       flutterVersion = await _flutterSdk.getVersion();
     }
 
+    License license = await detectLicenseInDir(pkgDir);
+
     return new Summary(sdkVersion, package, new Version.parse(pkgInfo.version),
-        summary, files, issues,
+        summary, files, issues, license,
         flutterVersion: flutterVersion);
   }
 

--- a/lib/src/license.dart
+++ b/lib/src/license.dart
@@ -1,0 +1,139 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+class License {
+  final String name;
+  final String version;
+
+  License(this.name, [this.version]);
+
+  factory License.fromJson(Map json) =>
+      new License(json['name'], json['version']);
+
+  Map<String, dynamic> toJson() {
+    Map map = {
+      'name': name,
+    };
+    if (version != null) {
+      map['version'] = version;
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    if (version == null) return name;
+    return '$name $version';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is License &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          version == other.version;
+
+  @override
+  int get hashCode => name.hashCode ^ version.hashCode;
+}
+
+abstract class LicenseNames {
+  static const String AGPL = 'AGPL';
+  static const String BSD = 'BSD';
+  static const String GPL = 'GPL';
+  static const String MIT = 'MIT';
+  static const String missing = 'missing';
+  static const String unknown = 'unknown';
+}
+
+Future<License> detectLicenseInDir(String baseDir) async {
+  final List<FileSystemEntity> list =
+      await new Directory(baseDir).list().toList();
+  final File licenseFile = list.firstWhere(_isLicenseFile, orElse: () => null);
+  if (licenseFile == null) {
+    return new License(LicenseNames.missing);
+  }
+  final String content = await licenseFile.readAsString();
+  final License license = detectLicenseInContent(content);
+  return license ?? new License(LicenseNames.unknown);
+}
+
+License detectLicenseInContent(String content) {
+  final String stripped = _longTextPrepare(content);
+
+  String version;
+  final Match versionMatch = _version.firstMatch(stripped);
+  if (versionMatch != null) {
+    version = versionMatch.group(1);
+    if (version.isNotEmpty && !version.contains('.')) {
+      version += '.0';
+    }
+  }
+
+  if (_agpl.hasMatch(stripped)) {
+    return new License(LicenseNames.AGPL, version);
+  }
+  if (_gplLong.hasMatch(stripped)) {
+    return new License(LicenseNames.GPL, version);
+  }
+  if (_gplShort.hasMatch(stripped)) {
+    return new License(LicenseNames.GPL, version);
+  }
+  if (_mit.hasMatch(stripped)) {
+    return new License(LicenseNames.MIT, version);
+  }
+
+  if (_bsdPreamble.hasMatch(stripped) && _bsdEmphasis.hasMatch(stripped)) {
+    return new License(LicenseNames.BSD);
+  }
+
+  return null;
+}
+
+final RegExp _whitespace = new RegExp('\\s+');
+final RegExp _extraCharacters = new RegExp('\\"|\\\'|\\*');
+
+final RegExp _agpl =
+    new RegExp('GNU AFFERO GENERAL PUBLIC LICENSE', caseSensitive: false);
+final RegExp _gplLong =
+    new RegExp('GENERAL PUBLIC LICENSE', caseSensitive: false);
+final RegExp _gplShort = new RegExp('GNU GPL', caseSensitive: false);
+final RegExp _mit = new RegExp('The MIT License', caseSensitive: false);
+final RegExp _version =
+    new RegExp(r'Version (\d+(\.\d*)?)', caseSensitive: false);
+
+final RegExp _bsdPreamble = _longTextRegExp('''
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met''');
+
+final RegExp _bsdEmphasis = _longTextRegExp('''
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.
+''');
+
+bool _isLicenseFile(FileSystemEntity fse) {
+  if (fse is File) {
+    final String relative = p.relative(fse.path, from: fse.parent.path);
+    final String lower = relative.toLowerCase();
+    return lower == 'license' ||
+        lower == 'license.txt' ||
+        lower == 'license.md';
+  }
+  return false;
+}
+
+String _longTextPrepare(String text) =>
+    text.replaceAll(_extraCharacters, ' ').replaceAll(_whitespace, ' ').trim();
+
+RegExp _longTextRegExp(String text) =>
+    new RegExp(_longTextPrepare(text), caseSensitive: false);

--- a/lib/src/summary.dart
+++ b/lib/src/summary.dart
@@ -7,6 +7,7 @@ import 'dart:collection';
 import 'package:pub_semver/pub_semver.dart';
 
 import 'analyzer_output.dart';
+import 'license.dart';
 import 'platform.dart';
 import 'pub_summary.dart';
 import 'pubspec.dart';
@@ -83,9 +84,10 @@ class Summary {
   final PubSummary pubSummary;
   final Map<String, DartFileSummary> dartFiles;
   final List<AnalyzerIssue> issues;
+  final License license;
 
   Summary(this.sdkVersion, this.packageName, this.packageVersion,
-      this.pubSummary, this.dartFiles, this.issues,
+      this.pubSummary, this.dartFiles, this.issues, this.license,
       {this.flutterVersion});
 
   factory Summary.fromJson(Map<String, dynamic> json) {
@@ -102,8 +104,12 @@ class Summary {
     List<AnalyzerIssue> issues =
         issuesRaw?.map((Map map) => new AnalyzerIssue.fromJson(map))?.toList();
 
-    return new Summary(
-        sdkVersion, packageName, packageVersion, pubSummary, dartFiles, issues,
+    Map licenseRaw = json['license'];
+    License license =
+        licenseRaw == null ? null : new License.fromJson(licenseRaw);
+
+    return new Summary(sdkVersion, packageName, packageVersion, pubSummary,
+        dartFiles, issues, license,
         flutterVersion: json['flutterVersion']);
   }
 
@@ -125,6 +131,7 @@ class Summary {
       'packageVersion': packageVersion.toString(),
       'pubSummary': pubSummary,
       'dartFiles': dartFiles,
+      'license': license,
     });
 
     if (issues != null && issues.isNotEmpty) {

--- a/test/end2end/http_data.dart
+++ b/test/end2end/http_data.dart
@@ -674,5 +674,6 @@ final data = {
       "isFormatted": false,
       "analyzerItems": [],
     }
-  }
+  },
+  "license": {"name": "BSD"}
 };

--- a/test/end2end/pub_server_data.dart
+++ b/test/end2end/pub_server_data.dart
@@ -385,6 +385,7 @@ final data = {
           "error": "'expectAsync' is deprecated and shouldn't be used."
         }
       ]
-    }
+    },
   },
+  "license": {"name": "BSD"}
 };

--- a/test/license_test.dart
+++ b/test/license_test.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2017, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pana/src/license.dart';
+
+main() {
+  group('AGPL', () {
+    test('explicit', () {
+      expect(detectLicenseInContent('GNU AFFERO GENERAL PUBLIC LICENSE'),
+          new License('AGPL'));
+    });
+  });
+
+  group('BSD', () {
+    test('detect project LICENSE', () async {
+      expect(await detectLicenseInDir('.'), new License('BSD'));
+    });
+  });
+
+  group('GPL', () {
+    test('explicit', () {
+      expect(
+          detectLicenseInContent([
+            'GNU GENERAL PUBLIC LICENSE',
+            'Version 2, June 1991'
+          ].join('\n')),
+          new License('GPL', '2.0'));
+      expect(detectLicenseInContent(['GNU GPL Version 2'].join('\n')),
+          new License('GPL', '2.0'));
+    });
+  });
+
+  group('MIT', () {
+    test('explicit', () {
+      expect(detectLicenseInContent('\n\n   The MIT license\n\n blah...'),
+          new License('MIT'));
+    });
+  });
+
+  group('unknown', () {
+    test('empty content', () {
+      expect(detectLicenseInContent(''), isNull);
+    });
+  });
+}


### PR DESCRIPTION
I think the [licensee](https://github.com/benbalter/licensee) or [detect-license](https://github.com/tantalor/detect-license/) should be used only as a fallback when we fail to detect it. We shall try to get away with trivial patterns, because:
- it is simple to do so for most use cases
- faster to execute than an external process with is own runtime baggage
- doesn't require additional setup for local development.

This CL is for the very simple patterns, we can add more as we go ahead with the package analysis, and eventually some third-party if we have many files that are not classified properly.