### PR TITLE
Fix 'null' text in platform conflict descriptions.

### DIFF
--- a/lib/src/fitness.dart
+++ b/lib/src/fitness.dart
@@ -65,7 +65,9 @@ Future<FitnessResult> calcFitness(
     if (components != null) {
       description += ' Detected components: $components.';
     }
-    description += ' ${platform.reason}';
+    if (platform.reason != null && platform.reason.isNotEmpty) {
+      description += ' ${platform.reason}';
+    }
     suggestions.add(new Suggestion.error(
       SuggestionCode.platformConflictInFile,
       'Fix platform conflict in `$dartFile`.',


### PR DESCRIPTION
The current `package:test` analysis has a "null" string in it, this fixes it.