### PR TITLE
Removed `hash_and_equals` from the default set of lints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.7.3
+
+* Removed `hash_and_equals` from the default set of lints.
+  There are valid reasons to not follow this rule.
+
 ## 0.7.2
 
 * Handle more critical exceptions and report them with more details.

--- a/lib/src/analysis_options.dart
+++ b/lib/src/analysis_options.dart
@@ -12,7 +12,6 @@ analyzer:
 linter:
   rules:
     - camel_case_types
-    - hash_and_equals
     - iterable_contains_unrelated_type
     - list_remove_unrelated_type
     - unrelated_type_equality_checks

--- a/lib/src/version.g.dart
+++ b/lib/src/version.g.dart
@@ -10,4 +10,4 @@ part of pana.version;
 // Generator: PackageVersionGenerator
 // **************************************************************************
 
-final _$panaPkgVersionPubSemverVersion = new Version.parse("0.7.2");
+final _$panaPkgVersionPubSemverVersion = new Version.parse("0.7.3-dev");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.7.2
+version: 0.7.3-dev
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
There are valid reasons to not follow this rule.