### PR TITLE
Add top-level `models.dart` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Updates:
 
 * Check if `dartdoc` can run on the package.
 
+* Added a top-level `models.dart` library exposing several of the data classes.
+
 ## 0.10.6
 
 * Enable Dart 2 Preview in analyzer options (including non-Flutter packages).

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -1,0 +1,1 @@
+export 'src/model.dart';


### PR DESCRIPTION
Allows import of this code in a web app without bringing in pkg:analyzer
and friends.