### PR TITLE
Remove some of the pubspec.lock validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Only direct unconstrained dependencies decrease the health score.
 
+* Remove some of the `pubspec.lock` validation.
+
 ## 0.8.2
 
 * Unblock platform classification on a new class of errors.

--- a/lib/src/pkg_resolution.dart
+++ b/lib/src/pkg_resolution.dart
@@ -96,17 +96,8 @@ void _validateLockedVersions(String path, Map<String, Version> pkgVersions) {
       Map lockMap = yamlToJson(lockFileContent);
       Map<String, Object> pkgs = lockMap['packages'];
       if (pkgs != null) {
-        var expectedPackages = pkgVersions.keys.toSet();
-
         pkgs.forEach((String key, Object v) {
-          if (!expectedPackages.remove(key)) {
-            throw new StateError(
-                "Did not parse package `$key` from pub output, "
-                "but it was found in `pubspec.lock`.");
-          }
-
           var m = v as Map;
-
           var lockedVersion = new Version.parse(m['version']);
           if (pkgVersions[key] != lockedVersion) {
             throw new StateError(
@@ -114,12 +105,6 @@ void _validateLockedVersions(String path, Map<String, Version> pkgVersions) {
                 "match the locked version $lockedVersion.");
           }
         });
-
-        if (expectedPackages.isNotEmpty) {
-          throw new StateError(
-              "We parsed more packaged than were found in the lock file: "
-              "${expectedPackages.join(', ')}");
-        }
       }
     }
   }

--- a/test/end2end/stream_broken_data.dart
+++ b/test/end2end/stream_broken_data.dart
@@ -90,7 +90,7 @@ final _data = {
       "level": "error",
       "title": "Fix dependencies in `pubspec.yaml`.",
       "description":
-          "Running `pub upgrade` failed with the following output:\n\n```\nBad state: Did not parse package `args` from pub output, but it was found in `pubspec.lock`.\n```\n"
+          "Running `pub upgrade` failed with the following output:\n\n```\nBad state: For args, the parsed version null did not match the locked version 1.2.0.\n```\n"
     },
   ],
   "pkgResolution": null,


### PR DESCRIPTION
Keeping some of the validation, because it could indicate issue in our output-parsing code, but the rest can cause false-alarms (because of the `dev_dependency` removal).
Closes #207. 