### PR TITLE
Platform classification: more exposed, less blocked.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 * Less verbose logging.
 
+* Updated platform classification:
+  * Library conflict rule is moved to the end of the evaluation.
+  * Top file-related suggestions are directly exposed.
+  * The bulk summary suggestion is more compact.
+
 ## 0.11.4
 
 * Export libraries used by pub site.

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -238,6 +238,15 @@ class Suggestion extends Object
     if (other.isError && !isError) return 1;
     if (isWarning && !other.isError && !other.isWarning) return -1;
     if (other.isWarning && !isError && !isWarning) return 1;
+
+    // special case: `bulk` should go to the end of its level
+    if (code == SuggestionCode.bulk && other.code != SuggestionCode.bulk) {
+      return 1;
+    }
+    if (code != SuggestionCode.bulk && other.code == SuggestionCode.bulk) {
+      return -1;
+    }
+
     if (penalty != null && other.penalty == null) return -1;
     if (penalty == null && other.penalty != null) return 1;
     if (penalty != null && other.penalty != null) {

--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -207,14 +207,6 @@ DartPlatform classifyPkgPlatform(
     return '`$s` (components: $components)';
   }
 
-  final conflicts =
-      libraries.keys.where((key) => libraries[key].hasConflict).toList();
-  if (conflicts.isNotEmpty) {
-    conflicts.sort();
-    final sample = buildSample(conflicts.map(formatConflictSample));
-    return new DartPlatform.conflict('Conflicting libraries: $sample.');
-  }
-
   final allComponentsSet = new Set<String>();
   libraries.values
       .map((p) => p.components)
@@ -264,12 +256,19 @@ DartPlatform classifyPkgPlatform(
   if (allComponentsSet.isEmpty) {
     return new DartPlatform.everywhere(
         'No platform restriction found in libraries.');
-  } else {
-    final componentsFound =
-        allComponentNames.map((name) => '`$name`').join(', ');
-    return new DartPlatform.fromComponents(allComponentNames,
-        reason: 'Platform components identified in package: $componentsFound.');
   }
+
+  final conflicts =
+      libraries.keys.where((key) => libraries[key].hasConflict).toList();
+  if (conflicts.isNotEmpty) {
+    conflicts.sort();
+    final sample = buildSample(conflicts.map(formatConflictSample));
+    return new DartPlatform.conflict('Conflicting libraries: $sample.');
+  }
+
+  final componentsFound = allComponentNames.map((name) => '`$name`').join(', ');
+  return new DartPlatform.fromComponents(allComponentNames,
+      reason: 'Platform components identified in package: $componentsFound.');
 }
 
 String _selectPrimaryLibrary(Pubspec pubspec, Set<String> libraryUris) {

--- a/test/end2end/fs_shim-0.7.1.json
+++ b/test/end2end/fs_shim-0.7.1.json
@@ -77,6 +77,28 @@
     "hintCount": 28,
     "suggestions": [
       {
+        "code": "dartanalyzer.warning",
+        "level": "error",
+        "title": "Fix `lib/src/idb/idb_file_system.dart`.",
+        "description": "Strong-mode analysis of `lib/src/idb/idb_file_system.dart` failed with the following error:\n\nline: 303 col: 49  \nThe argument type '(int) → Node' can't be assigned to the parameter type '(dynamic) → FutureOr<Node>'.\n",
+        "file": "lib/src/idb/idb_file_system.dart",
+        "penalty": {
+          "amount": 1,
+          "fraction": 2000
+        }
+      },
+      {
+        "code": "dartanalyzer.warning",
+        "level": "error",
+        "title": "Fix `lib/src/idb/idb_file_system_storage.dart`.",
+        "description": "Strong-mode analysis of `lib/src/idb/idb_file_system_storage.dart` failed with the following error:\n\nline: 101 col: 41  \nThe function '_nodeFromMap' has type '(Map<dynamic, dynamic>) → Object' that isn't of expected type '(dynamic) → FutureOr<dynamic>'. This means its parameter or return type does not match what is expected.\n",
+        "file": "lib/src/idb/idb_file_system_storage.dart",
+        "penalty": {
+          "amount": 1,
+          "fraction": 2000
+        }
+      },
+      {
         "code": "pubspec.dependencies.unconstrained",
         "level": "warning",
         "title": "Use constrained dependencies.",
@@ -90,7 +112,7 @@
         "code": "bulk",
         "level": "warning",
         "title": "Fix analysis and formatting issues.",
-        "description": "Analysis or formatting checks reported 11 errors 28 hints.\n\nStrong-mode analysis of `lib/src/idb/idb_file_system.dart` failed with the following error:\n\nline: 303 col: 49  \nThe argument type '(int) → Node' can't be assigned to the parameter type '(dynamic) → FutureOr<Node>'.\n\nStrong-mode analysis of `lib/src/idb/idb_file_system_storage.dart` failed with the following error:\n\nline: 101 col: 41  \nThe function '_nodeFromMap' has type '(Map<dynamic, dynamic>) → Object' that isn't of expected type '(dynamic) → FutureOr<dynamic>'. This means its parameter or return type does not match what is expected.\n\nSimilar analysis of the following files failed:\n\n- `lib/src/io/io_directory.dart` (error)\n- `lib/src/io/io_file_system.dart` (error)\n- `lib/src/io/io_file_system_entity.dart` (error)\n- `lib/src/io/io_link.dart` (error)\n- `lib/fs.dart` (hint)\n- `lib/src/common/fs_mixin.dart` (hint)\n- `lib/src/idb/idb_file.dart` (hint)\n- `lib/src/io/io_file.dart` (hint)\n- `lib/src/io/io_fs.dart` (hint)\n- `lib/utils/copy.dart` (hint)\n- `lib/utils/io/entity.dart` (hint)\n- `lib/utils/src/utils_impl.dart` (hint)\n",
+        "description": "Additional issues in the following files (4 errors, 8 hints):\n\n- `lib/src/idb/idb_file_system.dart` (error)\n- `lib/src/idb/idb_file_system_storage.dart` (error)\n- `lib/src/io/io_directory.dart` (error)\n- `lib/src/io/io_file_system.dart` (error)\n- `lib/src/io/io_file_system_entity.dart` (error)\n- `lib/src/io/io_link.dart` (error)\n- `lib/fs.dart` (hint)\n- `lib/src/common/fs_mixin.dart` (hint)\n- `lib/src/idb/idb_file.dart` (hint)\n- `lib/src/io/io_file.dart` (hint)\n- `lib/src/io/io_fs.dart` (hint)\n- `lib/utils/copy.dart` (hint)\n- `lib/utils/io/entity.dart` (hint)\n- `lib/utils/src/utils_impl.dart` (hint)\n",
         "penalty": {
           "amount": 578,
           "fraction": 0

--- a/test/end2end/fs_shim-0.7.1.json
+++ b/test/end2end/fs_shim-0.7.1.json
@@ -188,8 +188,7 @@
         "package": "sembast",
         "dependencyType": "transitive",
         "constraintType": "inherited",
-        "resolved": "1.8.0",
-        "available": "1.9.0-dev.1"
+        "resolved": "1.9.0"
       },
       {
         "package": "synchronized",

--- a/test/end2end/http-0.11.3-13.json
+++ b/test/end2end/http-0.11.3-13.json
@@ -55,16 +55,6 @@
     "hintCount": 38,
     "suggestions": [
       {
-        "code": "bulk",
-        "level": "hint",
-        "title": "Fix analysis and formatting issues.",
-        "description": "Analysis or formatting checks reported 38 hints.\n\nRun `dartfmt` to format `lib/browser_client.dart`.\n\nStrong-mode analysis of `lib/http.dart` gave the following hint:\n\nline: 112 col: 29  \n'UTF8' is deprecated and shouldn't be used.\n\nSimilar analysis of the following files failed:\n\n- `lib/src/base_client.dart` (hint)\n- `lib/src/base_request.dart` (hint)\n- `lib/src/base_response.dart` (hint)\n- `lib/src/boundary_characters.dart` (hint)\n- `lib/src/byte_stream.dart` (hint)\n- `lib/src/client.dart` (hint)\n- `lib/src/io_client.dart` (hint)\n- `lib/src/mock_client.dart` (hint)\n- `lib/src/multipart_file.dart` (hint)\n- `lib/src/multipart_request.dart` (hint)\n- `lib/src/request.dart` (hint)\n- `lib/src/response.dart` (hint)\n- `lib/src/streamed_request.dart` (hint)\n- `lib/src/streamed_response.dart` (hint)\n- `lib/src/utils.dart` (hint)\n",
-        "penalty": {
-          "amount": 38,
-          "fraction": 0
-        }
-      },
-      {
         "code": "pubspec.description.tooShort",
         "level": "hint",
         "title": "The description is too short.",
@@ -95,10 +85,42 @@
         }
       },
       {
+        "code": "dartfmt.warning",
+        "level": "hint",
+        "title": "Format `lib/browser_client.dart`.",
+        "description": "Run `dartfmt` to format `lib/browser_client.dart`.",
+        "file": "lib/browser_client.dart",
+        "penalty": {
+          "amount": 1,
+          "fraction": 0
+        }
+      },
+      {
+        "code": "dartanalyzer.warning",
+        "level": "hint",
+        "title": "Fix `lib/http.dart`.",
+        "description": "Strong-mode analysis of `lib/http.dart` gave the following hint:\n\nline: 112 col: 29  \n'UTF8' is deprecated and shouldn't be used.\n",
+        "file": "lib/http.dart",
+        "penalty": {
+          "amount": 1,
+          "fraction": 0
+        }
+      },
+      {
         "code": "analysisOptions.renameRequired",
         "level": "hint",
         "title": "Use `analysis_options.yaml`.",
         "description": "Rename old `.analysis_options` file to `analysis_options.yaml`."
+      },
+      {
+        "code": "bulk",
+        "level": "hint",
+        "title": "Fix analysis and formatting issues.",
+        "description": "Additional issues in the following files (15 hints):\n\n- `lib/browser_client.dart` (hint)\n- `lib/http.dart` (hint)\n- `lib/src/base_client.dart` (hint)\n- `lib/src/base_request.dart` (hint)\n- `lib/src/base_response.dart` (hint)\n- `lib/src/boundary_characters.dart` (hint)\n- `lib/src/byte_stream.dart` (hint)\n- `lib/src/client.dart` (hint)\n- `lib/src/io_client.dart` (hint)\n- `lib/src/mock_client.dart` (hint)\n- `lib/src/multipart_file.dart` (hint)\n- `lib/src/multipart_request.dart` (hint)\n- `lib/src/request.dart` (hint)\n- `lib/src/response.dart` (hint)\n- `lib/src/streamed_request.dart` (hint)\n- `lib/src/streamed_response.dart` (hint)\n- `lib/src/utils.dart` (hint)\n",
+        "penalty": {
+          "amount": 38,
+          "fraction": 0
+        }
       }
     ]
   },

--- a/test/end2end/pub_server-0.1.1-3.json
+++ b/test/end2end/pub_server-0.1.1-3.json
@@ -70,12 +70,13 @@
         }
       },
       {
-        "code": "bulk",
+        "code": "dartanalyzer.warning",
         "level": "hint",
-        "title": "Fix analysis and formatting issues.",
-        "description": "Analysis or formatting checks reported 7 hints.\n\nStrong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n\nline: 275 col: 24  \n'JSON' is deprecated and shouldn't be used.\n\n",
+        "title": "Fix `lib/shelf_pubserver.dart`.",
+        "description": "Strong-mode analysis of `lib/shelf_pubserver.dart` gave the following hint:\n\nline: 275 col: 24  \n'JSON' is deprecated and shouldn't be used.\n",
+        "file": "lib/shelf_pubserver.dart",
         "penalty": {
-          "amount": 7,
+          "amount": 1,
           "fraction": 0
         }
       },

--- a/test/end2end/skiplist-0.1.0.json
+++ b/test/end2end/skiplist-0.1.0.json
@@ -42,6 +42,17 @@
     "hintCount": 1,
     "suggestions": [
       {
+        "code": "dartanalyzer.warning",
+        "level": "error",
+        "title": "Fix `lib/skiplist.dart`.",
+        "description": "Strong-mode analysis of `lib/skiplist.dart` failed with the following error:\n\nline: 116 col: 3  \nInvalid override. The type of 'SkipList.remove' ('(K) → V') isn't a subtype of 'Map<K, V>.remove' ('(Object) → V').\n",
+        "file": "lib/skiplist.dart",
+        "penalty": {
+          "amount": 1,
+          "fraction": 2000
+        }
+      },
+      {
         "code": "platform.conflict.inPkg",
         "level": "error",
         "title": "Fix platform conflicts.",
@@ -49,16 +60,6 @@
         "penalty": {
           "amount": 0,
           "fraction": 2000
-        }
-      },
-      {
-        "code": "bulk",
-        "level": "warning",
-        "title": "Fix analysis and formatting issues.",
-        "description": "Analysis or formatting checks reported 8 errors 1 hint.\n\nStrong-mode analysis of `lib/skiplist.dart` failed with the following error:\n\nline: 116 col: 3  \nInvalid override. The type of 'SkipList.remove' ('(K) → V') isn't a subtype of 'Map<K, V>.remove' ('(Object) → V').\n\n",
-        "penalty": {
-          "amount": 401,
-          "fraction": 0
         }
       },
       {

--- a/test/end2end/stream-0.7.2-2.json
+++ b/test/end2end/stream-0.7.2-2.json
@@ -65,16 +65,6 @@
         }
       },
       {
-        "code": "bulk",
-        "level": "hint",
-        "title": "Fix analysis and formatting issues.",
-        "description": "Analysis or formatting checks reported 16 hints.\n\nRun `dartfmt` to format `lib/plugin.dart`.\n\nRun `dartfmt` to format `lib/rspc.dart`.\n\nSimilar analysis of the following files failed:\n\n- `lib/src/connect.dart` (hint)\n- `lib/src/connect_impl.dart` (hint)\n- `lib/src/plugin/configurer.dart` (hint)\n- `lib/src/plugin/loader.dart` (hint)\n- `lib/src/plugin/router.dart` (hint)\n- `lib/src/rsp_util.dart` (hint)\n- `lib/src/rspc/build.dart` (hint)\n- `lib/src/rspc/compiler.dart` (hint)\n- `lib/src/rspc/main.dart` (hint)\n- `lib/src/rspc/tag.dart` (hint)\n- `lib/src/rspc/tag_util.dart` (hint)\n- `lib/src/server.dart` (hint)\n- `lib/src/server_impl.dart` (hint)\n- `lib/stream.dart` (hint)\n",
-        "penalty": {
-          "amount": 16,
-          "fraction": 0
-        }
-      },
-      {
         "code": "packageVersion.preV1",
         "level": "hint",
         "title": "Package is pre-v1 release.",
@@ -85,12 +75,44 @@
         }
       },
       {
+        "code": "dartfmt.warning",
+        "level": "hint",
+        "title": "Format `lib/plugin.dart`.",
+        "description": "Run `dartfmt` to format `lib/plugin.dart`.",
+        "file": "lib/plugin.dart",
+        "penalty": {
+          "amount": 1,
+          "fraction": 0
+        }
+      },
+      {
+        "code": "dartfmt.warning",
+        "level": "hint",
+        "title": "Format `lib/rspc.dart`.",
+        "description": "Run `dartfmt` to format `lib/rspc.dart`.",
+        "file": "lib/rspc.dart",
+        "penalty": {
+          "amount": 1,
+          "fraction": 0
+        }
+      },
+      {
         "code": "example.missing",
         "level": "hint",
         "title": "Maintain an example.",
         "description": "None of the files in your `example/` directory matches a known example patterns. Common file name patterns include: `main.dart`, `example.dart` or you could also use `stream.dart`.",
         "penalty": {
           "amount": 1,
+          "fraction": 0
+        }
+      },
+      {
+        "code": "bulk",
+        "level": "hint",
+        "title": "Fix analysis and formatting issues.",
+        "description": "Additional issues in the following files (14 hints):\n\n- `lib/plugin.dart` (hint)\n- `lib/rspc.dart` (hint)\n- `lib/src/connect.dart` (hint)\n- `lib/src/connect_impl.dart` (hint)\n- `lib/src/plugin/configurer.dart` (hint)\n- `lib/src/plugin/loader.dart` (hint)\n- `lib/src/plugin/router.dart` (hint)\n- `lib/src/rsp_util.dart` (hint)\n- `lib/src/rspc/build.dart` (hint)\n- `lib/src/rspc/compiler.dart` (hint)\n- `lib/src/rspc/main.dart` (hint)\n- `lib/src/rspc/tag.dart` (hint)\n- `lib/src/rspc/tag_util.dart` (hint)\n- `lib/src/server.dart` (hint)\n- `lib/src/server_impl.dart` (hint)\n- `lib/stream.dart` (hint)\n",
+        "penalty": {
+          "amount": 16,
           "fraction": 0
         }
       }

--- a/test/maintenance_test.dart
+++ b/test/maintenance_test.dart
@@ -39,6 +39,12 @@ final _withIssuesJson = {
       'penalty': {'amount': 0, 'fraction': 1000},
     },
     {
+      'code': 'errorCode',
+      'level': 'error',
+      'title': 'error',
+      'description': 'error'
+    },
+    {
       'code': 'changelog.missing',
       'level': 'warning',
       'title': 'Maintain `CHANGELOG.md`.',
@@ -77,14 +83,6 @@ final _withIssuesJson = {
       'description':
           'Readme should inform others about your project, what it does, and how they can use it.',
       'penalty': {'amount': 0, 'fraction': 500}
-    },
-    {
-      'code': 'bulk',
-      'level': 'warning',
-      'title': 'Fix analysis and formatting issues.',
-      'description':
-          'Analysis or formatting checks reported 1 error 1 warning 1 hint.\n\nerror\n\n',
-      'penalty': {'amount': 61, 'fraction': 0},
     },
     {
       'code': 'packageVersion.preRelease',
@@ -152,7 +150,7 @@ void main() {
 
   group('getMaintenanceScore', () {
     test('with issues', () {
-      expect(getMaintenanceScore(_withIssues), closeTo(0.428, 0.001));
+      expect(getMaintenanceScore(_withIssues), closeTo(0.434, 0.001));
     });
 
     test('perfect', () {


### PR DESCRIPTION
Updated platform classification:
  * Library conflict rule is moved to the end of the evaluation.
  * Top file-related suggestions are directly exposed.
  * The bulk summary suggestion is more compact.

Handles https://github.com/dart-lang/pub-dartlang-dart/issues/1355 the following way:
- `package:test` will be classified as `flutter`, and `other`
- The library conflict will be visible in the suggestion list with heavy (20%) penalty.

With that, the overall score remains the same, but the package will have a valid platform list, and it will be clear why its maintenance score is penalized.