### PR TITLE
Less strict plaform classification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.2-dev
+
+* Unblock platform classification on a new class of errors.
+
 ## 0.8.1
 
 * Use Flutter-recommended analysis options when analyzer Flutter packages.

--- a/lib/src/code_problem.dart
+++ b/lib/src/code_problem.dart
@@ -23,6 +23,7 @@ class CodeProblem extends Object
   static const _platformNonBlockerCodes = const <String>[
     'ARGUMENT_TYPE_NOT_ASSIGNABLE',
     'STRONG_MODE_COULD_NOT_INFER',
+    'STRONG_MODE_INVALID_CAST_FUNCTION_EXPR',
     'STRONG_MODE_INVALID_CAST_NEW_EXPR',
     'STRONG_MODE_INVALID_METHOD_OVERRIDE',
   ];

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -317,11 +317,10 @@ class PackageAnalyzer {
           'Error(s) prevent platform classification.');
     } else {
       final dfs = files.values.firstWhere(
-          (dfs) => dfs.isPublicApi && dfs.hasCodeError,
+          (dfs) => dfs.isPublicApi && dfs.platform.hasConflict,
           orElse: () => null);
       if (dfs != null) {
-        platform = new DartPlatform.conflict(
-            'Error(s) in ${dfs.path}: ${dfs.firstCodeError.description}');
+        platform = new DartPlatform.conflict(dfs.platform.reason);
       }
     }
     platform ??= classifyPkgPlatform(pubspec, allTransitiveLibs);

--- a/test/end2end/skiplist_data.dart
+++ b/test/end2end/skiplist_data.dart
@@ -154,18 +154,11 @@ final _data = {
         'package:meta/meta.dart',
         'package:quiver_iterables/iterables.dart'
       ],
-      'platform': {
-        'worksEverywhere': false,
-        'reason':
-            'Error(s) in lib/skiplist.dart: The function expression type \'(_SkipListEntry<Comparable<dynamic>, dynamic>) → Comparable<dynamic>\' isn\'t of type \'(_SkipListEntry<Comparable<dynamic>, dynamic>) → K\'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s).'
-      },
+      'platform': {'worksEverywhere': true},
       'fitness': {'magnitude': 185.0, 'shortcoming': 185.0}
     }
   },
-  'platform': {
-    'worksEverywhere': false,
-    'reason': 'Error(s) prevent platform classification.',
-  },
+  'platform': {'worksEverywhere': true, 'reason': 'All libraries agree'},
   'licenses': [
     {
       'path': 'LICENSE',


### PR DESCRIPTION
- Fixes #194.
- Also fixes a use-case where the individual Dart files are unblocked of classification, but the package-level classification was still blocked by them.