### PR TITLE
Better expose platform conflict reasons.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * The SDK was effectively restricted to at least this version due to other
     dependencies.
 
+* Better expose platform conflict reasons.
+
 ## 0.11.3
 
 * Support changing part of the analysis result.

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -332,13 +332,6 @@ class PackageAnalyzer {
     if (pkgPlatformConflict != null) {
       platform = new DartPlatform.conflict(
           'Error(s) prevent platform classification:\n\n$pkgPlatformConflict');
-    } else {
-      final dfs = files.values.firstWhere(
-          (dfs) => dfs.isPublicApi && dfs.platform.hasConflict,
-          orElse: () => null);
-      if (dfs != null) {
-        platform = new DartPlatform.conflict(dfs.platform.reason);
-      }
     }
     platform ??= classifyPkgPlatform(pubspec, allTransitiveLibs);
 

--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -205,9 +205,12 @@ DartPlatform classifyPkgPlatform(
       libraries.keys.where((key) => libraries[key].hasConflict).toList();
   if (conflicts.isNotEmpty) {
     conflicts.sort();
-    var sample = conflicts.take(3).map((s) => '`$s`').join(', ');
+    var sample = conflicts.take(3).map((s) {
+      final components = libraries[s].components.map((s) => '`$s`').join(', ');
+      return '`$s` (components: $components)';
+    }).join(', ');
     if (conflicts.length > 3) {
-      sample = '$sample (and ${conflicts.length - 3} more).';
+      sample = '$sample and ${conflicts.length - 3} more.';
     }
     return new DartPlatform.conflict('Conflicting libraries: $sample.');
   }
@@ -232,9 +235,13 @@ DartPlatform classifyPkgPlatform(
       );
     } else {
       flutterConflicts.sort();
-      var sample = flutterConflicts.take(3).map((s) => '`$s`').join(', ');
+      var sample = flutterConflicts.take(3).map((s) {
+        final components =
+            libraries[s].components.map((s) => '`$s`').join(', ');
+        return '`$s` (components: $components)';
+      }).join(', ');
       if (flutterConflicts.length > 3) {
-        sample = '$sample (and ${flutterConflicts.length - 3} more).';
+        sample = '$sample and ${flutterConflicts.length - 3} more.';
       }
       return new DartPlatform.conflict(
           'References Flutter, but has conflicting libraries: $sample.');

--- a/test/platform_test.dart
+++ b/test/platform_test.dart
@@ -210,6 +210,17 @@ void main() {
   });
 
   group('Conflicting PkgPlatform', () {
+    test('Web package with isolate', () {
+      var sum = classifyPkgPlatform(emptyPubspec, {
+        'package:_example/lib.dart': ['dart:html', 'dart:isolate'],
+      });
+      expect(sum.worksEverywhere, isFalse);
+      expect(sum.worksAnywhere, isFalse);
+      expect(sum.components, null);
+      expect(sum.reason,
+          'Conflicting libraries: `package:_example/lib.dart` (components: `html`, `isolate`).');
+    });
+
     test('Flutter package with mirrors', () {
       var sum = classifyPkgPlatform(flutterPluginPubspec, {
         'package:_example/lib.dart': ['dart:mirrors'],
@@ -218,7 +229,7 @@ void main() {
       expect(sum.worksAnywhere, isFalse);
       expect(sum.components, null);
       expect(sum.reason,
-          'References Flutter, but has conflicting libraries: `package:_example/lib.dart`.');
+          'References Flutter, but has conflicting libraries: `package:_example/lib.dart` (components: `mirrors`).');
     });
   });
 }


### PR DESCRIPTION
https://github.com/dart-lang/pub-dartlang-dart/issues/1355

Removing early platform-conflict detection, relying on a more detailed report.