### PR TITLE
Don't run dartdoc in end2end tests.

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -665,7 +665,8 @@ class Maintenance extends Object with _$MaintenanceSerializerMixin {
   /// whether version is flagged `-beta`, `-alpha`, etc.
   final bool isPreReleaseVersion;
 
-  /// whether running dartdoc was successful (null if was not running)
+  /// whether running dartdoc was successful (null if it hasn't run yet)
+  @JsonKey(includeIfNull: false)
   final bool dartdocSuccessful;
 
   /// the number of errors encountered during analysis

--- a/lib/src/model.g.dart
+++ b/lib/src/model.g.dart
@@ -367,10 +367,6 @@ abstract class _$MaintenanceSerializerMixin {
       'strongModeEnabled': strongModeEnabled,
       'isExperimentalVersion': isExperimentalVersion,
       'isPreReleaseVersion': isPreReleaseVersion,
-      'dartdocSuccessful': dartdocSuccessful,
-      'errorCount': errorCount,
-      'warningCount': warningCount,
-      'hintCount': hintCount,
     };
 
     void writeNotNull(String key, dynamic value) {
@@ -379,6 +375,10 @@ abstract class _$MaintenanceSerializerMixin {
       }
     }
 
+    writeNotNull('dartdocSuccessful', dartdocSuccessful);
+    val['errorCount'] = errorCount;
+    val['warningCount'] = warningCount;
+    val['hintCount'] = hintCount;
     writeNotNull('suggestions', suggestions);
     return val;
   }

--- a/test/end2end/fs_shim-0.7.1.json
+++ b/test/end2end/fs_shim-0.7.1.json
@@ -72,7 +72,6 @@
     "strongModeEnabled": true,
     "isExperimentalVersion": true,
     "isPreReleaseVersion": false,
-    "dartdocSuccessful": true,
     "errorCount": 11,
     "warningCount": 0,
     "hintCount": 28,

--- a/test/end2end/http-0.11.3-13.json
+++ b/test/end2end/http-0.11.3-13.json
@@ -50,7 +50,6 @@
     "strongModeEnabled": true,
     "isExperimentalVersion": true,
     "isPreReleaseVersion": false,
-    "dartdocSuccessful": true,
     "errorCount": 0,
     "warningCount": 0,
     "hintCount": 38,

--- a/test/end2end/pub_server-0.1.1-3.json
+++ b/test/end2end/pub_server-0.1.1-3.json
@@ -55,7 +55,6 @@
     "strongModeEnabled": false,
     "isExperimentalVersion": true,
     "isPreReleaseVersion": false,
-    "dartdocSuccessful": true,
     "errorCount": 0,
     "warningCount": 0,
     "hintCount": 7,

--- a/test/end2end/skiplist-0.1.0.json
+++ b/test/end2end/skiplist-0.1.0.json
@@ -37,7 +37,6 @@
     "strongModeEnabled": false,
     "isExperimentalVersion": true,
     "isPreReleaseVersion": false,
-    "dartdocSuccessful": false,
     "errorCount": 8,
     "warningCount": 0,
     "hintCount": 1,
@@ -50,16 +49,6 @@
         "penalty": {
           "amount": 0,
           "fraction": 2000
-        }
-      },
-      {
-        "code": "dartdoc.aborted",
-        "level": "error",
-        "title": "Running `dartdoc` failed.",
-        "description": "Make sure `dartdoc` runs without any issues.",
-        "penalty": {
-          "amount": 0,
-          "fraction": 1000
         }
       },
       {

--- a/test/end2end/stream-0.7.2-2.json
+++ b/test/end2end/stream-0.7.2-2.json
@@ -40,7 +40,6 @@
     "strongModeEnabled": false,
     "isExperimentalVersion": true,
     "isPreReleaseVersion": false,
-    "dartdocSuccessful": null,
     "errorCount": 0,
     "warningCount": 0,
     "hintCount": 16,

--- a/test/end2end_test.dart
+++ b/test/end2end_test.dart
@@ -42,7 +42,6 @@ void main() {
           version: version,
           options: new InspectOptions(
             verbosity: Verbosity.verbose,
-            dartdocOutputDir: '$rootPath/dartdoc',
           ),
         );
 


### PR DESCRIPTION
As the pub site will do dartdoc coverage report and scoring outside of `pana`, there is no need to run the tests with `dartdoc`.

The flag and option should eventually be removed (in a future breaking release).