### PR TITLE
Flutter-specific dartanalyzer options.

### DIFF
--- a/lib/src/analysis_options.dart
+++ b/lib/src/analysis_options.dart
@@ -18,3 +18,33 @@ linter:
     - unrelated_type_equality_checks
     - valid_regexps
 ''';
+
+// Keep it updated with
+// https://github.com/flutter/flutter/blob/master/packages/flutter/lib/analysis_options_user.yaml
+const String flutterAnalysisOptions = '''
+analyzer:
+  language:
+    enableStrictCallChecks: true
+    enableSuperMixins: true
+    enableAssertInitializer: true
+  strong-mode: true
+  errors:
+    # treat missing required parameters as a warning (not a hint)
+    missing_required_param: warning
+    # treat missing returns as a warning (not a hint)
+    missing_return: warning
+    # allow having TODOs in the code
+    todo: ignore
+
+# Source of linter options:
+# http://dart-lang.github.io/linter/lints/options/options.html
+
+linter:
+  rules:
+    - camel_case_types
+    - hash_and_equals
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - unrelated_type_equality_checks
+    - valid_regexps
+''';

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -218,7 +218,7 @@ class PackageAnalyzer {
 
       if (dartFiles.isNotEmpty) {
         try {
-          analyzerItems = await _pkgAnalyze(pkgDir);
+          analyzerItems = await _pkgAnalyze(pkgDir, isFlutter);
         } on ArgumentError catch (e) {
           if (e.toString().contains("No dart files found at: .")) {
             log.warning("No files to analyze...");
@@ -347,13 +347,13 @@ class PackageAnalyzer {
     );
   }
 
-  Future<Set<CodeProblem>> _pkgAnalyze(String pkgPath) async {
+  Future<Set<CodeProblem>> _pkgAnalyze(String pkgPath, bool isFlutter) async {
     log.info('Analyzing package...');
     final dirs = await listFocusDirs(pkgPath);
     if (dirs.isEmpty) {
       return null;
     }
-    final proc = await _dartSdk.runAnalyzer(pkgPath, dirs);
+    final proc = await _dartSdk.runAnalyzer(pkgPath, dirs, isFlutter);
 
     String output = proc.stderr;
     if ('\n$output'.contains('\nUnhandled exception:\n')) {

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -49,11 +49,12 @@ class DartSdk implements DartSdkInfo {
   }
 
   Future<ProcessResult> runAnalyzer(
-      String packageDir, List<String> dirs) async {
+      String packageDir, List<String> dirs, bool isFlutter) async {
     final optionsFileName =
         'pana_analysis_options_${new DateTime.now().microsecondsSinceEpoch}.g.yaml';
     final optionsFile = new File(p.join(packageDir, optionsFileName));
-    await optionsFile.writeAsString(analysisOptions);
+    await optionsFile
+        .writeAsString(isFlutter ? flutterAnalysisOptions : analysisOptions);
     final params = ['--options', optionsFile.path, '--format', 'machine']
       ..addAll(dirs);
     final pr = await runProc(


### PR DESCRIPTION
We can fine-tune how to synchronize the linter rules between the two, I've just copied the flutter's options file as it was to unblock supermixin.