### PR TITLE
 Updated report on dartanalyzer suggestions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.6
+
+* Updated report on `dartanalyzer` suggestions.
+
 ## 0.11.5
 
 * Less verbose logging.

--- a/lib/src/messages.dart
+++ b/lib/src/messages.dart
@@ -62,3 +62,23 @@ String buildSample(Iterable<String> items) {
   }
   return sample;
 }
+
+String pluralizeCount(int count, String name) {
+  if (count <= 0) {
+    return null;
+  } else if (count == 1) {
+    return '$count $name';
+  } else {
+    return '$count ${name}s';
+  }
+}
+
+String formatIssueCounts(int errorCount, int warningCount, int hintCount) {
+  final reportParts = <String>[
+    pluralizeCount(errorCount, 'error'),
+    pluralizeCount(warningCount, 'warning'),
+    pluralizeCount(hintCount, 'hint'),
+  ];
+  reportParts.removeWhere((s) => s == null);
+  return reportParts.join(', ');
+}

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -868,6 +868,16 @@ class CodeProblem extends Object
     return 0;
   }
 
+  int severityCompareTo(CodeProblem other) {
+    if (isError && !other.isError) return -1;
+    if (!isError && other.isError) return 1;
+    if (isWarning && !other.isWarning) return -1;
+    if (!isWarning && other.isWarning) return 1;
+    if (isInfo && !other.isInfo) return -1;
+    if (!isInfo && other.isInfo) return 1;
+    return compareTo(other);
+  }
+
   @override
   int get hashCode => hashObjects(_values);
 

--- a/lib/src/version.g.dart
+++ b/lib/src/version.g.dart
@@ -10,4 +10,4 @@ part of pana.version;
 // PackageVersionGenerator
 // **************************************************************************
 
-final _$panaPkgVersionPubSemverVersion = new Version.parse("0.11.5");
+final _$panaPkgVersionPubSemverVersion = new Version.parse("0.11.6");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.11.5
+version: 0.11.6
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 

--- a/test/end2end/dartdoc-0.20.0.json
+++ b/test/end2end/dartdoc-0.20.0.json
@@ -1,6 +1,6 @@
 {
   "runtimeInfo": {
-    "panaVersion": "0.11.5-dev",
+    "panaVersion": "0.11.6",
     "sdkVersion": "2.0.0-dev.66.0"
   },
   "packageName": "dartdoc",
@@ -82,10 +82,10 @@
         "code": "dartanalyzer.warning",
         "level": "error",
         "title": "Fix `lib/src/model.dart`.",
-        "description": "Analysis of `lib/src/model.dart` failed with the following error:\n\nline: 4782 col: 21  \nThe class 'Canonicalization' can't be used as a mixin because it extends a class other than Object.\n",
+        "description": "Analysis of `lib/src/model.dart` failed with 1 error, 2 hints:\n\nline 4782 col 21: The class 'Canonicalization' can't be used as a mixin because it extends a class other than Object.\n\nline 1063 col 17: Always override `hashCode` if overriding `==`.\n\nline 2110 col 25: Invocation of Iterable<E>.contains with references of unrelated types.",
         "file": "lib/src/model.dart",
         "penalty": {
-          "amount": 1,
+          "amount": 805,
           "fraction": 2000
         }
       },
@@ -123,7 +123,7 @@
   },
   "fitness": {
     "magnitude": 7994.0,
-    "shortcoming": 804.8000000000001
+    "shortcoming": 805.0
   },
   "pkgResolution": {
     "dependencies": [
@@ -1229,6 +1229,15 @@
       "isFormatted": true,
       "codeProblems": [
         {
+          "severity": "ERROR",
+          "errorType": "COMPILE_TIME_ERROR",
+          "errorCode": "MIXIN_INHERITS_FROM_NOT_OBJECT",
+          "file": "lib/src/model.dart",
+          "line": 4782,
+          "col": 21,
+          "description": "The class 'Canonicalization' can't be used as a mixin because it extends a class other than Object."
+        },
+        {
           "severity": "INFO",
           "errorType": "LINT",
           "errorCode": "hash_and_equals",
@@ -1245,53 +1254,22 @@
           "line": 2110,
           "col": 25,
           "description": "Invocation of Iterable<E>.contains with references of unrelated types."
-        },
-        {
-          "severity": "ERROR",
-          "errorType": "COMPILE_TIME_ERROR",
-          "errorCode": "MIXIN_INHERITS_FROM_NOT_OBJECT",
-          "file": "lib/src/model.dart",
-          "line": 4782,
-          "col": 21,
-          "description": "The class 'Canonicalization' can't be used as a mixin because it extends a class other than Object."
         }
       ],
       "fitness": {
         "magnitude": 4014.0,
-        "shortcoming": 804.8000000000001
+        "shortcoming": 805.0
       },
       "suggestions": [
         {
           "code": "dartanalyzer.warning",
           "level": "error",
           "title": "Fix `lib/src/model.dart`.",
-          "description": "Analysis of `lib/src/model.dart` failed with the following error:\n\nline: 4782 col: 21  \nThe class 'Canonicalization' can't be used as a mixin because it extends a class other than Object.\n",
+          "description": "Analysis of `lib/src/model.dart` failed with 1 error, 2 hints:\n\nline 4782 col 21: The class 'Canonicalization' can't be used as a mixin because it extends a class other than Object.\n\nline 1063 col 17: Always override `hashCode` if overriding `==`.\n\nline 2110 col 25: Invocation of Iterable<E>.contains with references of unrelated types.",
           "file": "lib/src/model.dart",
           "penalty": {
-            "amount": 1,
+            "amount": 805,
             "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/model.dart`.",
-          "description": "Analysis of `lib/src/model.dart` gave the following hint:\n\nline: 1063 col: 17  \nAlways override `hashCode` if overriding `==`.\n",
-          "file": "lib/src/model.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/model.dart`.",
-          "description": "Analysis of `lib/src/model.dart` gave the following hint:\n\nline: 2110 col: 25  \nInvocation of Iterable<E>.contains with references of unrelated types.\n",
-          "file": "lib/src/model.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
           }
         }
       ]

--- a/test/end2end/fs_shim-0.7.1.json
+++ b/test/end2end/fs_shim-0.7.1.json
@@ -1,6 +1,6 @@
 {
   "runtimeInfo": {
-    "panaVersion": "0.11.5-dev",
+    "panaVersion": "0.11.6",
     "sdkVersion": "2.0.0-dev.66.0"
   },
   "packageName": "fs_shim",
@@ -74,28 +74,28 @@
     "isPreReleaseVersion": false,
     "errorCount": 11,
     "warningCount": 0,
-    "hintCount": 28,
+    "hintCount": 26,
     "suggestions": [
       {
         "code": "dartanalyzer.warning",
         "level": "error",
         "title": "Fix `lib/src/idb/idb_file_system.dart`.",
-        "description": "Analysis of `lib/src/idb/idb_file_system.dart` failed with the following error:\n\nline: 303 col: 49  \nThe argument type '(int) → Node' can't be assigned to the parameter type '(dynamic) → FutureOr<Node>'.\n",
+        "description": "Analysis of `lib/src/idb/idb_file_system.dart` failed with 3 errors:\n\nline 303 col 49: The argument type '(int) → Node' can't be assigned to the parameter type '(dynamic) → FutureOr<Node>'.\n\nline 571 col 54: The argument type '(int) → Null' can't be assigned to the parameter type '(dynamic) → FutureOr<dynamic>'.\n\nline 710 col 45: The function expression type '(int) → dynamic' isn't of type '(dynamic) → FutureOr<dynamic>'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s).",
         "file": "lib/src/idb/idb_file_system.dart",
         "penalty": {
-          "amount": 1,
-          "fraction": 2000
+          "amount": 348,
+          "fraction": 6000
         }
       },
       {
         "code": "dartanalyzer.warning",
         "level": "error",
         "title": "Fix `lib/src/idb/idb_file_system_storage.dart`.",
-        "description": "Analysis of `lib/src/idb/idb_file_system_storage.dart` failed with the following error:\n\nline: 101 col: 41  \nThe function '_nodeFromMap' has type '(Map<dynamic, dynamic>) → Object' that isn't of expected type '(dynamic) → FutureOr<dynamic>'. This means its parameter or return type does not match what is expected.\n",
+        "description": "Analysis of `lib/src/idb/idb_file_system_storage.dart` failed with 3 errors:\n\nline 101 col 41: The function '_nodeFromMap' has type '(Map<dynamic, dynamic>) → Object' that isn't of expected type '(dynamic) → FutureOr<dynamic>'. This means its parameter or return type does not match what is expected.\n\nline 104 col 42: The argument type '(int) → Future<dynamic>' can't be assigned to the parameter type '(dynamic) → FutureOr<dynamic>'.\n\nline 246 col 43: The argument type '(int) → Node' can't be assigned to the parameter type '(dynamic) → FutureOr<Node>'.",
         "file": "lib/src/idb/idb_file_system_storage.dart",
         "penalty": {
-          "amount": 1,
-          "fraction": 2000
+          "amount": 168,
+          "fraction": 6000
         }
       },
       {
@@ -112,7 +112,7 @@
         "code": "bulk",
         "level": "warning",
         "title": "Fix additional 12 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files (4 errors, 8 hints):\n\n- `lib/src/idb/idb_file_system.dart` (error)\n- `lib/src/idb/idb_file_system_storage.dart` (error)\n- `lib/src/io/io_directory.dart` (error)\n- `lib/src/io/io_file_system.dart` (error)\n- `lib/src/io/io_file_system_entity.dart` (error)\n- `lib/src/io/io_link.dart` (error)\n- `lib/fs.dart` (hint)\n- `lib/src/common/fs_mixin.dart` (hint)\n- `lib/src/idb/idb_file.dart` (hint)\n- `lib/src/io/io_file.dart` (hint)\n- `lib/src/io/io_fs.dart` (hint)\n- `lib/utils/copy.dart` (hint)\n- `lib/utils/io/entity.dart` (hint)\n- `lib/utils/src/utils_impl.dart` (hint)\n",
+        "description": "Additional issues in the following files:\n\n- `lib/src/io/io_directory.dart` (2 errors)\n- `lib/src/io/io_file_system.dart` (1 error)\n- `lib/src/io/io_file_system_entity.dart` (1 error)\n- `lib/src/io/io_link.dart` (1 error)\n- `lib/src/io/io_fs.dart` (14 hints)\n- `lib/fs.dart` (3 hints)\n- `lib/src/common/fs_mixin.dart` (3 hints)\n- `lib/src/io/io_file.dart` (3 hints)\n- `lib/src/idb/idb_file.dart` (2 hints)\n- `lib/utils/copy.dart` (Run `dartfmt` to format `lib/utils/copy.dart`.)\n- `lib/utils/io/entity.dart` (1 hint)\n- `lib/utils/src/utils_impl.dart` (Run `dartfmt` to format `lib/utils/src/utils_impl.dart`.)\n",
         "penalty": {
           "amount": 208,
           "fraction": 0
@@ -142,7 +142,7 @@
   },
   "fitness": {
     "magnitude": 2873.0,
-    "shortcoming": 597.6
+    "shortcoming": 598.0
   },
   "pkgResolution": {
     "dependencies": [
@@ -181,7 +181,7 @@
         "constraintType": "normal",
         "constraint": ">=1.4.0",
         "resolved": "1.5.0",
-        "available": "1.6.0-dev.1"
+        "available": "1.6.0-dev.2"
       },
       {
         "package": "js",
@@ -302,32 +302,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/fs.dart`.",
-          "description": "Analysis of `lib/fs.dart` gave the following hint:\n\nline: 179 col: 58  \n'UTF8' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/fs.dart` reported 3 hints:\n\nline 179 col 58: 'UTF8' is deprecated and shouldn't be used.\n\nline 229 col 26: 'UTF8' is deprecated and shouldn't be used.\n\nline 246 col 51: 'UTF8' is deprecated and shouldn't be used.",
           "file": "lib/fs.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/fs.dart`.",
-          "description": "Analysis of `lib/fs.dart` gave the following hint:\n\nline: 229 col: 26  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/fs.dart`.",
-          "description": "Analysis of `lib/fs.dart` gave the following hint:\n\nline: 246 col: 51  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/fs.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 3,
             "fraction": 0
           }
         }
@@ -606,32 +584,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/common/fs_mixin.dart`.",
-          "description": "Analysis of `lib/src/common/fs_mixin.dart` gave the following hint:\n\nline: 34 col: 58  \n'UTF8' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/common/fs_mixin.dart` reported 3 hints:\n\nline 34 col 58: 'UTF8' is deprecated and shouldn't be used.\n\nline 50 col 30: 'UTF8' is deprecated and shouldn't be used.\n\nline 74 col 51: 'UTF8' is deprecated and shouldn't be used.",
           "file": "lib/src/common/fs_mixin.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/common/fs_mixin.dart`.",
-          "description": "Analysis of `lib/src/common/fs_mixin.dart` gave the following hint:\n\nline: 50 col: 30  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/common/fs_mixin.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/common/fs_mixin.dart`.",
-          "description": "Analysis of `lib/src/common/fs_mixin.dart` gave the following hint:\n\nline: 74 col: 51  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/common/fs_mixin.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 3,
             "fraction": 0
           }
         }
@@ -710,21 +666,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/idb/idb_file.dart`.",
-          "description": "Analysis of `lib/src/idb/idb_file.dart` gave the following hint:\n\nline: 20 col: 68  \n'UTF8' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/idb/idb_file.dart` reported 2 hints:\n\nline 20 col 68: 'UTF8' is deprecated and shouldn't be used.\n\nline 48 col 30: 'UTF8' is deprecated and shouldn't be used.",
           "file": "lib/src/idb/idb_file.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/idb/idb_file.dart`.",
-          "description": "Analysis of `lib/src/idb/idb_file.dart` gave the following hint:\n\nline: 48 col: 30  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/idb/idb_file.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 2,
             "fraction": 0
           }
         }
@@ -782,33 +727,11 @@
           "code": "dartanalyzer.warning",
           "level": "error",
           "title": "Fix `lib/src/idb/idb_file_system.dart`.",
-          "description": "Analysis of `lib/src/idb/idb_file_system.dart` failed with the following error:\n\nline: 303 col: 49  \nThe argument type '(int) → Node' can't be assigned to the parameter type '(dynamic) → FutureOr<Node>'.\n",
+          "description": "Analysis of `lib/src/idb/idb_file_system.dart` failed with 3 errors:\n\nline 303 col 49: The argument type '(int) → Node' can't be assigned to the parameter type '(dynamic) → FutureOr<Node>'.\n\nline 571 col 54: The argument type '(int) → Null' can't be assigned to the parameter type '(dynamic) → FutureOr<dynamic>'.\n\nline 710 col 45: The function expression type '(int) → dynamic' isn't of type '(dynamic) → FutureOr<dynamic>'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s).",
           "file": "lib/src/idb/idb_file_system.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/src/idb/idb_file_system.dart`.",
-          "description": "Analysis of `lib/src/idb/idb_file_system.dart` failed with the following error:\n\nline: 571 col: 54  \nThe argument type '(int) → Null' can't be assigned to the parameter type '(dynamic) → FutureOr<dynamic>'.\n",
-          "file": "lib/src/idb/idb_file_system.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/src/idb/idb_file_system.dart`.",
-          "description": "Analysis of `lib/src/idb/idb_file_system.dart` failed with the following error:\n\nline: 710 col: 45  \nThe function expression type '(int) → dynamic' isn't of type '(dynamic) → FutureOr<dynamic>'. This means its parameter or return type does not match what is expected. Consider changing parameter type(s) or the returned type(s).\n",
-          "file": "lib/src/idb/idb_file_system.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
+            "amount": 348,
+            "fraction": 6000
           }
         }
       ]
@@ -875,33 +798,11 @@
           "code": "dartanalyzer.warning",
           "level": "error",
           "title": "Fix `lib/src/idb/idb_file_system_storage.dart`.",
-          "description": "Analysis of `lib/src/idb/idb_file_system_storage.dart` failed with the following error:\n\nline: 101 col: 41  \nThe function '_nodeFromMap' has type '(Map<dynamic, dynamic>) → Object' that isn't of expected type '(dynamic) → FutureOr<dynamic>'. This means its parameter or return type does not match what is expected.\n",
+          "description": "Analysis of `lib/src/idb/idb_file_system_storage.dart` failed with 3 errors:\n\nline 101 col 41: The function '_nodeFromMap' has type '(Map<dynamic, dynamic>) → Object' that isn't of expected type '(dynamic) → FutureOr<dynamic>'. This means its parameter or return type does not match what is expected.\n\nline 104 col 42: The argument type '(int) → Future<dynamic>' can't be assigned to the parameter type '(dynamic) → FutureOr<dynamic>'.\n\nline 246 col 43: The argument type '(int) → Node' can't be assigned to the parameter type '(dynamic) → FutureOr<Node>'.",
           "file": "lib/src/idb/idb_file_system_storage.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/src/idb/idb_file_system_storage.dart`.",
-          "description": "Analysis of `lib/src/idb/idb_file_system_storage.dart` failed with the following error:\n\nline: 104 col: 42  \nThe argument type '(int) → Future<dynamic>' can't be assigned to the parameter type '(dynamic) → FutureOr<dynamic>'.\n",
-          "file": "lib/src/idb/idb_file_system_storage.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/src/idb/idb_file_system_storage.dart`.",
-          "description": "Analysis of `lib/src/idb/idb_file_system_storage.dart` failed with the following error:\n\nline: 246 col: 43  \nThe argument type '(int) → Node' can't be assigned to the parameter type '(dynamic) → FutureOr<Node>'.\n",
-          "file": "lib/src/idb/idb_file_system_storage.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
+            "amount": 168,
+            "fraction": 6000
           }
         }
       ]
@@ -952,29 +853,18 @@
       ],
       "fitness": {
         "magnitude": 59.0,
-        "shortcoming": 23.6
+        "shortcoming": 24.0
       },
       "suggestions": [
         {
           "code": "dartanalyzer.warning",
           "level": "error",
           "title": "Fix `lib/src/io/io_directory.dart`.",
-          "description": "Analysis of `lib/src/io/io_directory.dart` failed with the following error:\n\nline: 39 col: 55  \nThe argument type '(Directory) → DirectoryImpl' can't be assigned to the parameter type '(dynamic) → FutureOr<DirectoryImpl>'.\n",
+          "description": "Analysis of `lib/src/io/io_directory.dart` failed with 2 errors:\n\nline 39 col 55: The argument type '(Directory) → DirectoryImpl' can't be assigned to the parameter type '(dynamic) → FutureOr<DirectoryImpl>'.\n\nline 43 col 13: The argument type '(FileSystemEntity) → DirectoryImpl' can't be assigned to the parameter type '(dynamic) → FutureOr<DirectoryImpl>'.",
           "file": "lib/src/io/io_directory.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/src/io/io_directory.dart`.",
-          "description": "Analysis of `lib/src/io/io_directory.dart` failed with the following error:\n\nline: 43 col: 13  \nThe argument type '(FileSystemEntity) → DirectoryImpl' can't be assigned to the parameter type '(dynamic) → FutureOr<DirectoryImpl>'.\n",
-          "file": "lib/src/io/io_directory.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
+            "amount": 24,
+            "fraction": 4000
           }
         }
       ]
@@ -1021,32 +911,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/io/io_file.dart`.",
-          "description": "Analysis of `lib/src/io/io_file.dart` gave the following hint:\n\nline: 35 col: 64  \n'UTF8' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/io/io_file.dart` reported 3 hints:\n\nline 35 col 64: 'UTF8' is deprecated and shouldn't be used.\n\nline 70 col 30: 'UTF8' is deprecated and shouldn't be used.\n\nline 81 col 51: 'UTF8' is deprecated and shouldn't be used.",
           "file": "lib/src/io/io_file.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_file.dart`.",
-          "description": "Analysis of `lib/src/io/io_file.dart` gave the following hint:\n\nline: 70 col: 30  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_file.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_file.dart`.",
-          "description": "Analysis of `lib/src/io/io_file.dart` gave the following hint:\n\nline: 81 col: 51  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_file.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 3,
             "fraction": 0
           }
         }
@@ -1086,10 +954,10 @@
           "code": "dartanalyzer.warning",
           "level": "error",
           "title": "Fix `lib/src/io/io_file_system.dart`.",
-          "description": "Analysis of `lib/src/io/io_file_system.dart` failed with the following error:\n\nline: 19 col: 11  \nThe argument type '(FileSystemEntityType) → FileSystemEntityType' can't be assigned to the parameter type '(dynamic) → FutureOr<FileSystemEntityType>'.\n",
+          "description": "Analysis of `lib/src/io/io_file_system.dart` failed with 1 error:\n\nline 19 col 11: The argument type '(FileSystemEntityType) → FileSystemEntityType' can't be assigned to the parameter type '(dynamic) → FutureOr<FileSystemEntityType>'.",
           "file": "lib/src/io/io_file_system.dart",
           "penalty": {
-            "amount": 1,
+            "amount": 10,
             "fraction": 2000
           }
         }
@@ -1119,10 +987,10 @@
           "code": "dartanalyzer.warning",
           "level": "error",
           "title": "Fix `lib/src/io/io_file_system_entity.dart`.",
-          "description": "Analysis of `lib/src/io/io_file_system_entity.dart` failed with the following error:\n\nline: 40 col: 13  \nThe argument type '(FileStat) → FileStatImpl' can't be assigned to the parameter type '(dynamic) → FutureOr<FileStat>'.\n",
+          "description": "Analysis of `lib/src/io/io_file_system_entity.dart` failed with 1 error:\n\nline 40 col 13: The argument type '(FileStat) → FileStatImpl' can't be assigned to the parameter type '(dynamic) → FutureOr<FileStat>'.",
           "file": "lib/src/io/io_file_system_entity.dart",
           "penalty": {
-            "amount": 1,
+            "amount": 10,
             "fraction": 2000
           }
         }
@@ -1279,153 +1147,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 20 col: 26  \n'WRITE' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/io/io_fs.dart` reported 14 hints, including:\n\nline 20 col 26: 'WRITE' is deprecated and shouldn't be used.\n\nline 22 col 26: 'READ' is deprecated and shouldn't be used.\n\nline 24 col 26: 'APPEND' is deprecated and shouldn't be used.\n\nline 32 col 22: 'WRITE' is deprecated and shouldn't be used.\n\nline 34 col 22: 'READ' is deprecated and shouldn't be used.",
           "file": "lib/src/io/io_fs.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 22 col: 26  \n'READ' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 24 col: 26  \n'APPEND' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 32 col: 22  \n'WRITE' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 34 col: 22  \n'READ' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 36 col: 22  \n'APPEND' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 62 col: 34  \n'FILE' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 64 col: 34  \n'DIRECTORY' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 66 col: 34  \n'LINK' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 68 col: 34  \n'NOT_FOUND' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 79 col: 38  \n'FILE' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 81 col: 38  \n'DIRECTORY' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 83 col: 38  \n'LINK' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/io/io_fs.dart`.",
-          "description": "Analysis of `lib/src/io/io_fs.dart` gave the following hint:\n\nline: 85 col: 38  \n'NOT_FOUND' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/io/io_fs.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 14,
             "fraction": 0
           }
         }
@@ -1455,10 +1180,10 @@
           "code": "dartanalyzer.warning",
           "level": "error",
           "title": "Fix `lib/src/io/io_link.dart`.",
-          "description": "Analysis of `lib/src/io/io_link.dart` failed with the following error:\n\nline: 28 col: 13  \nThe argument type '(FileSystemEntity) → LinkImpl' can't be assigned to the parameter type '(dynamic) → FutureOr<LinkImpl>'.\n",
+          "description": "Analysis of `lib/src/io/io_link.dart` failed with 1 error:\n\nline 28 col 13: The argument type '(FileSystemEntity) → LinkImpl' can't be assigned to the parameter type '(dynamic) → FutureOr<LinkImpl>'.",
           "file": "lib/src/io/io_link.dart",
           "penalty": {
-            "amount": 1,
+            "amount": 10,
             "fraction": 2000
           }
         }
@@ -1756,7 +1481,7 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/utils/io/entity.dart`.",
-          "description": "Analysis of `lib/utils/io/entity.dart` gave the following hint:\n\nline: 59 col: 28  \n'NOT_FOUND' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/utils/io/entity.dart` reported 1 hint:\n\nline 59 col 28: 'NOT_FOUND' is deprecated and shouldn't be used.",
           "file": "lib/utils/io/entity.dart",
           "penalty": {
             "amount": 1,

--- a/test/end2end/http-0.11.3-13.json
+++ b/test/end2end/http-0.11.3-13.json
@@ -1,6 +1,6 @@
 {
   "runtimeInfo": {
-    "panaVersion": "0.11.5-dev",
+    "panaVersion": "0.11.6",
     "sdkVersion": "2.0.0-dev.66.0"
   },
   "packageName": "http",
@@ -52,7 +52,7 @@
     "isPreReleaseVersion": false,
     "errorCount": 0,
     "warningCount": 0,
-    "hintCount": 38,
+    "hintCount": 21,
     "suggestions": [
       {
         "code": "pubspec.description.tooShort",
@@ -75,6 +75,17 @@
         }
       },
       {
+        "code": "dartanalyzer.warning",
+        "level": "hint",
+        "title": "Fix `lib/src/multipart_request.dart`.",
+        "description": "Analysis of `lib/src/multipart_request.dart` reported 5 hints:\n\nline 64 col 11: 'UTF8' is deprecated and shouldn't be used.\n\nline 65 col 11: 'UTF8' is deprecated and shouldn't be used.\n\nline 70 col 11: 'UTF8' is deprecated and shouldn't be used.\n\nline 93 col 22: 'UTF8' is deprecated and shouldn't be used.\n\nline 96 col 48: 'UTF8' is deprecated and shouldn't be used.",
+        "file": "lib/src/multipart_request.dart",
+        "penalty": {
+          "amount": 5,
+          "fraction": 0
+        }
+      },
+      {
         "code": "example.missing",
         "level": "hint",
         "title": "Maintain an example.",
@@ -85,24 +96,13 @@
         }
       },
       {
-        "code": "dartfmt.warning",
-        "level": "hint",
-        "title": "Format `lib/browser_client.dart`.",
-        "description": "Run `dartfmt` to format `lib/browser_client.dart`.",
-        "file": "lib/browser_client.dart",
-        "penalty": {
-          "amount": 1,
-          "fraction": 0
-        }
-      },
-      {
         "code": "dartanalyzer.warning",
         "level": "hint",
         "title": "Fix `lib/http.dart`.",
-        "description": "Analysis of `lib/http.dart` gave the following hint:\n\nline: 112 col: 29  \n'UTF8' is deprecated and shouldn't be used.\n",
+        "description": "Analysis of `lib/http.dart` reported 3 hints:\n\nline 64 col 29: 'UTF8' is deprecated and shouldn't be used.\n\nline 88 col 29: 'UTF8' is deprecated and shouldn't be used.\n\nline 112 col 29: 'UTF8' is deprecated and shouldn't be used.",
         "file": "lib/http.dart",
         "penalty": {
-          "amount": 1,
+          "amount": 3,
           "fraction": 0
         }
       },
@@ -116,7 +116,7 @@
         "code": "bulk",
         "level": "hint",
         "title": "Fix additional 15 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files (15 hints):\n\n- `lib/browser_client.dart` (hint)\n- `lib/http.dart` (hint)\n- `lib/src/base_client.dart` (hint)\n- `lib/src/base_request.dart` (hint)\n- `lib/src/base_response.dart` (hint)\n- `lib/src/boundary_characters.dart` (hint)\n- `lib/src/byte_stream.dart` (hint)\n- `lib/src/client.dart` (hint)\n- `lib/src/io_client.dart` (hint)\n- `lib/src/mock_client.dart` (hint)\n- `lib/src/multipart_file.dart` (hint)\n- `lib/src/multipart_request.dart` (hint)\n- `lib/src/request.dart` (hint)\n- `lib/src/response.dart` (hint)\n- `lib/src/streamed_request.dart` (hint)\n- `lib/src/streamed_response.dart` (hint)\n- `lib/src/utils.dart` (hint)\n",
+        "description": "Additional issues in the following files:\n\n- `lib/src/client.dart` (3 hints)\n- `lib/src/base_client.dart` (2 hints)\n- `lib/src/byte_stream.dart` (2 hints)\n- `lib/src/request.dart` (2 hints)\n- `lib/src/response.dart` (2 hints)\n- `lib/browser_client.dart` (Run `dartfmt` to format `lib/browser_client.dart`.)\n- `lib/src/base_request.dart` (Run `dartfmt` to format `lib/src/base_request.dart`.)\n- `lib/src/base_response.dart` (Run `dartfmt` to format `lib/src/base_response.dart`.)\n- `lib/src/boundary_characters.dart` (Run `dartfmt` to format `lib/src/boundary_characters.dart`.)\n- `lib/src/io_client.dart` (Run `dartfmt` to format `lib/src/io_client.dart`.)\n- `lib/src/mock_client.dart` (Run `dartfmt` to format `lib/src/mock_client.dart`.)\n- `lib/src/multipart_file.dart` (1 hint)\n- `lib/src/streamed_request.dart` (Run `dartfmt` to format `lib/src/streamed_request.dart`.)\n- `lib/src/streamed_response.dart` (Run `dartfmt` to format `lib/src/streamed_response.dart`.)\n- `lib/src/utils.dart` (1 hint)\n",
         "penalty": {
           "amount": 15,
           "fraction": 0
@@ -580,32 +580,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/http.dart`.",
-          "description": "Analysis of `lib/http.dart` gave the following hint:\n\nline: 112 col: 29  \n'UTF8' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/http.dart` reported 3 hints:\n\nline 64 col 29: 'UTF8' is deprecated and shouldn't be used.\n\nline 88 col 29: 'UTF8' is deprecated and shouldn't be used.\n\nline 112 col 29: 'UTF8' is deprecated and shouldn't be used.",
           "file": "lib/http.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/http.dart`.",
-          "description": "Analysis of `lib/http.dart` gave the following hint:\n\nline: 64 col: 29  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/http.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/http.dart`.",
-          "description": "Analysis of `lib/http.dart` gave the following hint:\n\nline: 88 col: 29  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/http.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 3,
             "fraction": 0
           }
         },
@@ -655,21 +633,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/base_client.dart`.",
-          "description": "Analysis of `lib/src/base_client.dart` gave the following hint:\n\nline: 163 col: 44  \n'typed' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/base_client.dart` reported 2 hints:\n\nline 163 col 44: 'typed' is deprecated and shouldn't be used.\n\nline 165 col 44: 'typed' is deprecated and shouldn't be used.",
           "file": "lib/src/base_client.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/base_client.dart`.",
-          "description": "Analysis of `lib/src/base_client.dart` gave the following hint:\n\nline: 165 col: 44  \n'typed' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/base_client.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 2,
             "fraction": 0
           }
         },
@@ -788,21 +755,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/byte_stream.dart`.",
-          "description": "Analysis of `lib/src/byte_stream.dart` gave the following hint:\n\nline: 31 col: 51  \n'UTF8' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/byte_stream.dart` reported 2 hints:\n\nline 31 col 51: 'UTF8' is deprecated and shouldn't be used.\n\nline 34 col 52: 'UTF8' is deprecated and shouldn't be used.",
           "file": "lib/src/byte_stream.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/byte_stream.dart`.",
-          "description": "Analysis of `lib/src/byte_stream.dart` gave the following hint:\n\nline: 34 col: 52  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/byte_stream.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 2,
             "fraction": 0
           }
         },
@@ -861,32 +817,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/client.dart`.",
-          "description": "Analysis of `lib/src/client.dart` gave the following hint:\n\nline: 101 col: 31  \n'UTF8' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/client.dart` reported 3 hints:\n\nline 59 col 31: 'UTF8' is deprecated and shouldn't be used.\n\nline 80 col 31: 'UTF8' is deprecated and shouldn't be used.\n\nline 101 col 31: 'UTF8' is deprecated and shouldn't be used.",
           "file": "lib/src/client.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/client.dart`.",
-          "description": "Analysis of `lib/src/client.dart` gave the following hint:\n\nline: 59 col: 31  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/client.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/client.dart`.",
-          "description": "Analysis of `lib/src/client.dart` gave the following hint:\n\nline: 80 col: 31  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/client.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 3,
             "fraction": 0
           }
         },
@@ -983,7 +917,7 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/multipart_file.dart`.",
-          "description": "Analysis of `lib/src/multipart_file.dart` gave the following hint:\n\nline: 73 col: 74  \n'UTF8' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/multipart_file.dart` reported 1 hint:\n\nline 73 col 74: 'UTF8' is deprecated and shouldn't be used.",
           "file": "lib/src/multipart_file.dart",
           "penalty": {
             "amount": 1,
@@ -1063,54 +997,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/multipart_request.dart`.",
-          "description": "Analysis of `lib/src/multipart_request.dart` gave the following hint:\n\nline: 64 col: 11  \n'UTF8' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/multipart_request.dart` reported 5 hints:\n\nline 64 col 11: 'UTF8' is deprecated and shouldn't be used.\n\nline 65 col 11: 'UTF8' is deprecated and shouldn't be used.\n\nline 70 col 11: 'UTF8' is deprecated and shouldn't be used.\n\nline 93 col 22: 'UTF8' is deprecated and shouldn't be used.\n\nline 96 col 48: 'UTF8' is deprecated and shouldn't be used.",
           "file": "lib/src/multipart_request.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/multipart_request.dart`.",
-          "description": "Analysis of `lib/src/multipart_request.dart` gave the following hint:\n\nline: 65 col: 11  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/multipart_request.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/multipart_request.dart`.",
-          "description": "Analysis of `lib/src/multipart_request.dart` gave the following hint:\n\nline: 70 col: 11  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/multipart_request.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/multipart_request.dart`.",
-          "description": "Analysis of `lib/src/multipart_request.dart` gave the following hint:\n\nline: 93 col: 22  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/multipart_request.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/multipart_request.dart`.",
-          "description": "Analysis of `lib/src/multipart_request.dart` gave the following hint:\n\nline: 96 col: 48  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/multipart_request.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 5,
             "fraction": 0
           }
         },
@@ -1160,21 +1050,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/request.dart`.",
-          "description": "Analysis of `lib/src/request.dart` gave the following hint:\n\nline: 133 col: 26  \n'UTF8' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/request.dart` reported 2 hints:\n\nline 39 col 42: 'UTF8' is deprecated and shouldn't be used.\n\nline 133 col 26: 'UTF8' is deprecated and shouldn't be used.",
           "file": "lib/src/request.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/request.dart`.",
-          "description": "Analysis of `lib/src/request.dart` gave the following hint:\n\nline: 39 col: 42  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/request.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 2,
             "fraction": 0
           }
         },
@@ -1224,21 +1103,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/response.dart`.",
-          "description": "Analysis of `lib/src/response.dart` gave the following hint:\n\nline: 24 col: 8  \n'LATIN1' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/response.dart` reported 2 hints:\n\nline 24 col 8: 'LATIN1' is deprecated and shouldn't be used.\n\nline 83 col 18: 'LATIN1' is deprecated and shouldn't be used.",
           "file": "lib/src/response.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/src/response.dart`.",
-          "description": "Analysis of `lib/src/response.dart` gave the following hint:\n\nline: 83 col: 18  \n'LATIN1' is deprecated and shouldn't be used.\n",
-          "file": "lib/src/response.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 2,
             "fraction": 0
           }
         },
@@ -1325,7 +1193,7 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/src/utils.dart`.",
-          "description": "Analysis of `lib/src/utils.dart` gave the following hint:\n\nline: 43 col: 66  \n'LATIN1' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/src/utils.dart` reported 1 hint:\n\nline 43 col 66: 'LATIN1' is deprecated and shouldn't be used.",
           "file": "lib/src/utils.dart",
           "penalty": {
             "amount": 1,

--- a/test/end2end/pub_server-0.1.1-3.json
+++ b/test/end2end/pub_server-0.1.1-3.json
@@ -1,6 +1,6 @@
 {
   "runtimeInfo": {
-    "panaVersion": "0.11.5-dev",
+    "panaVersion": "0.11.6",
     "sdkVersion": "2.0.0-dev.66.0"
   },
   "packageName": "pub_server",
@@ -57,7 +57,7 @@
     "isPreReleaseVersion": false,
     "errorCount": 0,
     "warningCount": 0,
-    "hintCount": 7,
+    "hintCount": 6,
     "suggestions": [
       {
         "code": "packageVersion.preV1",
@@ -73,10 +73,10 @@
         "code": "dartanalyzer.warning",
         "level": "hint",
         "title": "Fix `lib/shelf_pubserver.dart`.",
-        "description": "Analysis of `lib/shelf_pubserver.dart` gave the following hint:\n\nline: 275 col: 24  \n'JSON' is deprecated and shouldn't be used.\n",
+        "description": "Analysis of `lib/shelf_pubserver.dart` reported 6 hints, including:\n\nline 275 col 24: 'JSON' is deprecated and shouldn't be used.\n\nline 275 col 42: 'UTF8' is deprecated and shouldn't be used.\n\nline 455 col 15: 'JSON' is deprecated and shouldn't be used.\n\nline 463 col 15: 'JSON' is deprecated and shouldn't be used.\n\nline 471 col 15: 'JSON' is deprecated and shouldn't be used.",
         "file": "lib/shelf_pubserver.dart",
         "penalty": {
-          "amount": 1,
+          "amount": 6,
           "fraction": 0
         }
       },
@@ -175,7 +175,7 @@
         "constraintType": "normal",
         "constraint": ">=0.5.6 <0.7.0",
         "resolved": "0.6.8",
-        "available": "0.7.3+1"
+        "available": "0.7.3+2"
       },
       {
         "package": "source_span",
@@ -551,65 +551,10 @@
           "code": "dartanalyzer.warning",
           "level": "hint",
           "title": "Fix `lib/shelf_pubserver.dart`.",
-          "description": "Analysis of `lib/shelf_pubserver.dart` gave the following hint:\n\nline: 275 col: 24  \n'JSON' is deprecated and shouldn't be used.\n",
+          "description": "Analysis of `lib/shelf_pubserver.dart` reported 6 hints, including:\n\nline 275 col 24: 'JSON' is deprecated and shouldn't be used.\n\nline 275 col 42: 'UTF8' is deprecated and shouldn't be used.\n\nline 455 col 15: 'JSON' is deprecated and shouldn't be used.\n\nline 463 col 15: 'JSON' is deprecated and shouldn't be used.\n\nline 471 col 15: 'JSON' is deprecated and shouldn't be used.",
           "file": "lib/shelf_pubserver.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/shelf_pubserver.dart`.",
-          "description": "Analysis of `lib/shelf_pubserver.dart` gave the following hint:\n\nline: 275 col: 42  \n'UTF8' is deprecated and shouldn't be used.\n",
-          "file": "lib/shelf_pubserver.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/shelf_pubserver.dart`.",
-          "description": "Analysis of `lib/shelf_pubserver.dart` gave the following hint:\n\nline: 455 col: 15  \n'JSON' is deprecated and shouldn't be used.\n",
-          "file": "lib/shelf_pubserver.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/shelf_pubserver.dart`.",
-          "description": "Analysis of `lib/shelf_pubserver.dart` gave the following hint:\n\nline: 463 col: 15  \n'JSON' is deprecated and shouldn't be used.\n",
-          "file": "lib/shelf_pubserver.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/shelf_pubserver.dart`.",
-          "description": "Analysis of `lib/shelf_pubserver.dart` gave the following hint:\n\nline: 471 col: 15  \n'JSON' is deprecated and shouldn't be used.\n",
-          "file": "lib/shelf_pubserver.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 0
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "hint",
-          "title": "Fix `lib/shelf_pubserver.dart`.",
-          "description": "Analysis of `lib/shelf_pubserver.dart` gave the following hint:\n\nline: 488 col: 17  \n'JSON' is deprecated and shouldn't be used.\n",
-          "file": "lib/shelf_pubserver.dart",
-          "penalty": {
-            "amount": 1,
+            "amount": 6,
             "fraction": 0
           }
         },

--- a/test/end2end/skiplist-0.1.0.json
+++ b/test/end2end/skiplist-0.1.0.json
@@ -1,6 +1,6 @@
 {
   "runtimeInfo": {
-    "panaVersion": "0.11.5-dev",
+    "panaVersion": "0.11.6",
     "sdkVersion": "2.0.0-dev.66.0"
   },
   "packageName": "skiplist",
@@ -39,17 +39,17 @@
     "isPreReleaseVersion": false,
     "errorCount": 8,
     "warningCount": 0,
-    "hintCount": 1,
+    "hintCount": 0,
     "suggestions": [
       {
         "code": "dartanalyzer.warning",
         "level": "error",
         "title": "Fix `lib/skiplist.dart`.",
-        "description": "Analysis of `lib/skiplist.dart` failed with the following error:\n\nline: 116 col: 3  \nInvalid override. The type of 'SkipList.remove' ('(K) → V') isn't a subtype of 'Map<K, V>.remove' ('(Object) → V').\n",
+        "description": "Analysis of `lib/skiplist.dart` failed with 8 errors, including:\n\nline 77 col 3: Invalid override. The type of 'SkipList.[]' ('(K) → V') isn't a subtype of 'Map<K, V>.[]' ('(Object) → V').\n\nline 77 col 3: Invalid override. The type of 'SkipList.[]' ('(K) → V') isn't a subtype of 'MapMixin<K, V>.[]' ('(Object) → V').\n\nline 91 col 3: Invalid override. The type of 'SkipList.containsKey' ('(K) → bool') isn't a subtype of 'Map<K, V>.containsKey' ('(Object) → bool').\n\nline 91 col 3: Invalid override. The type of 'SkipList.containsKey' ('(K) → bool') isn't a subtype of 'MapMixin<K, V>.containsKey' ('(Object) → bool').\n\nline 116 col 3: Invalid override. The type of 'SkipList.remove' ('(K) → V') isn't a subtype of 'Map<K, V>.remove' ('(Object) → V').",
         "file": "lib/skiplist.dart",
         "penalty": {
-          "amount": 1,
-          "fraction": 2000
+          "amount": 296,
+          "fraction": 10000
         }
       },
       {
@@ -228,88 +228,11 @@
           "code": "dartanalyzer.warning",
           "level": "error",
           "title": "Fix `lib/skiplist.dart`.",
-          "description": "Analysis of `lib/skiplist.dart` failed with the following error:\n\nline: 116 col: 3  \nInvalid override. The type of 'SkipList.remove' ('(K) → V') isn't a subtype of 'Map<K, V>.remove' ('(Object) → V').\n",
+          "description": "Analysis of `lib/skiplist.dart` failed with 8 errors, including:\n\nline 77 col 3: Invalid override. The type of 'SkipList.[]' ('(K) → V') isn't a subtype of 'Map<K, V>.[]' ('(Object) → V').\n\nline 77 col 3: Invalid override. The type of 'SkipList.[]' ('(K) → V') isn't a subtype of 'MapMixin<K, V>.[]' ('(Object) → V').\n\nline 91 col 3: Invalid override. The type of 'SkipList.containsKey' ('(K) → bool') isn't a subtype of 'Map<K, V>.containsKey' ('(Object) → bool').\n\nline 91 col 3: Invalid override. The type of 'SkipList.containsKey' ('(K) → bool') isn't a subtype of 'MapMixin<K, V>.containsKey' ('(Object) → bool').\n\nline 116 col 3: Invalid override. The type of 'SkipList.remove' ('(K) → V') isn't a subtype of 'Map<K, V>.remove' ('(Object) → V').",
           "file": "lib/skiplist.dart",
           "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/skiplist.dart`.",
-          "description": "Analysis of `lib/skiplist.dart` failed with the following error:\n\nline: 116 col: 3  \nInvalid override. The type of 'SkipList.remove' ('(K) → V') isn't a subtype of 'MapMixin<K, V>.remove' ('(Object) → V').\n",
-          "file": "lib/skiplist.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/skiplist.dart`.",
-          "description": "Analysis of `lib/skiplist.dart` failed with the following error:\n\nline: 165 col: 3  \nInvalid override. The type of 'SkipList.containsValue' ('(V) → bool') isn't a subtype of 'Map<K, V>.containsValue' ('(Object) → bool').\n",
-          "file": "lib/skiplist.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/skiplist.dart`.",
-          "description": "Analysis of `lib/skiplist.dart` failed with the following error:\n\nline: 165 col: 3  \nInvalid override. The type of 'SkipList.containsValue' ('(V) → bool') isn't a subtype of 'MapMixin<K, V>.containsValue' ('(Object) → bool').\n",
-          "file": "lib/skiplist.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/skiplist.dart`.",
-          "description": "Analysis of `lib/skiplist.dart` failed with the following error:\n\nline: 77 col: 3  \nInvalid override. The type of 'SkipList.[]' ('(K) → V') isn't a subtype of 'Map<K, V>.[]' ('(Object) → V').\n",
-          "file": "lib/skiplist.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/skiplist.dart`.",
-          "description": "Analysis of `lib/skiplist.dart` failed with the following error:\n\nline: 77 col: 3  \nInvalid override. The type of 'SkipList.[]' ('(K) → V') isn't a subtype of 'MapMixin<K, V>.[]' ('(Object) → V').\n",
-          "file": "lib/skiplist.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/skiplist.dart`.",
-          "description": "Analysis of `lib/skiplist.dart` failed with the following error:\n\nline: 91 col: 3  \nInvalid override. The type of 'SkipList.containsKey' ('(K) → bool') isn't a subtype of 'Map<K, V>.containsKey' ('(Object) → bool').\n",
-          "file": "lib/skiplist.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
-          }
-        },
-        {
-          "code": "dartanalyzer.warning",
-          "level": "error",
-          "title": "Fix `lib/skiplist.dart`.",
-          "description": "Analysis of `lib/skiplist.dart` failed with the following error:\n\nline: 91 col: 3  \nInvalid override. The type of 'SkipList.containsKey' ('(K) → bool') isn't a subtype of 'MapMixin<K, V>.containsKey' ('(Object) → bool').\n",
-          "file": "lib/skiplist.dart",
-          "penalty": {
-            "amount": 1,
-            "fraction": 2000
+            "amount": 296,
+            "fraction": 10000
           }
         },
         {

--- a/test/end2end/stream-0.7.2-2.json
+++ b/test/end2end/stream-0.7.2-2.json
@@ -1,6 +1,6 @@
 {
   "runtimeInfo": {
-    "panaVersion": "0.11.5-dev",
+    "panaVersion": "0.11.6",
     "sdkVersion": "2.0.0-dev.66.0"
   },
   "packageName": "stream",
@@ -42,7 +42,7 @@
     "isPreReleaseVersion": false,
     "errorCount": 0,
     "warningCount": 0,
-    "hintCount": 16,
+    "hintCount": 0,
     "suggestions": [
       {
         "code": "platform.conflict.inPkg",
@@ -110,7 +110,7 @@
         "code": "bulk",
         "level": "hint",
         "title": "Fix additional 14 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files (14 hints):\n\n- `lib/plugin.dart` (hint)\n- `lib/rspc.dart` (hint)\n- `lib/src/connect.dart` (hint)\n- `lib/src/connect_impl.dart` (hint)\n- `lib/src/plugin/configurer.dart` (hint)\n- `lib/src/plugin/loader.dart` (hint)\n- `lib/src/plugin/router.dart` (hint)\n- `lib/src/rsp_util.dart` (hint)\n- `lib/src/rspc/build.dart` (hint)\n- `lib/src/rspc/compiler.dart` (hint)\n- `lib/src/rspc/main.dart` (hint)\n- `lib/src/rspc/tag.dart` (hint)\n- `lib/src/rspc/tag_util.dart` (hint)\n- `lib/src/server.dart` (hint)\n- `lib/src/server_impl.dart` (hint)\n- `lib/stream.dart` (hint)\n",
+        "description": "Additional issues in the following files:\n\n- `lib/src/connect.dart` (Run `dartfmt` to format `lib/src/connect.dart`.)\n- `lib/src/connect_impl.dart` (Run `dartfmt` to format `lib/src/connect_impl.dart`.)\n- `lib/src/plugin/configurer.dart` (Run `dartfmt` to format `lib/src/plugin/configurer.dart`.)\n- `lib/src/plugin/loader.dart` (Run `dartfmt` to format `lib/src/plugin/loader.dart`.)\n- `lib/src/plugin/router.dart` (Run `dartfmt` to format `lib/src/plugin/router.dart`.)\n- `lib/src/rsp_util.dart` (Run `dartfmt` to format `lib/src/rsp_util.dart`.)\n- `lib/src/rspc/build.dart` (Run `dartfmt` to format `lib/src/rspc/build.dart`.)\n- `lib/src/rspc/compiler.dart` (Run `dartfmt` to format `lib/src/rspc/compiler.dart`.)\n- `lib/src/rspc/main.dart` (Run `dartfmt` to format `lib/src/rspc/main.dart`.)\n- `lib/src/rspc/tag.dart` (Run `dartfmt` to format `lib/src/rspc/tag.dart`.)\n- `lib/src/rspc/tag_util.dart` (Run `dartfmt` to format `lib/src/rspc/tag_util.dart`.)\n- `lib/src/server.dart` (Run `dartfmt` to format `lib/src/server.dart`.)\n- `lib/src/server_impl.dart` (Run `dartfmt` to format `lib/src/server_impl.dart`.)\n- `lib/stream.dart` (Run `dartfmt` to format `lib/stream.dart`.)\n",
         "penalty": {
           "amount": 14,
           "fraction": 0

--- a/test/maintenance_test.dart
+++ b/test/maintenance_test.dart
@@ -22,7 +22,7 @@ final _withIssuesJson = {
   "dartdocSuccessful": false,
   "errorCount": 1,
   "warningCount": 1,
-  "hintCount": 1,
+  "hintCount": 0,
   "suggestions": [
     {
       'code': 'platform.conflict.inPkg',
@@ -138,6 +138,12 @@ void main() {
       final maintenance = await detectMaintenance(
         d.sandbox,
         new Pubspec.fromJson({'name': 'sandbox', 'version': '0.1.0-alpha'}),
+        <CodeProblem>[
+          new CodeProblem('ERROR', 'COMPILE_ERROR', 'COMPILE_ERROR_1',
+              'Unable to compile', 'lib/file.dart', 10, 12),
+          new CodeProblem('WARNING', 'COMPILE_WARNING', 'COMPILE_WARNING_1',
+              'Unable to compile', 'lib/file.dart', 16, 5),
+        ],
         suggestions,
         [new PkgDependency('foo', 'direct', 'empty', null, null, null, null)],
         pkgPlatform: new DartPlatform.conflict('conflict description'),


### PR DESCRIPTION
- `dartanalyzer` suggestions become one per file, with the summary issue count included
- `maintenance` needed to be adjusted to handle the now-reduced suggestions per file