### PR TITLE
Removed Fitness.suggestions (moved/refactored)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 * Move all runtime/version info into `PanaRuntimeInfo` (and use it in `Summary`).
 
+* Removed `Fitness.suggestions` (moved it to `DartFileSummary`)
+
 Updates:
 
 * Check if `dartdoc` can run on the package (optional).

--- a/lib/src/fitness.dart
+++ b/lib/src/fitness.dart
@@ -14,7 +14,14 @@ import 'messages.dart' as messages;
 import 'model.dart';
 import 'pubspec.dart';
 
-Future<Fitness> calcFitness(
+class FitnessResult {
+  final Fitness fitness;
+  final List<Suggestion> suggestions;
+
+  FitnessResult(this.fitness, this.suggestions);
+}
+
+Future<FitnessResult> calcFitness(
     String pkgDir,
     Pubspec pubspec,
     String dartFile,
@@ -114,8 +121,8 @@ Future<Fitness> calcFitness(
     }
   }
   suggestions.sort();
-  return new Fitness(magnitude, min(shortcoming, magnitude),
-      suggestions: suggestions.isEmpty ? null : suggestions);
+  final fitness = new Fitness(magnitude, min(shortcoming, magnitude));
+  return new FitnessResult(fitness, suggestions.isEmpty ? null : suggestions);
 }
 
 Fitness calcPkgFitness(Iterable<DartFileSummary> files) {

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -104,6 +104,10 @@ class DartFileSummary extends Object with _$DartFileSummarySerializerMixin {
   @JsonKey(includeIfNull: false)
   final Fitness fitness;
 
+  /// The suggestions that affect the maintenance score.
+  @JsonKey(includeIfNull: false)
+  final List<Suggestion> suggestions;
+
   DartFileSummary(
     this.uri,
     this.size,
@@ -113,6 +117,7 @@ class DartFileSummary extends Object with _$DartFileSummarySerializerMixin {
     this.transitiveLibs,
     this.platform,
     this.fitness,
+    this.suggestions,
   );
 
   factory DartFileSummary.fromJson(Map<String, dynamic> json) =>
@@ -602,10 +607,7 @@ class Fitness extends Object with _$FitnessSerializerMixin {
   /// The faults, penalties and failures to meet the standards.
   final double shortcoming;
 
-  @JsonKey(includeIfNull: false)
-  final List<Suggestion> suggestions;
-
-  Fitness(this.magnitude, this.shortcoming, {this.suggestions});
+  Fitness(this.magnitude, this.shortcoming);
 
   factory Fitness.fromJson(Map json) => _$FitnessFromJson(json);
 
@@ -616,8 +618,6 @@ class Fitness extends Object with _$FitnessSerializerMixin {
     final score = (magnitude - shortcoming) / magnitude;
     return math.max(0.0, math.min(1.0, score));
   }
-
-  bool get hasSuggestion => suggestions != null && suggestions.isNotEmpty;
 }
 
 @JsonSerializable()

--- a/lib/src/model.g.dart
+++ b/lib/src/model.g.dart
@@ -114,26 +114,32 @@ abstract class _$PanaRuntimeInfoSerializerMixin {
   }
 }
 
-DartFileSummary _$DartFileSummaryFromJson(
-        Map<String, dynamic> json) =>
-    new DartFileSummary(
-        json['uri'] as String,
-        json['size'] as int,
-        json['isFormatted'] as bool,
-        (json['codeProblems'] as List)
-            ?.map((e) => e == null
+DartFileSummary
+    _$DartFileSummaryFromJson(Map<String, dynamic> json) =>
+        new DartFileSummary(
+            json['uri'] as String,
+            json['size'] as int,
+            json['isFormatted'] as bool,
+            (json['codeProblems'] as List)
+                ?.map((e) => e == null
+                    ? null
+                    : new CodeProblem.fromJson(e as Map<String, dynamic>))
+                ?.toList(),
+            (json['directLibs'] as List)?.map((e) => e as String)?.toList(),
+            (json['transitiveLibs'] as List)?.map((e) => e as String)?.toList(),
+            json['platform'] == null
                 ? null
-                : new CodeProblem.fromJson(e as Map<String, dynamic>))
-            ?.toList(),
-        (json['directLibs'] as List)?.map((e) => e as String)?.toList(),
-        (json['transitiveLibs'] as List)?.map((e) => e as String)?.toList(),
-        json['platform'] == null
-            ? null
-            : new DartPlatform.fromJson(
-                json['platform'] as Map<String, dynamic>),
-        json['fitness'] == null
-            ? null
-            : new Fitness.fromJson(json['fitness'] as Map<dynamic, dynamic>));
+                : new DartPlatform.fromJson(
+                    json['platform'] as Map<String, dynamic>),
+            json['fitness'] == null
+                ? null
+                : new Fitness.fromJson(
+                    json['fitness'] as Map<dynamic, dynamic>),
+            (json['suggestions'] as List)
+                ?.map((e) => e == null
+                    ? null
+                    : new Suggestion.fromJson(e as Map<String, dynamic>))
+                ?.toList());
 
 abstract class _$DartFileSummarySerializerMixin {
   String get uri;
@@ -144,6 +150,7 @@ abstract class _$DartFileSummarySerializerMixin {
   List<String> get transitiveLibs;
   DartPlatform get platform;
   Fitness get fitness;
+  List<Suggestion> get suggestions;
   Map<String, dynamic> toJson() {
     var val = <String, dynamic>{
       'uri': uri,
@@ -162,6 +169,7 @@ abstract class _$DartFileSummarySerializerMixin {
     writeNotNull('transitiveLibs', transitiveLibs);
     writeNotNull('platform', platform);
     writeNotNull('fitness', fitness);
+    writeNotNull('suggestions', suggestions);
     return val;
   }
 }
@@ -374,32 +382,13 @@ abstract class _$MaintenanceSerializerMixin {
 
 Fitness _$FitnessFromJson(Map<String, dynamic> json) => new Fitness(
     (json['magnitude'] as num)?.toDouble(),
-    (json['shortcoming'] as num)?.toDouble(),
-    suggestions: (json['suggestions'] as List)
-        ?.map((e) => e == null
-            ? null
-            : new Suggestion.fromJson(e as Map<String, dynamic>))
-        ?.toList());
+    (json['shortcoming'] as num)?.toDouble());
 
 abstract class _$FitnessSerializerMixin {
   double get magnitude;
   double get shortcoming;
-  List<Suggestion> get suggestions;
-  Map<String, dynamic> toJson() {
-    var val = <String, dynamic>{
-      'magnitude': magnitude,
-      'shortcoming': shortcoming,
-    };
-
-    void writeNotNull(String key, dynamic value) {
-      if (value != null) {
-        val[key] = value;
-      }
-    }
-
-    writeNotNull('suggestions', suggestions);
-    return val;
-  }
+  Map<String, dynamic> toJson() =>
+      <String, dynamic>{'magnitude': magnitude, 'shortcoming': shortcoming};
 }
 
 LicenseFile _$LicenseFileFromJson(Map<String, dynamic> json) =>

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -25,14 +25,14 @@ import 'sdk_env.dart';
 import 'utils.dart';
 
 class InspectOptions {
+  final bool verbose;
   final bool deleteTemporaryDirectory;
-  final bool keepTransitiveLibs;
   final String pubHostedUrl;
   final String dartdocOutputDir;
 
   InspectOptions({
+    this.verbose: false,
     this.deleteTemporaryDirectory: true,
-    this.keepTransitiveLibs: false,
     this.pubHostedUrl,
     this.dartdocOutputDir,
   });
@@ -286,7 +286,7 @@ class PackageAnalyzer {
         platform ??= classifyLibPlatform(transitiveLibs);
       }
       final isInLib = dartFile.startsWith('lib/');
-      final fitness = isInLib
+      final fitnessResult = isInLib
           ? await calcFitness(pkgDir, pubspec, dartFile, isFormatted,
               fileAnalyzerItems, directLibs, platform)
           : null;
@@ -296,12 +296,13 @@ class PackageAnalyzer {
         isFormatted,
         fileAnalyzerItems,
         directLibs,
-        options.keepTransitiveLibs ? transitiveLibs : null,
+        options.verbose ? transitiveLibs : null,
         platform,
-        fitness,
+        fitnessResult?.fitness,
+        options.verbose ? fitnessResult?.suggestions : null,
       );
-      if (fitness != null && fitness.hasSuggestion) {
-        dartFileSuggestions.addAll(fitness.suggestions);
+      if (fitnessResult?.suggestions != null) {
+        dartFileSuggestions.addAll(fitnessResult.suggestions);
       }
     }
     dartFileSuggestions.sort();

--- a/test/end2end/http_data.dart
+++ b/test/end2end/http_data.dart
@@ -262,16 +262,16 @@ final _data = {
       'fitness': {
         'magnitude': 83.0,
         'shortcoming': 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/browser_client.dart`.',
-            'description': 'Run `dartfmt` to format `lib/browser_client.dart`.',
-            'file': 'lib/browser_client.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/browser_client.dart`.',
+          'description': 'Run `dartfmt` to format `lib/browser_client.dart`.',
+          'file': 'lib/browser_client.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/http.dart": {
       "uri": "package:http/http.dart",
@@ -460,52 +460,52 @@ final _data = {
       'fitness': {
         'magnitude': 139.0,
         'shortcoming': 4.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/http.dart`.',
-            'description': 'Run `dartfmt` to format `lib/http.dart`.',
-            'file': 'lib/http.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/http.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/http.dart` gave the following hint:\n'
-                '\n'
-                'line: 64 col: 29  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/http.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/http.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/http.dart` gave the following hint:\n'
-                '\n'
-                'line: 88 col: 29  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/http.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/http.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/http.dart` gave the following hint:\n'
-                '\n'
-                'line: 112 col: 29  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/http.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/http.dart`.',
+          'description': 'Run `dartfmt` to format `lib/http.dart`.',
+          'file': 'lib/http.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/http.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/http.dart` gave the following hint:\n'
+              '\n'
+              'line: 64 col: 29  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/http.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/http.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/http.dart` gave the following hint:\n'
+              '\n'
+              'line: 88 col: 29  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/http.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/http.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/http.dart` gave the following hint:\n'
+              '\n'
+              'line: 112 col: 29  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/http.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+      ],
     },
     "lib/src/base_client.dart": {
       "uri": "package:http/src/base_client.dart",
@@ -534,41 +534,40 @@ final _data = {
       'fitness': {
         'magnitude': 136.0,
         'shortcoming': 3.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/base_client.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/base_client.dart`.',
-            'file': 'lib/src/base_client.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/base_client.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/base_client.dart` gave the following hint:\n'
-                '\n'
-                'line: 163 col: 44  \n'
-                '\'typed\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/base_client.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/base_client.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/base_client.dart` gave the following hint:\n'
-                '\n'
-                'line: 165 col: 44  \n'
-                '\'typed\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/base_client.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/base_client.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/base_client.dart`.',
+          'file': 'lib/src/base_client.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/base_client.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/base_client.dart` gave the following hint:\n'
+              '\n'
+              'line: 163 col: 44  \n'
+              '\'typed\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/base_client.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/base_client.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/base_client.dart` gave the following hint:\n'
+              '\n'
+              'line: 165 col: 44  \n'
+              '\'typed\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/base_client.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+      ],
     },
     "lib/src/base_request.dart": {
       "uri": "package:http/src/base_request.dart",
@@ -578,17 +577,16 @@ final _data = {
       'fitness': {
         'magnitude': 93.0,
         'shortcoming': 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/base_request.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/base_request.dart`.',
-            'file': 'lib/src/base_request.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/base_request.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/base_request.dart`.',
+          'file': 'lib/src/base_request.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/base_response.dart": {
       "uri": "package:http/src/base_response.dart",
@@ -598,17 +596,17 @@ final _data = {
       'fitness': {
         'magnitude': 32.0,
         'shortcoming': 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/base_response.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/base_response.dart`.',
-            'file': 'lib/src/base_response.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/base_response.dart`.',
+          'description':
+              'Run `dartfmt` to format `lib/src/base_response.dart`.',
+          'file': 'lib/src/base_response.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/boundary_characters.dart": {
       "uri": "package:http/src/boundary_characters.dart",
@@ -618,17 +616,17 @@ final _data = {
       'fitness': {
         'magnitude': 13.0,
         'shortcoming': 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/boundary_characters.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/boundary_characters.dart`.',
-            'file': 'lib/src/boundary_characters.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/boundary_characters.dart`.',
+          'description':
+              'Run `dartfmt` to format `lib/src/boundary_characters.dart`.',
+          'file': 'lib/src/boundary_characters.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/byte_stream.dart": {
       "uri": "package:http/src/byte_stream.dart",
@@ -657,41 +655,40 @@ final _data = {
       'fitness': {
         'magnitude': 25.0,
         'shortcoming': 3.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/byte_stream.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/byte_stream.dart`.',
-            'file': 'lib/src/byte_stream.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/byte_stream.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/byte_stream.dart` gave the following hint:\n'
-                '\n'
-                'line: 31 col: 51  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/byte_stream.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/byte_stream.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/byte_stream.dart` gave the following hint:\n'
-                '\n'
-                'line: 34 col: 52  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/byte_stream.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/byte_stream.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/byte_stream.dart`.',
+          'file': 'lib/src/byte_stream.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/byte_stream.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/byte_stream.dart` gave the following hint:\n'
+              '\n'
+              'line: 31 col: 51  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/byte_stream.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/byte_stream.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/byte_stream.dart` gave the following hint:\n'
+              '\n'
+              'line: 34 col: 52  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/byte_stream.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+      ],
     },
     "lib/src/client.dart": {
       "uri": "package:http/src/client.dart",
@@ -729,52 +726,52 @@ final _data = {
       'fitness': {
         'magnitude': 101.0,
         'shortcoming': 4.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/client.dart`.',
-            'description': 'Run `dartfmt` to format `lib/src/client.dart`.',
-            'file': 'lib/src/client.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/client.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/client.dart` gave the following hint:\n'
-                '\n'
-                'line: 59 col: 31  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/client.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/client.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/client.dart` gave the following hint:\n'
-                '\n'
-                'line: 80 col: 31  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/client.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/client.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/client.dart` gave the following hint:\n'
-                '\n'
-                'line: 101 col: 31  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/client.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/client.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/client.dart`.',
+          'file': 'lib/src/client.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/client.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/client.dart` gave the following hint:\n'
+              '\n'
+              'line: 59 col: 31  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/client.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/client.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/client.dart` gave the following hint:\n'
+              '\n'
+              'line: 80 col: 31  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/client.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/client.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/client.dart` gave the following hint:\n'
+              '\n'
+              'line: 101 col: 31  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/client.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+      ],
     },
     "lib/src/exception.dart": {
       "uri": "package:http/src/exception.dart",
@@ -791,16 +788,16 @@ final _data = {
       'fitness': {
         'magnitude': 49.0,
         'shortcoming': 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/io_client.dart`.',
-            'description': 'Run `dartfmt` to format `lib/src/io_client.dart`.',
-            'file': 'lib/src/io_client.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/io_client.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/io_client.dart`.',
+          'file': 'lib/src/io_client.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/mock_client.dart": {
       "uri": "package:http/src/mock_client.dart",
@@ -810,17 +807,16 @@ final _data = {
       'fitness': {
         'magnitude': 59.0,
         'shortcoming': 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/mock_client.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/mock_client.dart`.',
-            'file': 'lib/src/mock_client.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/mock_client.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/mock_client.dart`.',
+          'file': 'lib/src/mock_client.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/multipart_file.dart": {
       "uri": "package:http/src/multipart_file.dart",
@@ -840,29 +836,29 @@ final _data = {
       'fitness': {
         'magnitude': 79.0,
         'shortcoming': 2.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/multipart_file.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/multipart_file.dart`.',
-            'file': 'lib/src/multipart_file.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/multipart_file.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/multipart_file.dart` gave the following hint:\n'
-                '\n'
-                'line: 73 col: 74  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/multipart_file.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/multipart_file.dart`.',
+          'description':
+              'Run `dartfmt` to format `lib/src/multipart_file.dart`.',
+          'file': 'lib/src/multipart_file.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/multipart_file.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/multipart_file.dart` gave the following hint:\n'
+              '\n'
+              'line: 73 col: 74  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/multipart_file.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+      ],
     },
     "lib/src/multipart_request.dart": {
       "uri": "package:http/src/multipart_request.dart",
@@ -918,77 +914,77 @@ final _data = {
       'fitness': {
         'magnitude': 116.0,
         'shortcoming': 6.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/multipart_request.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/multipart_request.dart`.',
-            'file': 'lib/src/multipart_request.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/multipart_request.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/multipart_request.dart` gave the following hint:\n'
-                '\n'
-                'line: 64 col: 11  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/multipart_request.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/multipart_request.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/multipart_request.dart` gave the following hint:\n'
-                '\n'
-                'line: 65 col: 11  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/multipart_request.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/multipart_request.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/multipart_request.dart` gave the following hint:\n'
-                '\n'
-                'line: 70 col: 11  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/multipart_request.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/multipart_request.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/multipart_request.dart` gave the following hint:\n'
-                '\n'
-                'line: 93 col: 22  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/multipart_request.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/multipart_request.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/multipart_request.dart` gave the following hint:\n'
-                '\n'
-                'line: 96 col: 48  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/multipart_request.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/multipart_request.dart`.',
+          'description':
+              'Run `dartfmt` to format `lib/src/multipart_request.dart`.',
+          'file': 'lib/src/multipart_request.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/multipart_request.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/multipart_request.dart` gave the following hint:\n'
+              '\n'
+              'line: 64 col: 11  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/multipart_request.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/multipart_request.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/multipart_request.dart` gave the following hint:\n'
+              '\n'
+              'line: 65 col: 11  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/multipart_request.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/multipart_request.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/multipart_request.dart` gave the following hint:\n'
+              '\n'
+              'line: 70 col: 11  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/multipart_request.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/multipart_request.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/multipart_request.dart` gave the following hint:\n'
+              '\n'
+              'line: 93 col: 22  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/multipart_request.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/multipart_request.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/multipart_request.dart` gave the following hint:\n'
+              '\n'
+              'line: 96 col: 48  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/multipart_request.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+      ],
     },
     "lib/src/request.dart": {
       "uri": "package:http/src/request.dart",
@@ -1017,40 +1013,40 @@ final _data = {
       'fitness': {
         'magnitude': 109.0,
         'shortcoming': 3.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/request.dart`.',
-            'description': 'Run `dartfmt` to format `lib/src/request.dart`.',
-            'file': 'lib/src/request.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/request.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/request.dart` gave the following hint:\n'
-                '\n'
-                'line: 39 col: 42  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/request.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/request.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/request.dart` gave the following hint:\n'
-                '\n'
-                'line: 133 col: 26  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/request.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/request.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/request.dart`.',
+          'file': 'lib/src/request.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/request.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/request.dart` gave the following hint:\n'
+              '\n'
+              'line: 39 col: 42  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/request.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/request.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/request.dart` gave the following hint:\n'
+              '\n'
+              'line: 133 col: 26  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/request.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+      ],
     },
     "lib/src/response.dart": {
       "uri": "package:http/src/response.dart",
@@ -1079,40 +1075,40 @@ final _data = {
       'fitness': {
         'magnitude': 62.0,
         'shortcoming': 3.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/response.dart`.',
-            'description': 'Run `dartfmt` to format `lib/src/response.dart`.',
-            'file': 'lib/src/response.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/response.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/response.dart` gave the following hint:\n'
-                '\n'
-                'line: 24 col: 8  \n'
-                '\'LATIN1\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/response.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/response.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/response.dart` gave the following hint:\n'
-                '\n'
-                'line: 83 col: 18  \n'
-                '\'LATIN1\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/response.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/response.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/response.dart`.',
+          'file': 'lib/src/response.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/response.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/response.dart` gave the following hint:\n'
+              '\n'
+              'line: 24 col: 8  \n'
+              '\'LATIN1\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/response.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/response.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/response.dart` gave the following hint:\n'
+              '\n'
+              'line: 83 col: 18  \n'
+              '\'LATIN1\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/response.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+      ],
     },
     "lib/src/streamed_request.dart": {
       "uri": "package:http/src/streamed_request.dart",
@@ -1122,17 +1118,17 @@ final _data = {
       'fitness': {
         'magnitude': 28.0,
         'shortcoming': 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/streamed_request.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/streamed_request.dart`.',
-            'file': 'lib/src/streamed_request.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/streamed_request.dart`.',
+          'description':
+              'Run `dartfmt` to format `lib/src/streamed_request.dart`.',
+          'file': 'lib/src/streamed_request.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/streamed_response.dart": {
       "uri": "package:http/src/streamed_response.dart",
@@ -1142,17 +1138,17 @@ final _data = {
       'fitness': {
         'magnitude': 25.0,
         'shortcoming': 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/streamed_response.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/streamed_response.dart`.',
-            'file': 'lib/src/streamed_response.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/streamed_response.dart`.',
+          'description':
+              'Run `dartfmt` to format `lib/src/streamed_response.dart`.',
+          'file': 'lib/src/streamed_response.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/utils.dart": {
       "uri": "package:http/src/utils.dart",
@@ -1172,28 +1168,28 @@ final _data = {
       'fitness': {
         'magnitude': 96.0,
         'shortcoming': 2.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/utils.dart`.',
-            'description': 'Run `dartfmt` to format `lib/src/utils.dart`.',
-            'file': 'lib/src/utils.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/src/utils.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/src/utils.dart` gave the following hint:\n'
-                '\n'
-                'line: 43 col: 66  \n'
-                '\'LATIN1\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/src/utils.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/utils.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/utils.dart`.',
+          'file': 'lib/src/utils.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/src/utils.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/src/utils.dart` gave the following hint:\n'
+              '\n'
+              'line: 43 col: 66  \n'
+              '\'LATIN1\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/src/utils.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+      ],
     },
     "lib/testing.dart": {
       "uri": "package:http/testing.dart",

--- a/test/end2end/pub_server_data.dart
+++ b/test/end2end/pub_server_data.dart
@@ -346,89 +346,88 @@ final _data = {
       'fitness': {
         'magnitude': 360.0,
         'shortcoming': 7.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/shelf_pubserver.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/shelf_pubserver.dart`.',
-            'file': 'lib/shelf_pubserver.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/shelf_pubserver.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
-                '\n'
-                'line: 275 col: 24  \n'
-                '\'JSON\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/shelf_pubserver.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/shelf_pubserver.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
-                '\n'
-                'line: 275 col: 42  \n'
-                '\'UTF8\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/shelf_pubserver.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/shelf_pubserver.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
-                '\n'
-                'line: 455 col: 15  \n'
-                '\'JSON\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/shelf_pubserver.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/shelf_pubserver.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
-                '\n'
-                'line: 463 col: 15  \n'
-                '\'JSON\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/shelf_pubserver.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/shelf_pubserver.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
-                '\n'
-                'line: 471 col: 15  \n'
-                '\'JSON\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/shelf_pubserver.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-          {
-            'level': 'hint',
-            'title': 'Fix `lib/shelf_pubserver.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
-                '\n'
-                'line: 488 col: 17  \n'
-                '\'JSON\' is deprecated and shouldn\'t be used.\n'
-                '',
-            'file': 'lib/shelf_pubserver.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/shelf_pubserver.dart`.',
+          'description': 'Run `dartfmt` to format `lib/shelf_pubserver.dart`.',
+          'file': 'lib/shelf_pubserver.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/shelf_pubserver.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
+              '\n'
+              'line: 275 col: 24  \n'
+              '\'JSON\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/shelf_pubserver.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/shelf_pubserver.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
+              '\n'
+              'line: 275 col: 42  \n'
+              '\'UTF8\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/shelf_pubserver.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/shelf_pubserver.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
+              '\n'
+              'line: 455 col: 15  \n'
+              '\'JSON\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/shelf_pubserver.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/shelf_pubserver.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
+              '\n'
+              'line: 463 col: 15  \n'
+              '\'JSON\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/shelf_pubserver.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/shelf_pubserver.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
+              '\n'
+              'line: 471 col: 15  \n'
+              '\'JSON\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/shelf_pubserver.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+        {
+          'level': 'hint',
+          'title': 'Fix `lib/shelf_pubserver.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n'
+              '\n'
+              'line: 488 col: 17  \n'
+              '\'JSON\' is deprecated and shouldn\'t be used.\n'
+              '',
+          'file': 'lib/shelf_pubserver.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+      ],
     },
   },
   'platform': {

--- a/test/end2end/skiplist_data.dart
+++ b/test/end2end/skiplist_data.dart
@@ -153,112 +153,112 @@ final _data = {
       'fitness': {
         'magnitude': 185.0,
         'shortcoming': 185.0,
-        'suggestions': [
-          {
-            'level': 'error',
-            'title': 'Fix `lib/skiplist.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
-                '\n'
-                'line: 77 col: 3  \n'
-                'Invalid override. The type of \'SkipList.[]\' (\'(K) → V\') isn\'t a subtype of \'Map<K, V>.[]\' (\'(Object) → V\').\n'
-                '',
-            'file': 'lib/skiplist.dart',
-            'penalty': {'amount': 1, 'fraction': 2000}
-          },
-          {
-            'level': 'error',
-            'title': 'Fix `lib/skiplist.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
-                '\n'
-                'line: 77 col: 3  \n'
-                'Invalid override. The type of \'SkipList.[]\' (\'(K) → V\') isn\'t a subtype of \'MapMixin<K, V>.[]\' (\'(Object) → V\').\n'
-                '',
-            'file': 'lib/skiplist.dart',
-            'penalty': {'amount': 1, 'fraction': 2000}
-          },
-          {
-            'level': 'error',
-            'title': 'Fix `lib/skiplist.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
-                '\n'
-                'line: 91 col: 3  \n'
-                'Invalid override. The type of \'SkipList.containsKey\' (\'(K) → bool\') isn\'t a subtype of \'Map<K, V>.containsKey\' (\'(Object) → bool\').\n'
-                '',
-            'file': 'lib/skiplist.dart',
-            'penalty': {'amount': 1, 'fraction': 2000}
-          },
-          {
-            'level': 'error',
-            'title': 'Fix `lib/skiplist.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
-                '\n'
-                'line: 91 col: 3  \n'
-                'Invalid override. The type of \'SkipList.containsKey\' (\'(K) → bool\') isn\'t a subtype of \'MapMixin<K, V>.containsKey\' (\'(Object) → bool\').\n'
-                '',
-            'file': 'lib/skiplist.dart',
-            'penalty': {'amount': 1, 'fraction': 2000}
-          },
-          {
-            'level': 'error',
-            'title': 'Fix `lib/skiplist.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
-                '\n'
-                'line: 116 col: 3  \n'
-                'Invalid override. The type of \'SkipList.remove\' (\'(K) → V\') isn\'t a subtype of \'Map<K, V>.remove\' (\'(Object) → V\').\n'
-                '',
-            'file': 'lib/skiplist.dart',
-            'penalty': {'amount': 1, 'fraction': 2000}
-          },
-          {
-            'level': 'error',
-            'title': 'Fix `lib/skiplist.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
-                '\n'
-                'line: 116 col: 3  \n'
-                'Invalid override. The type of \'SkipList.remove\' (\'(K) → V\') isn\'t a subtype of \'MapMixin<K, V>.remove\' (\'(Object) → V\').\n'
-                '',
-            'file': 'lib/skiplist.dart',
-            'penalty': {'amount': 1, 'fraction': 2000}
-          },
-          {
-            'level': 'error',
-            'title': 'Fix `lib/skiplist.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
-                '\n'
-                'line: 165 col: 3  \n'
-                'Invalid override. The type of \'SkipList.containsValue\' (\'(V) → bool\') isn\'t a subtype of \'Map<K, V>.containsValue\' (\'(Object) → bool\').\n'
-                '',
-            'file': 'lib/skiplist.dart',
-            'penalty': {'amount': 1, 'fraction': 2000}
-          },
-          {
-            'level': 'error',
-            'title': 'Fix `lib/skiplist.dart`.',
-            'description':
-                'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
-                '\n'
-                'line: 165 col: 3  \n'
-                'Invalid override. The type of \'SkipList.containsValue\' (\'(V) → bool\') isn\'t a subtype of \'MapMixin<K, V>.containsValue\' (\'(Object) → bool\').\n'
-                '',
-            'file': 'lib/skiplist.dart',
-            'penalty': {'amount': 1, 'fraction': 2000}
-          },
-          {
-            'level': 'hint',
-            'title': 'Format `lib/skiplist.dart`.',
-            'description': 'Run `dartfmt` to format `lib/skiplist.dart`.',
-            'file': 'lib/skiplist.dart',
-            'penalty': {'amount': 1, 'fraction': 0}
-          },
-        ],
       },
+      'suggestions': [
+        {
+          'level': 'error',
+          'title': 'Fix `lib/skiplist.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
+              '\n'
+              'line: 77 col: 3  \n'
+              'Invalid override. The type of \'SkipList.[]\' (\'(K) → V\') isn\'t a subtype of \'Map<K, V>.[]\' (\'(Object) → V\').\n'
+              '',
+          'file': 'lib/skiplist.dart',
+          'penalty': {'amount': 1, 'fraction': 2000}
+        },
+        {
+          'level': 'error',
+          'title': 'Fix `lib/skiplist.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
+              '\n'
+              'line: 77 col: 3  \n'
+              'Invalid override. The type of \'SkipList.[]\' (\'(K) → V\') isn\'t a subtype of \'MapMixin<K, V>.[]\' (\'(Object) → V\').\n'
+              '',
+          'file': 'lib/skiplist.dart',
+          'penalty': {'amount': 1, 'fraction': 2000}
+        },
+        {
+          'level': 'error',
+          'title': 'Fix `lib/skiplist.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
+              '\n'
+              'line: 91 col: 3  \n'
+              'Invalid override. The type of \'SkipList.containsKey\' (\'(K) → bool\') isn\'t a subtype of \'Map<K, V>.containsKey\' (\'(Object) → bool\').\n'
+              '',
+          'file': 'lib/skiplist.dart',
+          'penalty': {'amount': 1, 'fraction': 2000}
+        },
+        {
+          'level': 'error',
+          'title': 'Fix `lib/skiplist.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
+              '\n'
+              'line: 91 col: 3  \n'
+              'Invalid override. The type of \'SkipList.containsKey\' (\'(K) → bool\') isn\'t a subtype of \'MapMixin<K, V>.containsKey\' (\'(Object) → bool\').\n'
+              '',
+          'file': 'lib/skiplist.dart',
+          'penalty': {'amount': 1, 'fraction': 2000}
+        },
+        {
+          'level': 'error',
+          'title': 'Fix `lib/skiplist.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
+              '\n'
+              'line: 116 col: 3  \n'
+              'Invalid override. The type of \'SkipList.remove\' (\'(K) → V\') isn\'t a subtype of \'Map<K, V>.remove\' (\'(Object) → V\').\n'
+              '',
+          'file': 'lib/skiplist.dart',
+          'penalty': {'amount': 1, 'fraction': 2000}
+        },
+        {
+          'level': 'error',
+          'title': 'Fix `lib/skiplist.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
+              '\n'
+              'line: 116 col: 3  \n'
+              'Invalid override. The type of \'SkipList.remove\' (\'(K) → V\') isn\'t a subtype of \'MapMixin<K, V>.remove\' (\'(Object) → V\').\n'
+              '',
+          'file': 'lib/skiplist.dart',
+          'penalty': {'amount': 1, 'fraction': 2000}
+        },
+        {
+          'level': 'error',
+          'title': 'Fix `lib/skiplist.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
+              '\n'
+              'line: 165 col: 3  \n'
+              'Invalid override. The type of \'SkipList.containsValue\' (\'(V) → bool\') isn\'t a subtype of \'Map<K, V>.containsValue\' (\'(Object) → bool\').\n'
+              '',
+          'file': 'lib/skiplist.dart',
+          'penalty': {'amount': 1, 'fraction': 2000}
+        },
+        {
+          'level': 'error',
+          'title': 'Fix `lib/skiplist.dart`.',
+          'description':
+              'Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n'
+              '\n'
+              'line: 165 col: 3  \n'
+              'Invalid override. The type of \'SkipList.containsValue\' (\'(V) → bool\') isn\'t a subtype of \'MapMixin<K, V>.containsValue\' (\'(Object) → bool\').\n'
+              '',
+          'file': 'lib/skiplist.dart',
+          'penalty': {'amount': 1, 'fraction': 2000}
+        },
+        {
+          'level': 'hint',
+          'title': 'Format `lib/skiplist.dart`.',
+          'description': 'Run `dartfmt` to format `lib/skiplist.dart`.',
+          'file': 'lib/skiplist.dart',
+          'penalty': {'amount': 1, 'fraction': 0}
+        },
+      ],
     },
   },
   'platform': {

--- a/test/end2end/stream_broken_data.dart
+++ b/test/end2end/stream_broken_data.dart
@@ -619,16 +619,16 @@ final _data = {
       "fitness": {
         "magnitude": 13.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/plugin.dart`.',
-            'description': 'Run `dartfmt` to format `lib/plugin.dart`.',
-            'file': 'lib/plugin.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/plugin.dart`.',
+          'description': 'Run `dartfmt` to format `lib/plugin.dart`.',
+          'file': 'lib/plugin.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/rspc.dart": {
       "uri": "package:stream/rspc.dart",
@@ -638,16 +638,16 @@ final _data = {
       "fitness": {
         "magnitude": 14.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/rspc.dart`.',
-            'description': 'Run `dartfmt` to format `lib/rspc.dart`.',
-            'file': 'lib/rspc.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/rspc.dart`.',
+          'description': 'Run `dartfmt` to format `lib/rspc.dart`.',
+          'file': 'lib/rspc.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/connect.dart": {
       "uri": "package:stream/src/connect.dart",
@@ -657,16 +657,16 @@ final _data = {
       "fitness": {
         "magnitude": 242.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/connect.dart`.',
-            'description': 'Run `dartfmt` to format `lib/src/connect.dart`.',
-            'file': 'lib/src/connect.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/connect.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/connect.dart`.',
+          'file': 'lib/src/connect.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/connect_impl.dart": {
       "uri": "package:stream/src/connect_impl.dart",
@@ -676,17 +676,16 @@ final _data = {
       "fitness": {
         "magnitude": 139.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/connect_impl.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/connect_impl.dart`.',
-            'file': 'lib/src/connect_impl.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/connect_impl.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/connect_impl.dart`.',
+          'file': 'lib/src/connect_impl.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/plugin/configurer.dart": {
       "uri": "package:stream/src/plugin/configurer.dart",
@@ -696,17 +695,17 @@ final _data = {
       "fitness": {
         "magnitude": 19.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/plugin/configurer.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/plugin/configurer.dart`.',
-            'file': 'lib/src/plugin/configurer.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/plugin/configurer.dart`.',
+          'description':
+              'Run `dartfmt` to format `lib/src/plugin/configurer.dart`.',
+          'file': 'lib/src/plugin/configurer.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/plugin/loader.dart": {
       "uri": "package:stream/src/plugin/loader.dart",
@@ -716,17 +715,17 @@ final _data = {
       "fitness": {
         "magnitude": 51.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/plugin/loader.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/plugin/loader.dart`.',
-            'file': 'lib/src/plugin/loader.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/plugin/loader.dart`.',
+          'description':
+              'Run `dartfmt` to format `lib/src/plugin/loader.dart`.',
+          'file': 'lib/src/plugin/loader.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/plugin/router.dart": {
       "uri": "package:stream/src/plugin/router.dart",
@@ -736,17 +735,17 @@ final _data = {
       "fitness": {
         "magnitude": 280.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/plugin/router.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/plugin/router.dart`.',
-            'file': 'lib/src/plugin/router.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/plugin/router.dart`.',
+          'description':
+              'Run `dartfmt` to format `lib/src/plugin/router.dart`.',
+          'file': 'lib/src/plugin/router.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/rsp_util.dart": {
       "uri": "package:stream/src/rsp_util.dart",
@@ -756,16 +755,16 @@ final _data = {
       "fitness": {
         "magnitude": 26.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/rsp_util.dart`.',
-            'description': 'Run `dartfmt` to format `lib/src/rsp_util.dart`.',
-            'file': 'lib/src/rsp_util.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/rsp_util.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/rsp_util.dart`.',
+          'file': 'lib/src/rsp_util.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/rspc/build.dart": {
       "uri": "package:stream/src/rspc/build.dart",
@@ -775,16 +774,16 @@ final _data = {
       "fitness": {
         "magnitude": 109.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/rspc/build.dart`.',
-            'description': 'Run `dartfmt` to format `lib/src/rspc/build.dart`.',
-            'file': 'lib/src/rspc/build.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/rspc/build.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/rspc/build.dart`.',
+          'file': 'lib/src/rspc/build.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/rspc/compiler.dart": {
       "uri": "package:stream/src/rspc/compiler.dart",
@@ -794,17 +793,17 @@ final _data = {
       "fitness": {
         "magnitude": 595.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/rspc/compiler.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/rspc/compiler.dart`.',
-            'file': 'lib/src/rspc/compiler.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/rspc/compiler.dart`.',
+          'description':
+              'Run `dartfmt` to format `lib/src/rspc/compiler.dart`.',
+          'file': 'lib/src/rspc/compiler.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/rspc/main.dart": {
       "uri": "package:stream/src/rspc/main.dart",
@@ -814,16 +813,16 @@ final _data = {
       "fitness": {
         "magnitude": 46.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/rspc/main.dart`.',
-            'description': 'Run `dartfmt` to format `lib/src/rspc/main.dart`.',
-            'file': 'lib/src/rspc/main.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/rspc/main.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/rspc/main.dart`.',
+          'file': 'lib/src/rspc/main.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/rspc/tag.dart": {
       "uri": "package:stream/src/rspc/tag.dart",
@@ -833,16 +832,16 @@ final _data = {
       "fitness": {
         "magnitude": 271.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/rspc/tag.dart`.',
-            'description': 'Run `dartfmt` to format `lib/src/rspc/tag.dart`.',
-            'file': 'lib/src/rspc/tag.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/rspc/tag.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/rspc/tag.dart`.',
+          'file': 'lib/src/rspc/tag.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/rspc/tag_util.dart": {
       "uri": "package:stream/src/rspc/tag_util.dart",
@@ -852,17 +851,17 @@ final _data = {
       "fitness": {
         "magnitude": 106.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/rspc/tag_util.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/rspc/tag_util.dart`.',
-            'file': 'lib/src/rspc/tag_util.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/rspc/tag_util.dart`.',
+          'description':
+              'Run `dartfmt` to format `lib/src/rspc/tag_util.dart`.',
+          'file': 'lib/src/rspc/tag_util.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/server.dart": {
       "uri": "package:stream/src/server.dart",
@@ -872,16 +871,16 @@ final _data = {
       "fitness": {
         "magnitude": 174.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/server.dart`.',
-            'description': 'Run `dartfmt` to format `lib/src/server.dart`.',
-            'file': 'lib/src/server.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/server.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/server.dart`.',
+          'file': 'lib/src/server.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/src/server_impl.dart": {
       "uri": "package:stream/src/server_impl.dart",
@@ -891,17 +890,16 @@ final _data = {
       "fitness": {
         "magnitude": 221.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/src/server_impl.dart`.',
-            'description':
-                'Run `dartfmt` to format `lib/src/server_impl.dart`.',
-            'file': 'lib/src/server_impl.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/src/server_impl.dart`.',
+          'description': 'Run `dartfmt` to format `lib/src/server_impl.dart`.',
+          'file': 'lib/src/server_impl.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
     },
     "lib/stream.dart": {
       "uri": "package:stream/stream.dart",
@@ -911,16 +909,16 @@ final _data = {
       "fitness": {
         "magnitude": 18.0,
         "shortcoming": 1.0,
-        'suggestions': [
-          {
-            'level': 'hint',
-            'title': 'Format `lib/stream.dart`.',
-            'description': 'Run `dartfmt` to format `lib/stream.dart`.',
-            'file': 'lib/stream.dart',
-            'penalty': {'amount': 1, 'fraction': 0},
-          },
-        ],
-      }
-    }
-  }
+      },
+      'suggestions': [
+        {
+          'level': 'hint',
+          'title': 'Format `lib/stream.dart`.',
+          'description': 'Run `dartfmt` to format `lib/stream.dart`.',
+          'file': 'lib/stream.dart',
+          'penalty': {'amount': 1, 'fraction': 0},
+        },
+      ],
+    },
+  },
 };

--- a/test/end2end_test.dart
+++ b/test/end2end_test.dart
@@ -40,7 +40,7 @@ void main() {
           data.name,
           version: data.version,
           options: new InspectOptions(
-            keepTransitiveLibs: true,
+            verbose: true,
             dartdocOutputDir: '$rootPath/dartdoc',
           ),
         );


### PR DESCRIPTION
#280 

At first I wanted to remove it completely, but it seems to provide some debug value of keeping it, putting it behind the new `verbose` option.

I'm also merging the `keepTransitiveLibs` option with the new `verbose` (can separate it if you'd prefer).