### PR TITLE
Include component list in platform classification reasons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1-dev
+
+* Include component list in platform classification reasons.
+
 ## 0.10.0
 
 **BREAKING CHANGES**:

--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -333,8 +333,11 @@ DartPlatform classifyPkgPlatform(
       return new DartPlatform.everywhere(
           'No platform restriction found in primary library `$primaryLibrary`.');
     } else {
+      final componentsFound =
+          primaryPlatform.components.map((name) => '`$name`').join(', ');
       return new DartPlatform.fromComponents(primaryPlatform.components,
-          reason: 'Primary library: `$primaryLibrary`.');
+          reason:
+              'Primary library: `$primaryLibrary` with components: $componentsFound.');
     }
   }
 
@@ -346,8 +349,10 @@ DartPlatform classifyPkgPlatform(
     return new DartPlatform.everywhere(
         'No platform restriction found in libraries.');
   } else {
+    final componentsFound =
+        allComponentNames.map((name) => '`$name`').join(', ');
     return new DartPlatform.fromComponents(allComponentNames,
-        reason: 'Multiple platform identified in libraries.');
+        reason: 'Platform components identified in package: $componentsFound.');
   }
 }
 

--- a/lib/src/version.g.dart
+++ b/lib/src/version.g.dart
@@ -10,4 +10,4 @@ part of pana.version;
 // Generator: PackageVersionGenerator
 // **************************************************************************
 
-final _$panaPkgVersionPubSemverVersion = new Version.parse("0.10.0");
+final _$panaPkgVersionPubSemverVersion = new Version.parse("0.10.1-dev");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.10.0
+version: 0.10.1-dev
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 

--- a/test/platform_test.dart
+++ b/test/platform_test.dart
@@ -160,7 +160,8 @@ void main() {
       expect(sum.components, ['html', 'io']);
       expect(sum.longPlatformDebug,
           'flutter: forbidden, web: used, other: conflict');
-      expect(sum.reason, 'Multiple platform identified in libraries.');
+      expect(sum.reason,
+          'Platform components identified in package: `html`, `io`.');
     });
 
     test('detects flutter in pubspec', () {


### PR DESCRIPTION
The current fallback message looks weird in certain cases (mostly build-related tools without primary library):

<img width="362" alt="screen shot 2018-01-19 at 3 44 09 pm" src="https://user-images.githubusercontent.com/4778111/35156215-77152898-fd30-11e7-8651-f0cf948975a0.png">

Instead, we'd have the following:

* Platform components identified in package: `io`, `mirrors`.