### PR TITLE
Unblock platform classification on invalid method overrides.

### DIFF
--- a/lib/src/code_problem.dart
+++ b/lib/src/code_problem.dart
@@ -16,14 +16,15 @@ class CodeProblem extends Object
     implements Comparable<CodeProblem> {
   /// The errors which don't block platform classification.
   static const _platformNonBlockerTypes = const <String>[
-    'STATIC_WARNING',
     'STATIC_TYPE_WARNING',
+    'STATIC_WARNING',
   ];
 
   static const _platformNonBlockerCodes = const <String>[
-    'STRONG_MODE_INVALID_CAST_NEW_EXPR',
     'ARGUMENT_TYPE_NOT_ASSIGNABLE',
     'STRONG_MODE_COULD_NOT_INFER',
+    'STRONG_MODE_INVALID_CAST_NEW_EXPR',
+    'STRONG_MODE_INVALID_METHOD_OVERRIDE',
   ];
 
   static final _regexp = new RegExp('^' + // beginning of line

--- a/test/end2end/skiplist_data.dart
+++ b/test/end2end/skiplist_data.dart
@@ -157,7 +157,7 @@ final _data = {
       'platform': {
         'worksEverywhere': false,
         'reason':
-            'Error(s) in lib/skiplist.dart: Invalid override. The type of \'SkipList.[]\' (\'(K) → V\') isn\'t a subtype of \'Map<K, V>.[]\' (\'(Object) → V\').'
+            'Error(s) in lib/skiplist.dart: The function expression type \'(_SkipListEntry<Comparable<dynamic>, dynamic>) → Comparable<dynamic>\' isn\'t of type \'(_SkipListEntry<Comparable<dynamic>, dynamic>) → K\'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s).'
       },
       'fitness': {'magnitude': 185.0, 'shortcoming': 185.0}
     }


### PR DESCRIPTION
This typically happens when somebody writes an equals or compareTo with the specific type instead of the generic (or vice versa).