### PR TITLE
Remove min-length requirements for changelog and readme

### DIFF
--- a/lib/src/maintenance.dart
+++ b/lib/src/maintenance.dart
@@ -159,9 +159,8 @@ Future<Maintenance> detectMaintenance(
     return false;
   }
 
-  final changelogExists =
-      await anyFileExists(changelogFileNames, minLength: 100);
-  final readmeExists = await anyFileExists(readmeFileNames, minLength: 100);
+  final changelogExists = await anyFileExists(changelogFileNames);
+  final readmeExists = await anyFileExists(readmeFileNames);
   final analysisOptionsExists =
       await anyFileExists(analysisOptionsFiles, caseSensitive: true);
   final oldAnalysisOptions =

--- a/test/end2end/skiplist_data.dart
+++ b/test/end2end/skiplist_data.dart
@@ -182,7 +182,7 @@ final _data = {
     'isExperimentalVersion': false,
     'isPreReleaseVersion': true,
     'errorCount': 1,
-    'warningCount': 1,
+    'warningCount': 0,
     'hintCount': 0,
   },
   'fitness': {'magnitude': 185.0, 'shortcoming': 185.0},
@@ -196,12 +196,6 @@ final _data = {
           'Invalid override. The type of \'SkipList.[]\' (\'(K) → V\') isn\'t a subtype of \'Map<K, V>.[]\' (\'(Object) → V\').\n'
           '',
       'file': 'lib/skiplist.dart',
-    },
-    {
-      'level': 'warning',
-      'title': 'Maintain `CHANGELOG.md`.',
-      'description':
-          'Changelog entries help clients to follow the progress in your code.',
     },
   ],
 };

--- a/test/end2end/skiplist_data.dart
+++ b/test/end2end/skiplist_data.dart
@@ -174,7 +174,7 @@ final _data = {
     },
   ],
   'maintenance': {
-    'missingChangelog': true,
+    'missingChangelog': false,
     'missingReadme': false,
     'missingAnalysisOptions': true,
     'oldAnalysisOptions': false,


### PR DESCRIPTION
We should have a separate measure for min-length if we think that's
important. As it stands, users will be confused if they see the error
when they have a (short) changelog/readme

Closes https://github.com/dart-lang/pana/issues/163