### PR TITLE
Rename platform: console to standalone.

### DIFF
--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -8,7 +8,7 @@ part 'platform.g.dart';
 
 abstract class KnownPlatforms {
   static const String browser = 'browser';
-  static const String console = 'console';
+  static const String standalone = 'standalone';
   static const String flutter = 'flutter';
   static const String mirrors = 'mirrors';
 
@@ -49,19 +49,20 @@ class PlatformInfo extends Object with _$PlatformInfoSerializerMixin {
   bool get hasConflict =>
       (!worksAnywhere) ||
       (uses.contains(KnownPlatforms.flutter) && !worksInFlutter) ||
-      (uses.contains(KnownPlatforms.native) && !worksInConsole);
+      (uses.contains(KnownPlatforms.native) && !worksInStandalone);
 
   bool get worksEverywhere =>
-      worksInBrowser && worksInConsole && worksInFlutter;
+      worksInBrowser && worksInStandalone && worksInFlutter;
 
-  bool get worksAnywhere => worksInBrowser || worksInConsole || worksInFlutter;
+  bool get worksAnywhere =>
+      worksInBrowser || worksInStandalone || worksInFlutter;
 
   bool get worksInBrowser =>
       _hasNoUseOf([KnownPlatforms.flutter, KnownPlatforms.native]) &&
       (uses.contains(KnownPlatforms.browser) ||
-          _hasNoUseOf([KnownPlatforms.console]));
+          _hasNoUseOf([KnownPlatforms.standalone]));
 
-  bool get worksInConsole =>
+  bool get worksInStandalone =>
       _hasNoUseOf([KnownPlatforms.browser, KnownPlatforms.flutter]);
 
   bool get worksInFlutter => _hasNoUseOf([
@@ -100,7 +101,7 @@ PlatformInfo classifyPlatform(Iterable<String> dependencies) {
   }
 
   if (libs.contains('dart:io')) {
-    uses.add(KnownPlatforms.console);
+    uses.add(KnownPlatforms.standalone);
   }
 
   if (libs.contains('dart:ui')) {

--- a/test/end2end/http_data.dart
+++ b/test/end2end/http_data.dart
@@ -194,7 +194,7 @@ final data = {
         "package:typed_data/typed_data.dart"
       ],
       "platform": {
-        "uses": ["browser", "console"]
+        "uses": ["browser", "standalone"]
       }
     },
     "lib/http.dart": {
@@ -351,7 +351,7 @@ final data = {
         "package:typed_data/typed_data.dart"
       ],
       "platform": {
-        "uses": ["console"]
+        "uses": ["standalone"]
       }
     },
     "lib/src/base_client.dart": {
@@ -584,7 +584,7 @@ final data = {
         "package:typed_data/typed_data.dart"
       ],
       "platform": {
-        "uses": ["console"]
+        "uses": ["standalone"]
       }
     },
     "test/html/client_test.dart": {

--- a/test/platform_test.dart
+++ b/test/platform_test.dart
@@ -11,7 +11,7 @@ void main() {
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isTrue);
       expect(p.worksInBrowser, isTrue);
-      expect(p.worksInConsole, isTrue);
+      expect(p.worksInStandalone, isTrue);
       expect(p.worksInFlutter, isTrue);
     });
 
@@ -21,7 +21,7 @@ void main() {
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isTrue);
       expect(p.worksInBrowser, isTrue);
-      expect(p.worksInConsole, isTrue);
+      expect(p.worksInStandalone, isTrue);
       expect(p.worksInFlutter, isTrue);
     });
 
@@ -31,7 +31,7 @@ void main() {
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
       expect(p.worksInBrowser, isFalse);
-      expect(p.worksInConsole, isTrue);
+      expect(p.worksInStandalone, isTrue);
       expect(p.worksInFlutter, isTrue);
     });
 
@@ -41,7 +41,7 @@ void main() {
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
       expect(p.worksInBrowser, isTrue);
-      expect(p.worksInConsole, isFalse);
+      expect(p.worksInStandalone, isFalse);
       expect(p.worksInFlutter, isFalse);
 
       p = classifyPlatform(['dart:svg']);
@@ -49,7 +49,7 @@ void main() {
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
       expect(p.worksInBrowser, isTrue);
-      expect(p.worksInConsole, isFalse);
+      expect(p.worksInStandalone, isFalse);
       expect(p.worksInFlutter, isFalse);
     });
 
@@ -59,7 +59,7 @@ void main() {
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
       expect(p.worksInBrowser, isFalse);
-      expect(p.worksInConsole, isFalse);
+      expect(p.worksInStandalone, isFalse);
       expect(p.worksInFlutter, isTrue);
     });
 
@@ -69,7 +69,7 @@ void main() {
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
       expect(p.worksInBrowser, isTrue);
-      expect(p.worksInConsole, isTrue);
+      expect(p.worksInStandalone, isTrue);
       expect(p.worksInFlutter, isFalse);
     });
 
@@ -79,7 +79,7 @@ void main() {
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
       expect(p.worksInBrowser, isTrue);
-      expect(p.worksInConsole, isFalse);
+      expect(p.worksInStandalone, isFalse);
       expect(p.worksInFlutter, isFalse);
     });
 
@@ -89,9 +89,9 @@ void main() {
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
       expect(p.worksInBrowser, isFalse);
-      expect(p.worksInConsole, isTrue);
+      expect(p.worksInStandalone, isTrue);
       expect(p.worksInFlutter, isFalse);
-      expect(p.uses, [KnownPlatforms.console, KnownPlatforms.native]);
+      expect(p.uses, [KnownPlatforms.native, KnownPlatforms.standalone]);
     });
 
     test('detect angular', () {
@@ -101,7 +101,7 @@ void main() {
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
       expect(p.worksInBrowser, isTrue);
-      expect(p.worksInConsole, isFalse);
+      expect(p.worksInStandalone, isFalse);
       expect(p.worksInFlutter, isFalse);
       expect(p.uses, [KnownPlatforms.angular, KnownPlatforms.browser]);
     });
@@ -114,7 +114,7 @@ void main() {
       expect(p.worksAnywhere, isFalse);
       expect(p.worksEverywhere, isFalse);
       expect(p.worksInBrowser, isFalse);
-      expect(p.worksInConsole, isFalse);
+      expect(p.worksInStandalone, isFalse);
       expect(p.worksInFlutter, isFalse);
     });
 
@@ -124,7 +124,7 @@ void main() {
       expect(p.worksAnywhere, isFalse);
       expect(p.worksEverywhere, isFalse);
       expect(p.worksInBrowser, isFalse);
-      expect(p.worksInConsole, isFalse);
+      expect(p.worksInStandalone, isFalse);
       expect(p.worksInFlutter, isFalse);
     });
 
@@ -134,7 +134,7 @@ void main() {
       expect(p.worksAnywhere, isFalse);
       expect(p.worksEverywhere, isFalse);
       expect(p.worksInBrowser, isFalse);
-      expect(p.worksInConsole, isFalse);
+      expect(p.worksInStandalone, isFalse);
       expect(p.worksInFlutter, isFalse);
       expect(p.uses, [KnownPlatforms.flutter, KnownPlatforms.native]);
     });
@@ -152,16 +152,16 @@ void main() {
       PlatformInfo pa = sum.libraries['package:_example/a.dart'];
       PlatformInfo pb = sum.libraries['package:_example/b.dart'];
       expect(pa.worksInBrowser, isTrue);
-      expect(pa.worksInConsole, isFalse);
+      expect(pa.worksInStandalone, isFalse);
       expect(pb.worksInBrowser, isFalse);
-      expect(pb.worksInConsole, isTrue);
+      expect(pb.worksInStandalone, isTrue);
     });
 
     test('detects flutter in pubspec', () {
       PlatformSummary sum = classifyPlatforms(flutterPluginPubspec, {});
       expect(sum.hasConflict, isFalse);
       expect(sum.package.worksInFlutter, isTrue);
-      expect(sum.package.worksInConsole, isFalse);
+      expect(sum.package.worksInStandalone, isFalse);
       expect(sum.package.worksInBrowser, isFalse);
     });
 
@@ -169,7 +169,7 @@ void main() {
       PlatformSummary sum = classifyPlatforms(flutterSdkPubspec, {});
       expect(sum.hasConflict, isFalse);
       expect(sum.package.worksInFlutter, isTrue);
-      expect(sum.package.worksInConsole, isFalse);
+      expect(sum.package.worksInStandalone, isFalse);
       expect(sum.package.worksInBrowser, isFalse);
     });
   });


### PR DESCRIPTION
It looks like a nuance detail, but I think we should use standalone instead of console. My reasons:
- I was looking for a 'console icon', and I got up to date with all of the gaming consoles, but no command line icon.
- The official article refers to it as standalone: https://www.dartlang.org/tutorials/dart-vm/cmdline
