### PR TITLE
Enable custom package directory (for direct downloads or local tests).

### DIFF
--- a/lib/src/summary.dart
+++ b/lib/src/summary.dart
@@ -79,7 +79,7 @@ class Summary extends Object with _$SummarySerializerMixin {
   final Map<String, Object> flutterVersion;
   final String packageName;
 
-  @JsonKey(nullable: false)
+  @JsonKey(includeIfNull: false)
   final Version packageVersion;
   final PubSummary pubSummary;
   final Map<String, DartFileSummary> dartFiles;

--- a/lib/src/summary.g.dart
+++ b/lib/src/summary.g.dart
@@ -62,7 +62,9 @@ Summary _$SummaryFromJson(Map<String, dynamic> json) => new Summary(
     new Version.parse(json['panaVersion']),
     json['sdkVersion'] as String,
     json['packageName'] as String,
-    new Version.parse(json['packageVersion']),
+    json['packageVersion'] == null
+        ? null
+        : new Version.parse(json['packageVersion']),
     json['pubSummary'] == null
         ? null
         : new PubSummary.fromJson(json['pubSummary'] as Map<String, dynamic>),
@@ -111,7 +113,7 @@ abstract class _$SummarySerializerMixin {
 
     writeNotNull('flutterVersion', flutterVersion);
     val['packageName'] = packageName;
-    val['packageVersion'] = packageVersion.toString();
+    writeNotNull('packageVersion', packageVersion?.toString());
     val['pubSummary'] = pubSummary;
     val['dartFiles'] = dartFiles;
     val['license'] = license;


### PR DESCRIPTION
Slight change of the summary.packageVersion field (non-nullable -> nullable), because there is a slight chance that a local directory is not able to identify the version, and it is better to not fail on the serialization in such cases.