### PR TITLE
Better messages in platform classification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Unblock platform classification on a new class of errors.
 
+* Better messages in platform classification.
+
 ## 0.8.1
 
 * Use Flutter-recommended analysis options when analyzer Flutter packages.

--- a/test/end2end/http_data.dart
+++ b/test/end2end/http_data.dart
@@ -672,7 +672,8 @@ final _data = {
   },
   'platform': {
     'worksEverywhere': true,
-    'reason': 'primary library - `package:http/http.dart`'
+    'reason':
+        'No platform restriction found in primary library `package:http/http.dart`.',
   },
   "licenses": [
     {

--- a/test/end2end/pub_server_data.dart
+++ b/test/end2end/pub_server_data.dart
@@ -289,7 +289,10 @@ final _data = {
       'fitness': {'magnitude': 360.0, 'shortcoming': 1.0},
     },
   },
-  'platform': {'worksEverywhere': true, 'reason': 'All libraries agree'},
+  'platform': {
+    'worksEverywhere': true,
+    'reason': 'No platform restriction found in libraries.',
+  },
   "licenses": [
     {
       "path": "LICENSE",

--- a/test/end2end/skiplist_data.dart
+++ b/test/end2end/skiplist_data.dart
@@ -158,7 +158,10 @@ final _data = {
       'fitness': {'magnitude': 185.0, 'shortcoming': 185.0}
     }
   },
-  'platform': {'worksEverywhere': true, 'reason': 'All libraries agree'},
+  'platform': {
+    'worksEverywhere': true,
+    'reason': 'No platform restriction found in libraries.',
+  },
   'licenses': [
     {
       'path': 'LICENSE',

--- a/test/platform_test.dart
+++ b/test/platform_test.dart
@@ -146,7 +146,8 @@ void main() {
       });
       expect(sum.worksEverywhere, isFalse);
       expect(sum.restrictedTo, ['flutter', 'server', 'web']);
-      expect(sum.descriptionAndReason, 'flutter,server,web: all of the above');
+      expect(sum.descriptionAndReason,
+          'flutter,server,web: Multiple platform identified in libraries.');
     });
 
     test('detects flutter in pubspec', () {
@@ -154,7 +155,7 @@ void main() {
       expect(sum.worksEverywhere, isFalse);
       expect(sum.restrictedTo, ['flutter']);
       expect(sum.descriptionAndReason,
-          'flutter: pubspec reference with no conflicts');
+          'flutter: References Flutter with no conflicting libraries.');
     });
 
     test('detects flutter package in dependencies', () {
@@ -162,7 +163,7 @@ void main() {
       expect(sum.worksEverywhere, isFalse);
       expect(sum.restrictedTo, ['flutter']);
       expect(sum.descriptionAndReason,
-          'flutter: pubspec reference with no conflicts');
+          'flutter: References Flutter with no conflicting libraries.');
     });
 
     test('detects flutter sdk in dependencies', () {
@@ -170,7 +171,7 @@ void main() {
       expect(sum.worksEverywhere, isFalse);
       expect(sum.restrictedTo, ['flutter']);
       expect(sum.descriptionAndReason,
-          'flutter: pubspec reference with no conflicts');
+          'flutter: References Flutter with no conflicting libraries.');
     });
   });
 
@@ -182,7 +183,7 @@ void main() {
       expect(sum.worksEverywhere, isFalse);
       expect(sum.restrictedTo, isNull);
       expect(sum.descriptionAndReason,
-          'undefined: flutter reference with library conflicts');
+          'undefined: References Flutter, but has conflicting libraries: `package:_example/lib.dart`.');
     });
   });
 }


### PR DESCRIPTION
- addresses https://github.com/dart-lang/pub-dartlang-dart/issues/750
- removed the `everythingRemoved` part, because it is no longer used (`items` is created with filtering out the ones that work everywhere, and we are using only platform names).