### PR TITLE
Use flutter format instead of dartfmt for Flutter packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 * Removed `Penalty` and using the simpler to understand `score` in place of it.
 
+**Updates:**
+
+* Use `flutter format` for Flutter packages.
+
 ## 0.11.8
 
 * Support Dart 2 gold release.

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -126,7 +126,7 @@ class PackageAnalyzer {
     Set<String> unformattedFiles;
     try {
       unformattedFiles = new SplayTreeSet<String>.from(
-          await _toolEnv.filesNeedingFormat(pkgDir));
+          await _toolEnv.filesNeedingFormat(pkgDir, usesFlutter));
 
       assert(unformattedFiles.every((f) => dartFiles.contains(f)),
           'dartfmt should only return Dart files');

--- a/test/end2end/dartdoc-0.20.0.json
+++ b/test/end2end/dartdoc-0.20.0.json
@@ -59,7 +59,16 @@
     "analyzerErrorCount": 0,
     "analyzerWarningCount": 0,
     "analyzerHintCount": 0,
-    "platformConflictCount": 0
+    "platformConflictCount": 0,
+    "suggestions": [
+      {
+        "code": "dartfmt.warning",
+        "level": "hint",
+        "title": "Format `lib/src/model.dart`.",
+        "description": "Run `dartfmt` to format `lib/src/model.dart`.",
+        "file": "lib/src/model.dart"
+      }
+    ]
   },
   "maintenance": {
     "missingChangelog": false,
@@ -209,7 +218,7 @@
     "lib/src/model.dart": {
       "uri": "package:dartdoc/src/model.dart",
       "size": 199428,
-      "isFormatted": true,
+      "isFormatted": false,
       "codeProblems": null
     },
     "lib/src/model_utils.dart": {


### PR DESCRIPTION
- `flutter format` emits different output and doesn't communicate with exit codes
- kept the same structure of per-directory scanning
- fixed a small bug with the non-Flutter code path where an empty `bin` directory would have ignored the `lib` entirely.
- https://github.com/dart-lang/pub-dartlang-dart/issues/1484
