### PR TITLE
Estimate health score penalties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.4
+
+* Documented how scoring works.
+
+* Estimate health score penalties.
+
 ## 0.12.3
 
 * Increased `dartfmt` timeout to 5 minutes.

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -16,6 +16,11 @@ import 'utils.dart' show toRelativePath;
 
 part 'model.g.dart';
 
+/// NOTE: In case these change, update README.md
+const healthErrorMultiplier = 0.75;
+const healthWarningMultiplier = 0.95;
+const healthHintMultiplier = 0.995;
+
 @JsonSerializable()
 class Summary extends Object with _$SummarySerializerMixin {
   @JsonKey(nullable: false)
@@ -658,19 +663,28 @@ class Health extends Object with _$HealthSerializerMixin {
 
   /// Returns a health score between 0.0 and 1.0 (1.0 being the top score it can get).
   ///
-  /// NOTE: In case this changes, update README.md
+  /// NOTE: In case these change, update README.md
   double get healthScore {
     if (anyProcessFailed) {
       // can't reliably determine the score if we can't parse and analyze the sources
       return 0.0;
     }
-    double score = math.pow(0.75, analyzerErrorCount) *
-        math.pow(0.95, analyzerWarningCount) *
-        math.pow(0.995, analyzerHintCount);
-    // TODO: document why and how platform conflict influence the score
+    var score = calculateBaseHealth(
+        analyzerErrorCount, analyzerWarningCount, analyzerHintCount);
     score -= 0.25 * platformConflictCount;
     return math.max(0.0, score);
   }
+}
+
+/// Returns the part of the health score that is calculated from the number of
+/// `dartanalyzer` items. Other penalties will be deduced from this base score
+/// (e.g. platform conflict, dartdoc coverage).
+double calculateBaseHealth(
+    int analyzerErrorCount, int analyzerWarningCount, int analyzerHintCount) {
+  final score = math.pow(healthErrorMultiplier, analyzerErrorCount) *
+      math.pow(healthWarningMultiplier, analyzerWarningCount) *
+      math.pow(healthHintMultiplier, analyzerHintCount);
+  return score.toDouble();
 }
 
 /// Describes the maintenance status of the package.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.12.3';
+const packageVersion = '0.12.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.12.3
+version: 0.12.4
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 

--- a/test/end2end/dartdoc-0.20.3.json
+++ b/test/end2end/dartdoc-0.20.3.json
@@ -81,14 +81,16 @@
         "level": "error",
         "title": "Fix `lib/src/model.dart`.",
         "description": "Analysis of `lib/src/model.dart` failed with 1 error, 4 hints:\n\nline 4855 col 21: The class 'Canonicalization' can't be used as a mixin because it extends a class other than Object.\n\nline 1064 col 17: Always override `hashCode` if overriding `==`.\n\nline 2118 col 25: Invocation of Iterable<E>.contains with references of unrelated types.\n\nline 5228 col 37: 'element' is deprecated and shouldn't be used.\n\nline 5229 col 25: 'element' is deprecated and shouldn't be used.",
-        "file": "lib/src/model.dart"
+        "file": "lib/src/model.dart",
+        "score": 26.49
       },
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
         "title": "Fix `lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart`.",
         "description": "Analysis of `lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart` reported 2 hints:\n\nline 274 col 12: Equality operator `==` invocation with references of unrelated types.\n\nline 274 col 23: Equality operator `==` invocation with references of unrelated types.",
-        "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart"
+        "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+        "score": 1.0
       }
     ]
   },

--- a/test/end2end/http-0.11.3-17.json
+++ b/test/end2end/http-0.11.3-17.json
@@ -51,6 +51,14 @@
     "platformConflictCount": 0,
     "suggestions": [
       {
+        "code": "dartanalyzer.warning",
+        "level": "hint",
+        "title": "Fix `lib/src/base_client.dart`.",
+        "description": "Analysis of `lib/src/base_client.dart` reported 2 hints:\n\nline 163 col 44: 'typed' is deprecated and shouldn't be used.\n\nline 165 col 44: 'typed' is deprecated and shouldn't be used.",
+        "file": "lib/src/base_client.dart",
+        "score": 1.0
+      },
+      {
         "code": "dartfmt.warning",
         "level": "hint",
         "title": "Format `lib/browser_client.dart`.",
@@ -63,13 +71,6 @@
         "title": "Format `lib/http.dart`.",
         "description": "Run `dartfmt` to format `lib/http.dart`.",
         "file": "lib/http.dart"
-      },
-      {
-        "code": "dartanalyzer.warning",
-        "level": "hint",
-        "title": "Fix `lib/src/base_client.dart`.",
-        "description": "Analysis of `lib/src/base_client.dart` reported 2 hints:\n\nline 163 col 44: 'typed' is deprecated and shouldn't be used.\n\nline 165 col 44: 'typed' is deprecated and shouldn't be used.",
-        "file": "lib/src/base_client.dart"
       },
       {
         "code": "bulk",

--- a/test/end2end/stream-2.0.1.json
+++ b/test/end2end/stream-2.0.1.json
@@ -56,6 +56,14 @@
     "platformConflictCount": 0,
     "suggestions": [
       {
+        "code": "dartanalyzer.warning",
+        "level": "hint",
+        "title": "Fix `lib/src/plugin/loader.dart`.",
+        "description": "Analysis of `lib/src/plugin/loader.dart` reported 1 hint:\n\nline 83 col 16: Always override `hashCode` if overriding `==`.",
+        "file": "lib/src/plugin/loader.dart",
+        "score": 0.5
+      },
+      {
         "code": "dartfmt.warning",
         "level": "hint",
         "title": "Format `lib/proxy.dart`.",
@@ -70,17 +78,10 @@
         "file": "lib/src/connect.dart"
       },
       {
-        "code": "dartfmt.warning",
-        "level": "hint",
-        "title": "Format `lib/src/connect_impl.dart`.",
-        "description": "Run `dartfmt` to format `lib/src/connect_impl.dart`.",
-        "file": "lib/src/connect_impl.dart"
-      },
-      {
         "code": "bulk",
         "level": "hint",
         "title": "Fix additional 11 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files:\n\n- `lib/src/plugin/loader.dart` (1 hint)\n- `lib/src/plugin/loader_impl.dart` (Run `dartfmt` to format `lib/src/plugin/loader_impl.dart`.)\n- `lib/src/plugin/router.dart` (Run `dartfmt` to format `lib/src/plugin/router.dart`.)\n- `lib/src/rsp_util.dart` (Run `dartfmt` to format `lib/src/rsp_util.dart`.)\n- `lib/src/rspc/build.dart` (Run `dartfmt` to format `lib/src/rspc/build.dart`.)\n- `lib/src/rspc/compiler.dart` (Run `dartfmt` to format `lib/src/rspc/compiler.dart`.)\n- `lib/src/rspc/main.dart` (Run `dartfmt` to format `lib/src/rspc/main.dart`.)\n- `lib/src/rspc/tag.dart` (Run `dartfmt` to format `lib/src/rspc/tag.dart`.)\n- `lib/src/rspc/tag_util.dart` (Run `dartfmt` to format `lib/src/rspc/tag_util.dart`.)\n- `lib/src/server.dart` (Run `dartfmt` to format `lib/src/server.dart`.)\n- `lib/src/server_impl.dart` (Run `dartfmt` to format `lib/src/server_impl.dart`.)\n"
+        "description": "Additional issues in the following files:\n\n- `lib/src/connect_impl.dart` (Run `dartfmt` to format `lib/src/connect_impl.dart`.)\n- `lib/src/plugin/loader_impl.dart` (Run `dartfmt` to format `lib/src/plugin/loader_impl.dart`.)\n- `lib/src/plugin/router.dart` (Run `dartfmt` to format `lib/src/plugin/router.dart`.)\n- `lib/src/rsp_util.dart` (Run `dartfmt` to format `lib/src/rsp_util.dart`.)\n- `lib/src/rspc/build.dart` (Run `dartfmt` to format `lib/src/rspc/build.dart`.)\n- `lib/src/rspc/compiler.dart` (Run `dartfmt` to format `lib/src/rspc/compiler.dart`.)\n- `lib/src/rspc/main.dart` (Run `dartfmt` to format `lib/src/rspc/main.dart`.)\n- `lib/src/rspc/tag.dart` (Run `dartfmt` to format `lib/src/rspc/tag.dart`.)\n- `lib/src/rspc/tag_util.dart` (Run `dartfmt` to format `lib/src/rspc/tag_util.dart`.)\n- `lib/src/server.dart` (Run `dartfmt` to format `lib/src/server.dart`.)\n- `lib/src/server_impl.dart` (Run `dartfmt` to format `lib/src/server_impl.dart`.)\n"
       }
     ]
   },


### PR DESCRIPTION
An alternative to https://github.com/dart-lang/pana/pull/414
The tradeoff here is:
- the impact of the score is not adjusted (the calculation is simpler),
- the sum of the individual penalties is larger than the overall penalty,
- there is no dependency on the order of the suggestions, it is symmetrical, and does not change if 1 out of N issues get fixed.
