### PR TITLE
Move *SDK environments into a single ToolEnvironment class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.11.0-dev
+
+**Breaking changes:**
+
+* `DartSdk`, `FlutterSdk` and `PubEnvironment` is replaced with `ToolEnvironment`.
+
 ## 0.10.6
 
 * Enable Dart 2 Preview in analyzer options (including non-Flutter packages).

--- a/lib/src/library_scanner.dart
+++ b/lib/src/library_scanner.dart
@@ -46,10 +46,10 @@ class LibraryScanner {
       this._context, this._overrides);
 
   factory LibraryScanner(
-      PubEnvironment pubEnv, String packagePath, bool useFlutter,
+      ToolEnvironment toolEnv, String packagePath, bool useFlutter,
       {List<LibraryOverride> overrides}) {
     // TODO: fail more clearly if this...fails
-    var sdkPath = pubEnv.dartSdk.sdkDir;
+    var sdkPath = toolEnv.dartSdkDir;
 
     var resourceProvider = PhysicalResourceProvider.INSTANCE;
     var sdk = new FolderBasedDartSdk(
@@ -65,7 +65,7 @@ class LibraryScanner {
     RunPubList runPubList;
     if (useFlutter) {
       runPubList = (Folder folder) =>
-          pubEnv.listPackageDirsSync(folder.path, useFlutter);
+          toolEnv.listPackageDirsSync(folder.path, useFlutter);
     }
 
     var pubPackageMapProvider = new PubPackageMapProvider(

--- a/lib/src/version.g.dart
+++ b/lib/src/version.g.dart
@@ -10,4 +10,4 @@ part of pana.version;
 // Generator: PackageVersionGenerator
 // **************************************************************************
 
-final _$panaPkgVersionPubSemverVersion = new Version.parse("0.10.6");
+final _$panaPkgVersionPubSemverVersion = new Version.parse("0.11.0-dev");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.10.6
+version: 0.11.0-dev
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
This is the first step of refactoring for #269 (among others). Running `pub global run dartdoc` requires us change back and forth between using a local and a global `PUB_CACHE`, and I would like to tidy up these runtime-related functions before implementing that.

