### PR TITLE
Handle MIT license without explicit 'MIT License' text.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Recommend descriptions between 60 and 180 characters.
 
+* Detect another license format
+
 ## 0.8.2
 
 * Unblock platform classification on a new class of errors.

--- a/lib/src/license.dart
+++ b/lib/src/license.dart
@@ -166,7 +166,7 @@ LicenseFile detectLicenseInContent(String originalContent,
   if (_gplShort.hasMatch(stripped)) {
     return new LicenseFile(relativePath, LicenseNames.GPL, version: version);
   }
-  if (_mit.hasMatch(stripped)) {
+  if (_mit.hasMatch(stripped) || _mitEmphasis.hasMatch(stripped)) {
     return new LicenseFile(relativePath, LicenseNames.MIT, version: version);
   }
   if (_unlicense.hasMatch(stripped)) {
@@ -218,6 +218,15 @@ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
 DISCLAIMED.
 ''');
+
+final RegExp _mitEmphasis = _longTextRegExp('''
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.''');
 
 bool _isLicenseFile(FileSystemEntity fse) {
   if (fse is File) {

--- a/test/license_test.dart
+++ b/test/license_test.dart
@@ -89,6 +89,8 @@ main() {
           new LicenseFile(null, 'MIT'));
       await expectFile(
           'test/licenses/mit.txt', new LicenseFile('mit.txt', 'MIT'));
+      await expectFile('test/licenses/mit_without_mit.txt',
+          new LicenseFile('mit_without_mit.txt', 'MIT'));
     });
   });
 

--- a/test/licenses/mit_without_mit.txt
+++ b/test/licenses/mit_without_mit.txt
@@ -1,0 +1,5 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Fixes #200 