### PR TITLE
Migrate `uses` values to store dart:* references directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.3.0
+
+* Renamed `KnownPlatforms` to `PlatformFlags`. Also:
+  * Removed `mirrors`, `browser` and `standalone`.
+  * Renamed `native` to `dartExtension`.
+
+* Now store `dart:*` references directly in
+  `PlatformInfo.uses`.
+
 ## 0.2.4
 
 * Detect native extensions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Added `String get description` which returns a simple `String` description
     of the supported platforms. Examples: `everywhere`, `flutter`, 
     `server, web`, `conflict`.
+  * Removed `angular` as a value in `uses`.
 
 ## 0.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
   * Removed `mirrors`, `browser` and `standalone`.
   * Renamed `native` to `dartExtension`.
 
-* Now store `dart:*` references directly in
-  `PlatformInfo.uses`.
+* `PlatformInfo`
+  * Now store `dart:*` references directly in `uses`.
+  * `worksInStandalone` renamed to `worksOnServer`.
+  * Other `.worksIn*` renamed to `worksOn*`.
+  * Added `String get description` which returns a simple `String` description
+    of the supported platforms. Examples: `everywhere`, `flutter`, 
+    `server, web`, `conflict`.
 
 ## 0.2.4
 

--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -1,20 +1,20 @@
 library pana.platform;
 
+import 'dart:collection';
 import 'package:source_gen/generators/json_serializable.dart';
 
 import 'pubspec.dart';
 
 part 'platform.g.dart';
 
-abstract class KnownPlatforms {
-  static const String browser = 'browser';
-  static const String standalone = 'standalone';
+abstract class PlatformFlags {
+  /// Denotes a package that references Flutter in `pubspec.yaml`.
   static const String flutter = 'flutter';
-  static const String mirrors = 'mirrors';
 
-  /// Native extensions (Dart VM with C/C++ code).
-  static const String native = 'native';
+  /// Denotes a library that depends on a native extensions via `dart-ext:`
+  static const String dartExtension = 'dart-ext';
 
+  /// Denotes a library that depends on pkg/angular or pkg/angular2
   static const String angular = 'angular';
 }
 
@@ -30,7 +30,7 @@ class PlatformSummary {
       _conflictsFlutter;
 
   bool get _conflictsFlutter =>
-      package.uses.contains(KnownPlatforms.flutter) &&
+      package.uses.contains(PlatformFlags.flutter) &&
       libraries.values.any((p) => !p.worksInFlutter);
 }
 
@@ -48,8 +48,8 @@ class PlatformInfo extends Object with _$PlatformInfoSerializerMixin {
 
   bool get hasConflict =>
       (!worksAnywhere) ||
-      (uses.contains(KnownPlatforms.flutter) && !worksInFlutter) ||
-      (uses.contains(KnownPlatforms.native) && !worksInStandalone);
+      (uses.contains(PlatformFlags.flutter) && !worksInFlutter) ||
+      (uses.contains(PlatformFlags.dartExtension) && !worksInStandalone);
 
   bool get worksEverywhere =>
       worksInBrowser && worksInStandalone && worksInFlutter;
@@ -58,18 +58,17 @@ class PlatformInfo extends Object with _$PlatformInfoSerializerMixin {
       worksInBrowser || worksInStandalone || worksInFlutter;
 
   bool get worksInBrowser =>
-      _hasNoUseOf([KnownPlatforms.flutter, KnownPlatforms.native]) &&
-      (uses.contains(KnownPlatforms.browser) ||
-          _hasNoUseOf([KnownPlatforms.standalone]));
+      _hasNoUseOf(
+          [PlatformFlags.flutter, 'dart:ui', PlatformFlags.dartExtension]) &&
+      (_webPackages.any(uses.contains) || _hasNoUseOf(['dart:io']));
 
   bool get worksInStandalone =>
-      _hasNoUseOf([KnownPlatforms.browser, KnownPlatforms.flutter]);
+      _hasNoUseOf(_webAnd(['dart:ui', PlatformFlags.flutter]));
 
-  bool get worksInFlutter => _hasNoUseOf([
-        KnownPlatforms.browser,
-        KnownPlatforms.mirrors,
-        KnownPlatforms.native,
-      ]);
+  bool get worksInFlutter => _hasNoUseOf(_webAnd([
+        'dart:mirrors',
+        PlatformFlags.dartExtension,
+      ]));
 
   bool _hasNoUseOf(Iterable<String> platforms) =>
       !platforms.any((p) => uses.contains(p));
@@ -78,7 +77,7 @@ class PlatformInfo extends Object with _$PlatformInfoSerializerMixin {
 PlatformInfo classifyPubspec(Pubspec pubspec) {
   final Set<String> uses = new Set();
   if (pubspec.hasFlutterKey || pubspec.dependsOnFlutterSdk) {
-    uses.add(KnownPlatforms.flutter);
+    uses.add(PlatformFlags.flutter);
   }
   return new PlatformInfo(uses);
 }
@@ -94,35 +93,28 @@ PlatformSummary classifyPlatforms(
 
 PlatformInfo classifyPlatform(Iterable<String> dependencies) {
   Set<String> libs = dependencies.toSet();
-  Set<String> uses = new Set();
+  Set<String> uses = new SplayTreeSet<String>();
 
-  if (_webPackages.any(libs.contains)) {
-    uses.add(KnownPlatforms.browser);
-  }
-
-  if (libs.contains('dart:io')) {
-    uses.add(KnownPlatforms.standalone);
-  }
-
-  if (libs.contains('dart:ui')) {
-    uses.add(KnownPlatforms.flutter);
-  }
-
-  if (libs.contains('dart:mirrors')) {
-    uses.add(KnownPlatforms.mirrors);
-  }
+  uses.addAll(libs.where((l) => _dartLibRegexp.hasMatch(l)));
 
   if (libs.any((String lib) => lib.startsWith('dart-ext:'))) {
-    uses.add(KnownPlatforms.native);
+    uses.add(PlatformFlags.dartExtension);
   }
 
   // packages
-  if (libs.any((p) => p.startsWith('package:angular2/'))) {
-    uses.add(KnownPlatforms.angular);
+  if (libs.any((p) => p.startsWith(_angularRegexp))) {
+    uses.add(PlatformFlags.angular);
   }
 
   return new PlatformInfo(uses);
 }
+
+final _angularRegexp = new RegExp(r"package:angular2?/");
+
+final _dartLibRegexp = new RegExp(r"^dart:[a-z_]+$");
+
+Iterable<String> _webAnd(Iterable<String> other) =>
+    [_webPackages, other].expand((s) => s);
 
 const List<String> _webPackages = const [
   'dart:html',

--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -13,9 +13,6 @@ abstract class PlatformFlags {
 
   /// Denotes a library that depends on a native extensions via `dart-ext:`
   static const String dartExtension = 'dart-ext';
-
-  /// Denotes a library that depends on `pkg/angular` or `pkg/angular2`.
-  static const String angular = 'angular';
 }
 
 class PlatformSummary {
@@ -128,15 +125,8 @@ PlatformInfo classifyPlatform(Iterable<String> dependencies) {
     uses.add(PlatformFlags.dartExtension);
   }
 
-  // packages
-  if (libs.any((p) => p.startsWith(_angularRegexp))) {
-    uses.add(PlatformFlags.angular);
-  }
-
   return new PlatformInfo(uses);
 }
-
-final _angularRegexp = new RegExp(r"package:angular2?/");
 
 final _dartLibRegexp = new RegExp(r"^dart:[a-z_]+$");
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.2.4
+version: 0.3.0-dev
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 

--- a/test/end2end/http_data.dart
+++ b/test/end2end/http_data.dart
@@ -183,7 +183,15 @@ final data = {
         "package:typed_data/typed_data.dart"
       ],
       "platform": {
-        "uses": ["browser", "standalone"]
+        "uses": [
+          'dart:async',
+          'dart:collection',
+          'dart:convert',
+          'dart:html',
+          'dart:io',
+          'dart:math',
+          'dart:typed_data'
+        ]
       }
     },
     "lib/http.dart": {
@@ -340,7 +348,14 @@ final data = {
         "package:typed_data/typed_data.dart"
       ],
       "platform": {
-        "uses": ["standalone"]
+        "uses": [
+          'dart:async',
+          'dart:collection',
+          'dart:convert',
+          'dart:io',
+          'dart:math',
+          'dart:typed_data'
+        ]
       }
     },
     "lib/src/base_client.dart": {
@@ -573,7 +588,14 @@ final data = {
         "package:typed_data/typed_data.dart"
       ],
       "platform": {
-        "uses": ["standalone"]
+        "uses": [
+          'dart:async',
+          'dart:collection',
+          'dart:convert',
+          'dart:io',
+          'dart:math',
+          'dart:typed_data'
+        ]
       }
     },
     "test/html/client_test.dart": {

--- a/test/end2end/pub_server_data.dart
+++ b/test/end2end/pub_server_data.dart
@@ -127,7 +127,9 @@ final data = {
         "package:pub_semver/src/version_range.dart",
         "package:pub_semver/src/version_union.dart"
       ],
-      "platform": {"uses": []}
+      "platform": {
+        "uses": ['dart:async', 'dart:collection', 'dart:math']
+      }
     },
     "lib/shelf_pubserver.dart": {
       "uri": "package:pub_server/shelf_pubserver.dart",
@@ -328,7 +330,16 @@ final data = {
         "package:yaml/src/yaml_node_wrapper.dart",
         "package:yaml/yaml.dart"
       ],
-      "platform": {"uses": []}
+      "platform": {
+        "uses": [
+          'dart:async',
+          'dart:collection',
+          'dart:convert',
+          'dart:isolate',
+          'dart:math',
+          'dart:typed_data'
+        ]
+      }
     },
     "test/shelf_pubserver_test.dart": {
       "uri": "path:pub_server/test/shelf_pubserver_test.dart",

--- a/test/platform_test.dart
+++ b/test/platform_test.dart
@@ -10,9 +10,10 @@ void main() {
       expect(p.hasConflict, isFalse);
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isTrue);
-      expect(p.worksInBrowser, isTrue);
-      expect(p.worksInStandalone, isTrue);
-      expect(p.worksInFlutter, isTrue);
+      expect(p.worksOnWeb, isTrue);
+      expect(p.worksOnServer, isTrue);
+      expect(p.worksOnFlutter, isTrue);
+      expect(p.description, 'everywhere');
     });
 
     test('unknown library', () {
@@ -20,9 +21,10 @@ void main() {
       expect(p.hasConflict, isFalse);
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isTrue);
-      expect(p.worksInBrowser, isTrue);
-      expect(p.worksInStandalone, isTrue);
-      expect(p.worksInFlutter, isTrue);
+      expect(p.worksOnWeb, isTrue);
+      expect(p.worksOnServer, isTrue);
+      expect(p.worksOnFlutter, isTrue);
+      expect(p.description, 'everywhere');
     });
 
     test('dart:io', () {
@@ -30,9 +32,10 @@ void main() {
       expect(p.hasConflict, isFalse);
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isFalse);
-      expect(p.worksInStandalone, isTrue);
-      expect(p.worksInFlutter, isTrue);
+      expect(p.worksOnWeb, isFalse);
+      expect(p.worksOnServer, isTrue);
+      expect(p.worksOnFlutter, isTrue);
+      expect(p.description, 'flutter, server');
     });
 
     test('dart:html', () {
@@ -40,17 +43,19 @@ void main() {
       expect(p.hasConflict, isFalse);
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isTrue);
-      expect(p.worksInStandalone, isFalse);
-      expect(p.worksInFlutter, isFalse);
+      expect(p.worksOnWeb, isTrue);
+      expect(p.worksOnServer, isFalse);
+      expect(p.worksOnFlutter, isFalse);
+      expect(p.description, 'web');
 
       p = classifyPlatform(['dart:svg']);
       expect(p.hasConflict, isFalse);
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isTrue);
-      expect(p.worksInStandalone, isFalse);
-      expect(p.worksInFlutter, isFalse);
+      expect(p.worksOnWeb, isTrue);
+      expect(p.worksOnServer, isFalse);
+      expect(p.worksOnFlutter, isFalse);
+      expect(p.description, 'web');
     });
 
     test('dart:ui', () {
@@ -58,9 +63,10 @@ void main() {
       expect(p.hasConflict, isFalse);
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isFalse);
-      expect(p.worksInStandalone, isFalse);
-      expect(p.worksInFlutter, isTrue);
+      expect(p.worksOnWeb, isFalse);
+      expect(p.worksOnServer, isFalse);
+      expect(p.worksOnFlutter, isTrue);
+      expect(p.description, 'flutter');
     });
 
     test('dart:mirrors', () {
@@ -68,9 +74,10 @@ void main() {
       expect(p.hasConflict, isFalse);
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isTrue);
-      expect(p.worksInStandalone, isTrue);
-      expect(p.worksInFlutter, isFalse);
+      expect(p.worksOnWeb, isTrue);
+      expect(p.worksOnServer, isTrue);
+      expect(p.worksOnFlutter, isFalse);
+      expect(p.description, 'server, web');
     });
 
     test('http package: both html and io', () {
@@ -78,9 +85,10 @@ void main() {
       expect(p.hasConflict, isFalse);
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isTrue);
-      expect(p.worksInStandalone, isFalse);
-      expect(p.worksInFlutter, isFalse);
+      expect(p.worksOnWeb, isTrue);
+      expect(p.worksOnServer, isFalse);
+      expect(p.worksOnFlutter, isFalse);
+      expect(p.description, 'web');
     });
 
     test('detect native', () {
@@ -88,10 +96,11 @@ void main() {
       expect(p.hasConflict, isFalse);
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isFalse);
-      expect(p.worksInStandalone, isTrue);
-      expect(p.worksInFlutter, isFalse);
+      expect(p.worksOnWeb, isFalse);
+      expect(p.worksOnServer, isTrue);
+      expect(p.worksOnFlutter, isFalse);
       expect(p.uses, [PlatformFlags.dartExtension, 'dart:io']);
+      expect(p.description, 'server');
     });
 
     test('detect angular2', () {
@@ -100,10 +109,11 @@ void main() {
       expect(p.hasConflict, isFalse);
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isTrue);
-      expect(p.worksInStandalone, isFalse);
-      expect(p.worksInFlutter, isFalse);
+      expect(p.worksOnWeb, isTrue);
+      expect(p.worksOnServer, isFalse);
+      expect(p.worksOnFlutter, isFalse);
       expect(p.uses, [PlatformFlags.angular, 'dart:html']);
+      expect(p.description, 'web');
     });
 
     test('detect angular', () {
@@ -112,10 +122,11 @@ void main() {
       expect(p.hasConflict, isFalse);
       expect(p.worksAnywhere, isTrue);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isTrue);
-      expect(p.worksInStandalone, isFalse);
-      expect(p.worksInFlutter, isFalse);
+      expect(p.worksOnWeb, isTrue);
+      expect(p.worksOnServer, isFalse);
+      expect(p.worksOnFlutter, isFalse);
       expect(p.uses, [PlatformFlags.angular, 'dart:html']);
+      expect(p.description, 'web');
     });
   });
 
@@ -125,9 +136,10 @@ void main() {
       expect(p.hasConflict, isTrue);
       expect(p.worksAnywhere, isFalse);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isFalse);
-      expect(p.worksInStandalone, isFalse);
-      expect(p.worksInFlutter, isFalse);
+      expect(p.worksOnWeb, isFalse);
+      expect(p.worksOnServer, isFalse);
+      expect(p.worksOnFlutter, isFalse);
+      expect(p.description, 'conflict');
     });
 
     test('dart:mirrors + dart:ui', () {
@@ -135,9 +147,10 @@ void main() {
       expect(p.hasConflict, isTrue);
       expect(p.worksAnywhere, isFalse);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isFalse);
-      expect(p.worksInStandalone, isFalse);
-      expect(p.worksInFlutter, isFalse);
+      expect(p.worksOnWeb, isFalse);
+      expect(p.worksOnServer, isFalse);
+      expect(p.worksOnFlutter, isFalse);
+      expect(p.description, 'conflict');
     });
 
     test('native + dart:ui', () {
@@ -145,10 +158,11 @@ void main() {
       expect(p.hasConflict, isTrue);
       expect(p.worksAnywhere, isFalse);
       expect(p.worksEverywhere, isFalse);
-      expect(p.worksInBrowser, isFalse);
-      expect(p.worksInStandalone, isFalse);
-      expect(p.worksInFlutter, isFalse);
+      expect(p.worksOnWeb, isFalse);
+      expect(p.worksOnServer, isFalse);
+      expect(p.worksOnFlutter, isFalse);
       expect(p.uses, [PlatformFlags.dartExtension, 'dart:ui']);
+      expect(p.description, 'conflict');
     });
   });
 
@@ -161,28 +175,35 @@ void main() {
       expect(sum.hasConflict, isFalse);
       expect(sum.package.worksEverywhere, isTrue);
       expect(sum.libraries.length, 2);
+      expect(sum.package.description, 'everywhere');
+
       PlatformInfo pa = sum.libraries['package:_example/a.dart'];
+      expect(pa.worksOnWeb, isTrue);
+      expect(pa.worksOnServer, isFalse);
+      expect(pa.description, 'web');
+
       PlatformInfo pb = sum.libraries['package:_example/b.dart'];
-      expect(pa.worksInBrowser, isTrue);
-      expect(pa.worksInStandalone, isFalse);
-      expect(pb.worksInBrowser, isFalse);
-      expect(pb.worksInStandalone, isTrue);
+      expect(pb.worksOnWeb, isFalse);
+      expect(pb.worksOnServer, isTrue);
+      expect(pb.description, 'flutter, server');
     });
 
     test('detects flutter in pubspec', () {
       PlatformSummary sum = classifyPlatforms(flutterPluginPubspec, {});
       expect(sum.hasConflict, isFalse);
-      expect(sum.package.worksInFlutter, isTrue);
-      expect(sum.package.worksInStandalone, isFalse);
-      expect(sum.package.worksInBrowser, isFalse);
+      expect(sum.package.worksOnFlutter, isTrue);
+      expect(sum.package.worksOnServer, isFalse);
+      expect(sum.package.worksOnWeb, isFalse);
+      expect(sum.package.description, 'flutter');
     });
 
     test('detects flutter in dependencies', () {
       PlatformSummary sum = classifyPlatforms(flutterSdkPubspec, {});
       expect(sum.hasConflict, isFalse);
-      expect(sum.package.worksInFlutter, isTrue);
-      expect(sum.package.worksInStandalone, isFalse);
-      expect(sum.package.worksInBrowser, isFalse);
+      expect(sum.package.worksOnFlutter, isTrue);
+      expect(sum.package.worksOnServer, isFalse);
+      expect(sum.package.worksOnWeb, isFalse);
+      expect(sum.package.description, 'flutter');
     });
   });
 
@@ -192,6 +213,7 @@ void main() {
         'package:_example/lib.dart': ['dart:mirrors'],
       });
       expect(sum.hasConflict, isTrue);
+      expect(sum.package.description, 'flutter');
     });
   });
 }

--- a/test/platform_test.dart
+++ b/test/platform_test.dart
@@ -91,10 +91,10 @@ void main() {
       expect(p.worksInBrowser, isFalse);
       expect(p.worksInStandalone, isTrue);
       expect(p.worksInFlutter, isFalse);
-      expect(p.uses, [KnownPlatforms.native, KnownPlatforms.standalone]);
+      expect(p.uses, [PlatformFlags.dartExtension, 'dart:io']);
     });
 
-    test('detect angular', () {
+    test('detect angular2', () {
       PlatformInfo p =
           classifyPlatform(['dart:html', 'package:angular2/angular2.dart']);
       expect(p.hasConflict, isFalse);
@@ -103,7 +103,19 @@ void main() {
       expect(p.worksInBrowser, isTrue);
       expect(p.worksInStandalone, isFalse);
       expect(p.worksInFlutter, isFalse);
-      expect(p.uses, [KnownPlatforms.angular, KnownPlatforms.browser]);
+      expect(p.uses, [PlatformFlags.angular, 'dart:html']);
+    });
+
+    test('detect angular', () {
+      PlatformInfo p =
+          classifyPlatform(['dart:html', 'package:angular/angular.dart']);
+      expect(p.hasConflict, isFalse);
+      expect(p.worksAnywhere, isTrue);
+      expect(p.worksEverywhere, isFalse);
+      expect(p.worksInBrowser, isTrue);
+      expect(p.worksInStandalone, isFalse);
+      expect(p.worksInFlutter, isFalse);
+      expect(p.uses, [PlatformFlags.angular, 'dart:html']);
     });
   });
 
@@ -136,7 +148,7 @@ void main() {
       expect(p.worksInBrowser, isFalse);
       expect(p.worksInStandalone, isFalse);
       expect(p.worksInFlutter, isFalse);
-      expect(p.uses, [KnownPlatforms.flutter, KnownPlatforms.native]);
+      expect(p.uses, [PlatformFlags.dartExtension, 'dart:ui']);
     });
   });
 

--- a/test/platform_test.dart
+++ b/test/platform_test.dart
@@ -102,32 +102,6 @@ void main() {
       expect(p.uses, [PlatformFlags.dartExtension, 'dart:io']);
       expect(p.description, 'server');
     });
-
-    test('detect angular2', () {
-      PlatformInfo p =
-          classifyPlatform(['dart:html', 'package:angular2/angular2.dart']);
-      expect(p.hasConflict, isFalse);
-      expect(p.worksAnywhere, isTrue);
-      expect(p.worksEverywhere, isFalse);
-      expect(p.worksOnWeb, isTrue);
-      expect(p.worksOnServer, isFalse);
-      expect(p.worksOnFlutter, isFalse);
-      expect(p.uses, [PlatformFlags.angular, 'dart:html']);
-      expect(p.description, 'web');
-    });
-
-    test('detect angular', () {
-      PlatformInfo p =
-          classifyPlatform(['dart:html', 'package:angular/angular.dart']);
-      expect(p.hasConflict, isFalse);
-      expect(p.worksAnywhere, isTrue);
-      expect(p.worksEverywhere, isFalse);
-      expect(p.worksOnWeb, isTrue);
-      expect(p.worksOnServer, isFalse);
-      expect(p.worksOnFlutter, isFalse);
-      expect(p.uses, [PlatformFlags.angular, 'dart:html']);
-      expect(p.description, 'web');
-    });
   });
 
   group('Conflicting Platform', () {


### PR DESCRIPTION
Makes the values stored in JSON output much less opaque