### PR TITLE
Flutter-specific suggestion messages for dartfmt and dartanalyzer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Fix CI test
 
+* Flutter-specific suggestion messages for `dartfmt` and `dartanalyzer`.
+
 ## 0.10.3
 
 * Fix end-to-end test (package dependency changed).

--- a/lib/src/fitness.dart
+++ b/lib/src/fitness.dart
@@ -12,7 +12,9 @@ import 'package:json_annotation/json_annotation.dart';
 import 'package:path/path.dart' as p;
 
 import 'code_problem.dart';
+import 'messages.dart' as messages;
 import 'platform.dart';
+import 'pubspec.dart';
 import 'summary.dart';
 
 part 'fitness.g.dart';
@@ -46,6 +48,7 @@ class Fitness extends Object with _$FitnessSerializerMixin {
 
 Future<Fitness> calcFitness(
     String pkgDir,
+    Pubspec pubspec,
     String dartFile,
     bool isFormatted,
     List<CodeProblem> fileAnalyzerItems,
@@ -99,7 +102,7 @@ Future<Fitness> calcFitness(
     shortcoming += hintPoints;
     suggestions.add(new Suggestion.hint(
       'Format `$dartFile`.',
-      'Run `dartfmt` to format `$dartFile`.',
+      messages.runDartfmtToFormatFile(pubspec.usesFlutter, dartFile),
       file: dartFile,
       penalty: new Penalty(amount: hintPoints.ceil()),
     ));

--- a/lib/src/maintenance.dart
+++ b/lib/src/maintenance.dart
@@ -314,7 +314,7 @@ Future<Maintenance> detectMaintenance(
 
   if (dartFileSuggestions.isNotEmpty) {
     final sb = new StringBuffer();
-    sb.write('`dartanalyzer` or `dartfmt` reported');
+    sb.write('Analysis or formatting checks reported');
     void reportIssues(int count, String name) {
       if (count == 1) {
         sb.write(' $count $name');
@@ -350,7 +350,7 @@ Future<Maintenance> detectMaintenance(
     maintenanceSuggestions.add(
       new Suggestion(
         level,
-        'Fix issues reported by `dartanalyzer` or `dartfmt`.',
+        'Fix analysis and formatting issues.',
         sb.toString(),
         // These are already reflected in the fitness score, but we'll also
         // penalize them here (with a much smaller amount), reflecting the need

--- a/lib/src/messages.dart
+++ b/lib/src/messages.dart
@@ -1,0 +1,53 @@
+// Copyright (c) 2018, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+class _MsgDict {
+  final String dartanalyzerShortName;
+  final String dartanalyzerShortCmd;
+  final String dartfmtShortName;
+  final String dartfmtShortCmd;
+
+  _MsgDict._({
+    this.dartanalyzerShortName: 'dartanalyzer',
+    this.dartanalyzerShortCmd: 'dartanalyzer .',
+    this.dartfmtShortName: 'dartfmt',
+    this.dartfmtShortCmd: 'dartfmt -n .',
+  });
+
+  static _MsgDict defaultDict = new _MsgDict._();
+
+  static _MsgDict flutterDict = new _MsgDict._(
+    dartanalyzerShortName: 'flutter analyze',
+    dartanalyzerShortCmd: 'flutter analyze',
+    dartfmtShortName: 'flutter format',
+    dartfmtShortCmd: 'flutter format',
+  );
+}
+
+String runDartfmtToFormatFile(bool usesFlutter, String dartFile) {
+  final dict = usesFlutter ? _MsgDict.flutterDict : _MsgDict.defaultDict;
+  return 'Run `${dict.dartfmtShortName}` to format `$dartFile`.';
+}
+
+String makeSureDartfmtRuns(bool usesFlutter) {
+  final dict = usesFlutter ? _MsgDict.flutterDict : _MsgDict.defaultDict;
+  return 'Make sure `${dict.dartfmtShortName}` runs.';
+}
+
+String runningDartfmtFailed(bool usesFlutter, errorMsg) {
+  final dict = usesFlutter ? _MsgDict.flutterDict : _MsgDict.defaultDict;
+  return 'Running `${dict.dartfmtShortCmd}` failed with the following output:\n\n'
+      '```\n$errorMsg\n```\n';
+}
+
+String makeSureDartanalyzerRuns(bool usesFlutter) {
+  final dict = usesFlutter ? _MsgDict.flutterDict : _MsgDict.defaultDict;
+  return 'Make sure `${dict.dartanalyzerShortName}` runs.';
+}
+
+String runningDartanalyzerFailed(bool usesFlutter, errorMsg) {
+  final dict = usesFlutter ? _MsgDict.flutterDict : _MsgDict.defaultDict;
+  return 'Running `${dict.dartanalyzerShortCmd}` failed with the following output:\n\n'
+      '```\n$errorMsg\n```\n';
+}

--- a/test/end2end/http_data.dart
+++ b/test/end2end/http_data.dart
@@ -920,8 +920,8 @@ final _data = {
       },
       {
         'level': 'hint',
-        'title': 'Fix issues reported by `dartanalyzer` or `dartfmt`.',
-        'description': '`dartanalyzer` or `dartfmt` reported 17 hints.\n\n'
+        'title': 'Fix analysis and formatting issues.',
+        'description': 'Analysis or formatting checks reported 17 hints.\n\n'
             'Run `dartfmt` to format `lib/browser_client.dart`.\n\n'
             'Run `dartfmt` to format `lib/http.dart`.\n\n'
             'Similar analysis of the following files failed:\n\n'

--- a/test/end2end/pub_server_data.dart
+++ b/test/end2end/pub_server_data.dart
@@ -345,8 +345,8 @@ final _data = {
       },
       {
         'level': 'hint',
-        'title': 'Fix issues reported by `dartanalyzer` or `dartfmt`.',
-        'description': '`dartanalyzer` or `dartfmt` reported 1 hint.\n\n'
+        'title': 'Fix analysis and formatting issues.',
+        'description': 'Analysis or formatting checks reported 1 hint.\n\n'
             'Run `dartfmt` to format `lib/shelf_pubserver.dart`.\n\n',
         'penalty': {'amount': 1, 'fraction': 0},
       },

--- a/test/end2end/skiplist_data.dart
+++ b/test/end2end/skiplist_data.dart
@@ -287,8 +287,9 @@ final _data = {
     'suggestions': [
       {
         'level': 'warning',
-        'title': 'Fix issues reported by `dartanalyzer` or `dartfmt`.',
-        'description': '`dartanalyzer` or `dartfmt` reported 8 errors 1 hint.\n'
+        'title': 'Fix analysis and formatting issues.',
+        'description':
+            'Analysis or formatting checks reported 8 errors 1 hint.\n'
             '\n'
             'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
             '\n'

--- a/test/end2end/stream_broken_data.dart
+++ b/test/end2end/stream_broken_data.dart
@@ -62,8 +62,8 @@ final _data = {
       },
       {
         'level': 'hint',
-        'title': 'Fix issues reported by `dartanalyzer` or `dartfmt`.',
-        'description': '`dartanalyzer` or `dartfmt` reported 16 hints.\n\n'
+        'title': 'Fix analysis and formatting issues.',
+        'description': 'Analysis or formatting checks reported 16 hints.\n\n'
             'Run `dartfmt` to format `lib/plugin.dart`.\n\n'
             'Run `dartfmt` to format `lib/rspc.dart`.\n\n'
             'Similar analysis of the following files failed:\n\n'

--- a/test/maintenance_test.dart
+++ b/test/maintenance_test.dart
@@ -61,9 +61,9 @@ final _withIssuesJson = {
     },
     {
       'level': 'warning',
-      'title': 'Fix issues reported by `dartanalyzer` or `dartfmt`.',
+      'title': 'Fix analysis and formatting issues.',
       'description':
-          '`dartanalyzer` or `dartfmt` reported 1 error 1 warning 1 hint.\n\nerror\n\n',
+          'Analysis or formatting checks reported 1 error 1 warning 1 hint.\n\nerror\n\n',
       'penalty': {'amount': 61, 'fraction': 0},
     },
     {


### PR DESCRIPTION
- Closes #262
- There is a reordering `lib/src/package_analyzer.dart`: pubspec is read earlier, moved before dartfmt run.
- Created `messages.dart` to eventually collect most of the message formatting code into one location.