### PR TITLE
A few more linter rules for code health score.

### DIFF
--- a/lib/src/analysis_options.dart
+++ b/lib/src/analysis_options.dart
@@ -11,15 +11,10 @@ analyzer:
 
 linter:
   rules:
+    - camel_case_types
     - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - unrelated_type_equality_checks
     - valid_regexps
-#    - annotate_overrides
-#    - camel_case_types
-#    - cancel_subscriptions
-#    - close_sinks
-#    - implementation_imports
-#    - no_adjacent_strings_in_list
-#    - prefer_is_empty
-#    - prefer_is_not_empty
-#    - test_types_in_equals
 ''';


### PR DESCRIPTION
Reasons:
- `camel_case_types`: I think it is better to respect the style guide in this instance.
- `iterable_contains_unrelated_type`: high probability for errors.
- `list_remove_unrelated_type`: high probability for errors.
- `unrelated_type_equality_checks`: high probability for errors.

Most of it is coming from is coming from `stagehand` defaults (#94), and I think the rest can be ignored for now.