### PR TITLE
Override platform classification when code quality is low.

### DIFF
--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -332,16 +332,21 @@ class PackageAnalyzer {
     }
     dartFileSuggestions.sort();
 
+    final pkgFitness = calcPkgFitness(files.values);
+
     DartPlatform platform;
     if (pkgPlatformConflict != null) {
       platform = new DartPlatform.conflict(
           'Error(s) prevent platform classification:\n\n$pkgPlatformConflict');
     }
     platform ??= classifyPkgPlatform(pubspec, allTransitiveLibs);
+    if (!platform.hasConflict && pkgFitness.healthScore < 0.33) {
+      platform = new DartPlatform.conflict(
+          'Low code quality prevents platform classification.');
+    }
 
     var licenses = await detectLicensesInDir(pkgDir);
     licenses = await updateLicenseUrls(pubspec.homepage, licenses);
-    final pkgFitness = calcPkgFitness(files.values);
 
     final maintenance = await detectMaintenance(
       pkgDir,

--- a/test/end2end/skiplist-0.1.0.json
+++ b/test/end2end/skiplist-0.1.0.json
@@ -19,13 +19,7 @@
     }
   },
   "platform": {
-    "components": [],
-    "uses": {
-      "flutter": "allowed",
-      "web": "allowed",
-      "other": "allowed"
-    },
-    "reason": "No platform restriction found in primary library `package:skiplist/skiplist.dart`."
+    "reason": "Low code quality prevents platform classification."
   },
   "licenses": [
     {
@@ -48,6 +42,16 @@
     "warningCount": 0,
     "hintCount": 1,
     "suggestions": [
+      {
+        "code": "platform.conflict.inPkg",
+        "level": "error",
+        "title": "Fix platform conflicts.",
+        "description": "Low code quality prevents platform classification.",
+        "penalty": {
+          "amount": 0,
+          "fraction": 2000
+        }
+      },
       {
         "code": "dartdoc.aborted",
         "level": "error",


### PR DESCRIPTION
It works for bignum the same way (referenced in https://github.com/dart-lang/pub-dartlang-dart/issues/1395)
