### PR TITLE
Rename PkgVersionDetails to PkgDependency

### DIFF
--- a/lib/src/pub_summary.g.dart
+++ b/lib/src/pub_summary.g.dart
@@ -39,3 +39,30 @@ abstract class _$PubSummarySerializerMixin {
                 availableVersions.values.map((e) => e?.toString()))
       };
 }
+
+PkgDependency _$PkgDependencyFromJson(Map<String, dynamic> json) =>
+    new PkgDependency(
+        json['package'] as String,
+        json['isDev'] as bool,
+        json['constraint'] == null
+            ? null
+            : new VersionConstraint.parse(json['constraint']),
+        json['resolved'] == null ? null : new Version.parse(json['resolved']),
+        json['available'] == null
+            ? null
+            : new Version.parse(json['available']));
+
+abstract class _$PkgDependencySerializerMixin {
+  String get package;
+  bool get isDev;
+  VersionConstraint get constraint;
+  Version get resolved;
+  Version get available;
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'package': package,
+        'isDev': isDev,
+        'constraint': constraint?.toString(),
+        'resolved': resolved?.toString(),
+        'available': available?.toString()
+      };
+}

--- a/tool/build_actions.dart
+++ b/tool/build_actions.dart
@@ -12,7 +12,10 @@ import 'version_helper.dart';
 final List<BuildAction> buildActions = [
   new BuildAction(
       new PartBuilder([
-        new JsonSerializableGenerator.withDefaultHelpers([new VersionHelper()]),
+        new JsonSerializableGenerator.withDefaultHelpers([
+          new VersionHelper(),
+          new VersionConstraintHelper(),
+        ]),
         new PackageVersionGenerator()
       ]),
       'pana',

--- a/tool/version_helper.dart
+++ b/tool/version_helper.dart
@@ -14,9 +14,7 @@ class VersionHelper extends TypeHelper {
     if (!_checker.isExactlyType(targetType)) {
       return null;
     }
-
     var nullThing = nullable ? '?' : '';
-
     return "$expression$nullThing.toString()";
   }
 
@@ -24,13 +22,33 @@ class VersionHelper extends TypeHelper {
     if (!_checker.isExactlyType(targetType)) {
       return null;
     }
-
     var value = 'new Version.parse($expression)';
-
     if (nullable) {
       value = '$expression == null ? null : $value';
     }
+    return value;
+  }
+}
 
+class VersionConstraintHelper extends TypeHelper {
+  final _checker = new TypeChecker.fromRuntime(VersionConstraint);
+
+  String serialize(DartType targetType, String expression, bool nullable, _) {
+    if (!_checker.isExactlyType(targetType)) {
+      return null;
+    }
+    var nullThing = nullable ? '?' : '';
+    return "$expression$nullThing.toString()";
+  }
+
+  String deserialize(DartType targetType, String expression, bool nullable, _) {
+    if (!_checker.isExactlyType(targetType)) {
+      return null;
+    }
+    var value = 'new VersionConstraint.parse($expression)';
+    if (nullable) {
+      value = '$expression == null ? null : $value';
+    }
     return value;
   }
 }


### PR DESCRIPTION
I'm planning to have this  detail-rich class in `Summary` instead of the fields in the current `PubSummary`. The scope now is limited to the serialization because of merge conflicts from other PRs.