### PR TITLE
Error scope in Suggestion.bug.

### DIFF
--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -187,7 +187,8 @@ class PackageAnalyzer {
         assert(libraryScanner.packageName == package);
       } on StateError catch (e, stack) {
         log.severe("Could not create LibraryScanner", e, stack);
-        suggestions.add(new Suggestion.bug(e, stack));
+        suggestions.add(
+            new Suggestion.bug('LibraryScanner creation failed.', e, stack));
       }
 
       if (libraryScanner != null) {
@@ -195,15 +196,17 @@ class PackageAnalyzer {
           log.info('Scanning direct dependencies...');
           allDirectLibs = await libraryScanner.scanDirectLibs();
         } catch (e, st) {
-          log.severe('Error scanning direct librariers', e, st);
-          suggestions.add(new Suggestion.bug(e, st));
+          log.severe('Error scanning direct libraries', e, st);
+          suggestions.add(
+              new Suggestion.bug('Error scanning direct libraries.', e, st));
         }
         try {
           log.info('Scanning transitive dependencies...');
           allTransitiveLibs = await libraryScanner.scanTransitiveLibs();
         } catch (e, st) {
-          log.severe('Error scanning transitive librariers', e, st);
-          suggestions.add(new Suggestion.bug(e, st));
+          log.severe('Error scanning transitive libraries', e, st);
+          suggestions.add(new Suggestion.bug(
+              'Error scanning transitive libraries.', e, st));
         }
         libraryScanner.clearCaches();
       }

--- a/lib/src/summary.dart
+++ b/lib/src/summary.dart
@@ -155,12 +155,12 @@ class Suggestion extends Object
 
   Suggestion(this.level, this.title, this.description, {this.file});
 
-  factory Suggestion.bug(Object error, StackTrace stack) {
-    var lines =
+  factory Suggestion.bug(String message, Object error, StackTrace stack) {
+    final title =
+        'There is likely a bug in the analysis code or a dependency: $message';
+    final description =
         LineSplitter.split([error, '', stack].join('\n')).take(100).join('\n');
-
-    return new Suggestion(SuggestionLevel.bug,
-        'There is likely a bug in the analysis code or a dependency.', lines);
+    return new Suggestion(SuggestionLevel.bug, title, description);
   }
 
   factory Suggestion.error(String title, String description, {String file}) =>


### PR DESCRIPTION
It is not self-evident from the diff, but the log.severe lines changed only the typo: `librariers` -> `libraries`.