### PR TITLE
Treat 'environment:' keys as dependent SDKs (e.g. flutter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Change platform classification of `dart:isolate`: no longer available on `web`.
 
+* Treat `environment:` keys as dependent SDKs (e.g. `flutter`).
+
 ## 0.10.5
 
 * Enable Dart 2 Preview in Flutter analyzer options.

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -90,6 +90,12 @@ class Pubspec {
           _dependentSdks.add(value['sdk']);
         }
       });
+      final environmentMap = _content['environment'];
+      if (environmentMap is Map) {
+        final List<String> keys = environmentMap.keys.toList();
+        keys.remove('sdk');
+        _dependentSdks.addAll(keys);
+      }
     }
     return _dependentSdks;
   }

--- a/test/pubspec_test.dart
+++ b/test/pubspec_test.dart
@@ -6,6 +6,7 @@ void main() {
     expect(emptyPubspec.hasFlutterKey, isFalse);
     expect(emptyPubspec.hasFlutterPluginKey, isFalse);
     expect(emptyPubspec.dependsOnFlutterSdk, isFalse);
+    expect(sdkOnlyEnvPubspec.dependsOnFlutterSdk, isFalse);
   });
 
   test('flutter', () {
@@ -20,6 +21,7 @@ void main() {
     expect(flutterSdkDevPubspec.hasFlutterPluginKey, isFalse);
     expect(flutterSdkDevPubspec.dependsOnFlutterSdk, isTrue);
     expect(flutterSdkDevPubspec.dependentSdks.toList(), ['flutter']);
+    expect(flutterInEnvPubspec.dependsOnFlutterSdk, isTrue);
   });
 
   test('unknown sdk', () {
@@ -62,5 +64,18 @@ final Pubspec unknownSdkPubspec = new Pubspec({
     'example': {
       'sdk': 'unknown',
     },
+  },
+});
+
+final Pubspec sdkOnlyEnvPubspec = new Pubspec({
+  'environment': {
+    'sdk': '^2.0.0',
+  },
+});
+
+final Pubspec flutterInEnvPubspec = new Pubspec({
+  'environment': {
+    'sdk': '^2.0.0',
+    'flutter': '^1.0.0',
   },
 });


### PR DESCRIPTION
Closes #110