### PR TITLE
Preapring 0.10.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.5-dev
+## 0.10.5
 
 * Enable Dart 2 Preview in Flutter analyzer options.
 

--- a/lib/src/version.g.dart
+++ b/lib/src/version.g.dart
@@ -10,4 +10,4 @@ part of pana.version;
 // Generator: PackageVersionGenerator
 // **************************************************************************
 
-final _$panaPkgVersionPubSemverVersion = new Version.parse("0.10.5-dev");
+final _$panaPkgVersionPubSemverVersion = new Version.parse("0.10.5");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.10.5-dev
+version: 0.10.5
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
The dartdoc/API doc coverage requires more work, and we'll need the Flutter analysis options to be released for the pub site this week.