### PR TITLE
Track and expose health scoring for analyzer suggestions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.4
+
+* Documented how scoring works.
+
+* Track and expose health scoring for analyzer suggestions.
+
 ## 0.12.3
 
 * Increased `dartfmt` timeout to 5 minutes.

--- a/lib/src/health.dart
+++ b/lib/src/health.dart
@@ -4,6 +4,8 @@
 
 library pana.health;
 
+import 'dart:math' as math;
+
 import 'package:meta/meta.dart';
 
 import 'messages.dart' as messages;
@@ -100,9 +102,10 @@ Health calcHealth({
   });
   var remainingScore = 100.0;
   for (final s in analyzerSuggestions) {
-    final score = (100.0 * remainingScore * (1.0 - s.percent)).round() / 100.0;
-    remainingScore *= s.percent;
-    suggestions.add(s.suggestion.change(score: score));
+    var penalty = (100.0 * remainingScore * (1.0 - s.percent)).round() / 100.0;
+    penalty = math.min(penalty, remainingScore);
+    remainingScore = math.max(0.0, remainingScore - penalty);
+    suggestions.add(s.suggestion.change(score: penalty));
   }
 
   suggestions.sort();

--- a/lib/src/health.dart
+++ b/lib/src/health.dart
@@ -57,7 +57,7 @@ Health calcHealth({
     }
   }
 
-  final analyzerSuggestions = <_Suggestion>[];
+  final analyzerSuggestions = <_SuggestionWithPercent>[];
 
   final reportedFiles = analyzerItems.map((cp) => cp.file).toSet();
   for (final path in reportedFiles) {
@@ -89,7 +89,7 @@ Health calcHealth({
         'Analysis of `$path` $failedWith $issueCounts$including:$issueList',
         file: path,
       );
-      analyzerSuggestions.add(new _Suggestion(suggestion,
+      analyzerSuggestions.add(new _SuggestionWithPercent(suggestion,
           calculateBaseHealth(errorCount, warningCount, hintCount)));
     }
   }
@@ -99,7 +99,7 @@ Health calcHealth({
     return -a.percent.compareTo(b.percent);
   });
   var remainingScore = 100.0;
-  for (var s in analyzerSuggestions) {
+  for (final s in analyzerSuggestions) {
     final score = (100.0 * remainingScore * (1.0 - s.percent)).round() / 100.0;
     remainingScore *= s.percent;
     suggestions.add(s.suggestion.change(score: score));
@@ -182,9 +182,9 @@ List<Suggestion> _compact(
   return suggestions;
 }
 
-class _Suggestion {
+class _SuggestionWithPercent {
   final Suggestion suggestion;
   final double percent;
 
-  _Suggestion(this.suggestion, this.percent);
+  _SuggestionWithPercent(this.suggestion, this.percent);
 }

--- a/lib/src/health.dart
+++ b/lib/src/health.dart
@@ -57,6 +57,8 @@ Health calcHealth({
     }
   }
 
+  final analyzerSuggestions = <_Suggestion>[];
+
   final reportedFiles = analyzerItems.map((cp) => cp.file).toSet();
   for (final path in reportedFiles) {
     final fileAnalyzerItems =
@@ -80,14 +82,27 @@ Health calcHealth({
           .map((cp) => '\n\nline ${cp.line} col ${cp.col}: ${cp.description}')
           .join();
 
-      suggestions.add(new Suggestion(
+      final suggestion = new Suggestion(
         SuggestionCode.dartanalyzerWarning,
         maxLevel,
         'Fix `$path`.',
         'Analysis of `$path` $failedWith $issueCounts$including:$issueList',
         file: path,
-      ));
+      );
+      analyzerSuggestions.add(new _Suggestion(suggestion,
+          calculateBaseHealth(errorCount, warningCount, hintCount)));
     }
+  }
+  analyzerSuggestions.sort((a, b) {
+    final x = a.suggestion.compareTo(b.suggestion);
+    if (x != 0) return x;
+    return -a.percent.compareTo(b.percent);
+  });
+  var remainingScore = 100.0;
+  for (var s in analyzerSuggestions) {
+    final score = (100.0 * remainingScore * (1.0 - s.percent)).round() / 100.0;
+    remainingScore *= s.percent;
+    suggestions.add(s.suggestion.change(score: score));
   }
 
   suggestions.sort();
@@ -147,12 +162,17 @@ List<Suggestion> _compact(
           ? SuggestionLevel.error
           : (hasWarning ? SuggestionLevel.warning : SuggestionLevel.hint);
 
+      final score = restSuggestions
+          .map((s) => s.score)
+          .where((d) => d != null)
+          .fold<double>(0.0, (a, b) => a + b);
       suggestions.add(
         new Suggestion(
           SuggestionCode.bulk,
           level,
           'Fix additional ${restSuggestions.length} files with analysis or formatting issues.',
           sb.toString(),
+          score: score > 0.0 ? score : null,
         ),
       );
     }
@@ -160,4 +180,11 @@ List<Suggestion> _compact(
 
   suggestions.sort();
   return suggestions;
+}
+
+class _Suggestion {
+  final Suggestion suggestion;
+  final double percent;
+
+  _Suggestion(this.suggestion, this.percent);
 }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -288,9 +288,22 @@ class Suggestion extends Object
   @override
   String toString() => 'Sugestion: $level - $description';
 
-  Suggestion change({double score}) {
-    return new Suggestion(code, level, title, description,
-        file: file, score: score ?? this.score);
+  Suggestion change({
+    String code,
+    String level,
+    String title,
+    String description,
+    String file,
+    double score,
+  }) {
+    return new Suggestion(
+      code ?? this.code,
+      level ?? this.level,
+      title ?? this.title,
+      description ?? this.description,
+      file: file ?? this.file,
+      score: score ?? this.score,
+    );
   }
 }
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -16,7 +16,7 @@ import 'utils.dart' show toRelativePath;
 
 part 'model.g.dart';
 
-/// NOTE: In case this changes, update README.md
+/// NOTE: In case these change, update README.md
 const healthErrorMultiplier = 0.75;
 const healthWarningMultiplier = 0.95;
 const healthHintMultiplier = 0.995;
@@ -668,7 +668,7 @@ class Health extends Object with _$HealthSerializerMixin {
 
   /// Returns a health score between 0.0 and 1.0 (1.0 being the top score it can get).
   ///
-  /// NOTE: In case this changes, update README.md
+  /// NOTE: In case these change, update README.md
   double get healthScore {
     if (anyProcessFailed) {
       // can't reliably determine the score if we can't parse and analyze the sources
@@ -681,6 +681,9 @@ class Health extends Object with _$HealthSerializerMixin {
   }
 }
 
+/// Returns the part of the health score that is calculated from the number of
+/// `dartanalyzer` items. Other penalties will be deduced from this base score
+/// (e.g. platform conflict, dartdoc coverage).
 double calculateBaseHealth(
     int analyzerErrorCount, int analyzerWarningCount, int analyzerHintCount) {
   final score = math.pow(healthErrorMultiplier, analyzerErrorCount) *

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.12.3';
+const packageVersion = '0.12.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.12.3
+version: 0.12.4
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 

--- a/test/end2end/dartdoc-0.20.3.json
+++ b/test/end2end/dartdoc-0.20.3.json
@@ -81,14 +81,16 @@
         "level": "error",
         "title": "Fix `lib/src/model.dart`.",
         "description": "Analysis of `lib/src/model.dart` failed with 1 error, 4 hints:\n\nline 4855 col 21: The class 'Canonicalization' can't be used as a mixin because it extends a class other than Object.\n\nline 1064 col 17: Always override `hashCode` if overriding `==`.\n\nline 2118 col 25: Invocation of Iterable<E>.contains with references of unrelated types.\n\nline 5228 col 37: 'element' is deprecated and shouldn't be used.\n\nline 5229 col 25: 'element' is deprecated and shouldn't be used.",
-        "file": "lib/src/model.dart"
+        "file": "lib/src/model.dart",
+        "score": 26.49
       },
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
         "title": "Fix `lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart`.",
         "description": "Analysis of `lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart` reported 2 hints:\n\nline 274 col 12: Equality operator `==` invocation with references of unrelated types.\n\nline 274 col 23: Equality operator `==` invocation with references of unrelated types.",
-        "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart"
+        "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+        "score": 0.73
       }
     ]
   },

--- a/test/end2end/http-0.11.3-17.json
+++ b/test/end2end/http-0.11.3-17.json
@@ -51,6 +51,14 @@
     "platformConflictCount": 0,
     "suggestions": [
       {
+        "code": "dartanalyzer.warning",
+        "level": "hint",
+        "title": "Fix `lib/src/base_client.dart`.",
+        "description": "Analysis of `lib/src/base_client.dart` reported 2 hints:\n\nline 163 col 44: 'typed' is deprecated and shouldn't be used.\n\nline 165 col 44: 'typed' is deprecated and shouldn't be used.",
+        "file": "lib/src/base_client.dart",
+        "score": 1.0
+      },
+      {
         "code": "dartfmt.warning",
         "level": "hint",
         "title": "Format `lib/browser_client.dart`.",
@@ -63,13 +71,6 @@
         "title": "Format `lib/http.dart`.",
         "description": "Run `dartfmt` to format `lib/http.dart`.",
         "file": "lib/http.dart"
-      },
-      {
-        "code": "dartanalyzer.warning",
-        "level": "hint",
-        "title": "Fix `lib/src/base_client.dart`.",
-        "description": "Analysis of `lib/src/base_client.dart` reported 2 hints:\n\nline 163 col 44: 'typed' is deprecated and shouldn't be used.\n\nline 165 col 44: 'typed' is deprecated and shouldn't be used.",
-        "file": "lib/src/base_client.dart"
       },
       {
         "code": "bulk",

--- a/test/end2end/stream-2.0.1.json
+++ b/test/end2end/stream-2.0.1.json
@@ -56,6 +56,14 @@
     "platformConflictCount": 0,
     "suggestions": [
       {
+        "code": "dartanalyzer.warning",
+        "level": "hint",
+        "title": "Fix `lib/src/plugin/loader.dart`.",
+        "description": "Analysis of `lib/src/plugin/loader.dart` reported 1 hint:\n\nline 83 col 16: Always override `hashCode` if overriding `==`.",
+        "file": "lib/src/plugin/loader.dart",
+        "score": 0.5
+      },
+      {
         "code": "dartfmt.warning",
         "level": "hint",
         "title": "Format `lib/proxy.dart`.",
@@ -70,17 +78,10 @@
         "file": "lib/src/connect.dart"
       },
       {
-        "code": "dartfmt.warning",
-        "level": "hint",
-        "title": "Format `lib/src/connect_impl.dart`.",
-        "description": "Run `dartfmt` to format `lib/src/connect_impl.dart`.",
-        "file": "lib/src/connect_impl.dart"
-      },
-      {
         "code": "bulk",
         "level": "hint",
         "title": "Fix additional 11 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files:\n\n- `lib/src/plugin/loader.dart` (1 hint)\n- `lib/src/plugin/loader_impl.dart` (Run `dartfmt` to format `lib/src/plugin/loader_impl.dart`.)\n- `lib/src/plugin/router.dart` (Run `dartfmt` to format `lib/src/plugin/router.dart`.)\n- `lib/src/rsp_util.dart` (Run `dartfmt` to format `lib/src/rsp_util.dart`.)\n- `lib/src/rspc/build.dart` (Run `dartfmt` to format `lib/src/rspc/build.dart`.)\n- `lib/src/rspc/compiler.dart` (Run `dartfmt` to format `lib/src/rspc/compiler.dart`.)\n- `lib/src/rspc/main.dart` (Run `dartfmt` to format `lib/src/rspc/main.dart`.)\n- `lib/src/rspc/tag.dart` (Run `dartfmt` to format `lib/src/rspc/tag.dart`.)\n- `lib/src/rspc/tag_util.dart` (Run `dartfmt` to format `lib/src/rspc/tag_util.dart`.)\n- `lib/src/server.dart` (Run `dartfmt` to format `lib/src/server.dart`.)\n- `lib/src/server_impl.dart` (Run `dartfmt` to format `lib/src/server_impl.dart`.)\n"
+        "description": "Additional issues in the following files:\n\n- `lib/src/connect_impl.dart` (Run `dartfmt` to format `lib/src/connect_impl.dart`.)\n- `lib/src/plugin/loader_impl.dart` (Run `dartfmt` to format `lib/src/plugin/loader_impl.dart`.)\n- `lib/src/plugin/router.dart` (Run `dartfmt` to format `lib/src/plugin/router.dart`.)\n- `lib/src/rsp_util.dart` (Run `dartfmt` to format `lib/src/rsp_util.dart`.)\n- `lib/src/rspc/build.dart` (Run `dartfmt` to format `lib/src/rspc/build.dart`.)\n- `lib/src/rspc/compiler.dart` (Run `dartfmt` to format `lib/src/rspc/compiler.dart`.)\n- `lib/src/rspc/main.dart` (Run `dartfmt` to format `lib/src/rspc/main.dart`.)\n- `lib/src/rspc/tag.dart` (Run `dartfmt` to format `lib/src/rspc/tag.dart`.)\n- `lib/src/rspc/tag_util.dart` (Run `dartfmt` to format `lib/src/rspc/tag_util.dart`.)\n- `lib/src/server.dart` (Run `dartfmt` to format `lib/src/server.dart`.)\n- `lib/src/server_impl.dart` (Run `dartfmt` to format `lib/src/server_impl.dart`.)\n"
       }
     ]
   },


### PR DESCRIPTION
This makes the report on health scoring consistent with maintenance scores:
- analyzer issues are calculated on a per-file base, starting from the one with most penalties
- bulk issues have the aggregate numbers

We may also expose the exact rule, but it may not be necessary anymore.

@sortie: I've included the version bump, please publish after merging.