### PR TITLE
Bugfix: do not initialize dartdocSuccessful with a value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Upgrade CI to dev.54 and fix new deprecation warnings.
 
+* Bugfix: do not initialize `dartdocSuccessful` with a value.
+
 ## 0.11.0
 
 **Breaking changes:**

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -197,7 +197,7 @@ class PackageAnalyzer {
 
     Set<CodeProblem> analyzerItems;
 
-    var dartdocSuccessful = false;
+    bool dartdocSuccessful;
     if (pkgResolution != null && options.dartdocOutputDir != null) {
       for (var i = 0; i <= options.dartdocRetry; i++) {
         try {

--- a/test/end2end/stream_broken_data.dart
+++ b/test/end2end/stream_broken_data.dart
@@ -47,7 +47,7 @@ final _data = {
     "strongModeEnabled": false,
     "isExperimentalVersion": true,
     "isPreReleaseVersion": false,
-    "dartdocSuccessful": false,
+    "dartdocSuccessful": null,
     "errorCount": 0,
     "warningCount": 0,
     "hintCount": 16,
@@ -58,12 +58,6 @@ final _data = {
         'description':
             'Error(s) prevent platform classification:\n\nMake sure `dartfmt` runs.',
         'penalty': {'amount': 0, 'fraction': 2000}
-      },
-      {
-        'level': 'error',
-        'title': 'Running `dartdoc` failed.',
-        'description': 'Make sure `dartdoc` runs without any issues.',
-        'penalty': {'amount': 0, 'fraction': 1000},
       },
       {
         'level': 'warning',


### PR DESCRIPTION
It will get the false as default, and we are reporting unsuccessful dartdoc generation in the analysis, when there was no actual run of it.