### PR TITLE
Also STRONG_MODE_COULD_NOT_INFER

### DIFF
--- a/lib/src/code_problem.dart
+++ b/lib/src/code_problem.dart
@@ -23,6 +23,7 @@ class CodeProblem extends Object
   static const _platformNonBlockerCodes = const <String>[
     'STRONG_MODE_INVALID_CAST_NEW_EXPR',
     'ARGUMENT_TYPE_NOT_ASSIGNABLE',
+    'STRONG_MODE_COULD_NOT_INFER',
   ];
 
   static final _regexp = new RegExp('^' + // beginning of line


### PR DESCRIPTION
Motivated by

https://analyzer-dot-dartlang-pub.appspot.com/packages/rpc/0.5.8/5655869022797824