### PR TITLE
Use raw links for images in repository URLs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1-dev
+
+* Use raw links for images in repository URLs.
+
 ## 0.9.0+1
 
 * Fix NPE when dependency has no constraint (e.g. git repo).

--- a/lib/src/download_utils.dart
+++ b/lib/src/download_utils.dart
@@ -11,6 +11,8 @@ import 'package:path/path.dart' as p;
 import 'logging.dart';
 import 'utils.dart';
 
+final imageExtensions = new Set.from(['.gif', '.jpg', '.jpeg', '.png']);
+
 /// Returns a non-null Directory instance only if it is able to download and
 /// extract the direct package dependency. On any failure it clears the temp
 /// directory, otherwise it is the caller's responsibility to delete it.
@@ -56,12 +58,16 @@ String getRepositoryUrl(String repository, String relativePath) {
 
     if (repository.startsWith('https://github.com/') ||
         repository.startsWith('https://gitlab.com/')) {
+      final extension = p.extension(relativePath).toLowerCase();
+      final isRaw = imageExtensions.contains(extension);
+      final typeSegment = isRaw ? 'raw' : 'blob';
+
       if (segments.length < 2) {
         return null;
       } else if (segments.length == 2) {
-        return p.join(repository, 'blob/master', relativePath);
+        return p.join(repository, typeSegment, 'master', relativePath);
       } else if (segments[2] == 'tree' || segments[2] == 'blob') {
-        segments[2] = 'blob';
+        segments[2] = typeSegment;
         final newUrl = uri.replace(pathSegments: segments).toString();
         return p.join(newUrl, relativePath);
       } else {

--- a/test/download_utils_test.dart
+++ b/test/download_utils_test.dart
@@ -20,7 +20,7 @@ void main() {
           '$prefix/dart-lang/angular/blob/master/README.md');
     });
 
-    test('project directory', () {
+    test('project subdir', () {
       expect(
           getRepositoryUrl(
               '$prefix/dart-lang/angular/tree/master/angular', 'README.md'),
@@ -29,6 +29,24 @@ void main() {
           getRepositoryUrl(
               '$prefix/dart-lang/angular/tree/master/angular/', 'README.md'),
           '$prefix/dart-lang/angular/blob/master/angular/README.md');
+    });
+
+    test('image links in root', () {
+      expect(getRepositoryUrl('$prefix/dart-lang/angular', 'logo.png'),
+          '$prefix/dart-lang/angular/raw/master/logo.png');
+      expect(getRepositoryUrl('$prefix/dart-lang/angular/', 'logo.png'),
+          '$prefix/dart-lang/angular/raw/master/logo.png');
+    });
+
+    test('image links in project subdir', () {
+      expect(
+          getRepositoryUrl(
+              '$prefix/dart-lang/angular/tree/master/angular', 'logo.png'),
+          '$prefix/dart-lang/angular/raw/master/angular/logo.png');
+      expect(
+          getRepositoryUrl(
+              '$prefix/dart-lang/angular/tree/master/angular/', 'logo.png'),
+          '$prefix/dart-lang/angular/raw/master/angular/logo.png');
     });
   }
 


### PR DESCRIPTION
- github redirects it to raw.githubusercontent.com (or something)
- gitlab will keep serving the file with the /raw/ path segment
