### PR TITLE
Penalty for description using too many non-ASCII characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Bulk processing and comparison.
 
+* Penalty for description using too many non-ASCII characters.
+
 ## 0.12.5
 
 * Increase the severity of missing SDK constraint.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ A package starts with `100` points, and the following detected issues have point
 - has platform conflicts (-20 points)
 - has unconstrained dependencies (-20 points)
 - `description` is too short (<60 characters) (-20 points)
+- `description` contains too many non-ASCII characters (-20 points)
 - `homepage` points to non-existent URL (-20 points)
 - `homepage` is not helpful (e.g. pointing to `http://localhost/`) (-10 points)
 - `documentation` points to non-existent URL (-10 points)

--- a/lib/src/maintenance.dart
+++ b/lib/src/maintenance.dart
@@ -367,6 +367,16 @@ Future<Maintenance> detectMaintenance(
         score: 10.0));
   }
 
+  // Checking the non-English characters in the description
+  if (nonAsciiRuneRatio(description) > 0.1) {
+    maintenanceSuggestions.add(new Suggestion.warning(
+        SuggestionCode.pubspecDescriptionAsciiOnly,
+        'The description contains too many non-ASCII characters.',
+        'The primary audience of this site will speak and use English, please '
+        'use fewer foreign characters in the description.',
+        score: 20.0));
+  }
+
   if (unconstrainedDeps != null && unconstrainedDeps.isNotEmpty) {
     final count = unconstrainedDeps.length;
     final pluralized = count == 1 ? '1 dependency' : '$count dependencies';

--- a/lib/src/maintenance.dart
+++ b/lib/src/maintenance.dart
@@ -372,8 +372,8 @@ Future<Maintenance> detectMaintenance(
     maintenanceSuggestions.add(new Suggestion.warning(
         SuggestionCode.pubspecDescriptionAsciiOnly,
         'The description contains too many non-ASCII characters.',
-        'The primary audience of this site will speak and use English, please '
-        'use fewer foreign characters in the description.',
+        "The site uses English as it's primary language. Please use a "
+        'description that primarily contains characters used when writing English.',
         score: 20.0));
   }
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -311,6 +311,8 @@ abstract class SuggestionCode {
   static const String pubspecDescriptionTooShort =
       'pubspec.description.tooShort';
   static const String pubspecDescriptionTooLong = 'pubspec.description.tooLong';
+  static const String pubspecDescriptionAsciiOnly =
+      'pubspec.description.asciiOnly';
   static const String pubspecDocumentationDoesNotExists =
       'pubspec.documentation.doesNotExists';
   static const String pubspecDocumentationIsNotHelpful =

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -246,3 +246,24 @@ Stream<ProcessSignal> getSignals() => Platform.isWindows
     ? ProcessSignal.sigint.watch()
     : StreamGroup.merge(
         [ProcessSignal.sigterm.watch(), ProcessSignal.sigint.watch()]);
+
+/// Returns the ratio of non-ASCII runes (Unicode characters) in a given text:
+/// (number of runes that are non-ASCII) / (total number of character runes).
+///
+/// The return value is between [0.0 - 1.0].
+double nonAsciiRuneRatio(String text) {
+  if (text == null || text.isEmpty) {
+    return 0.0;
+  }
+  // 160 - non-breaking space
+  final total = text.runes.where((r) => r > 32 && r != 160).length;
+  if (total == 0) {
+    return 0.0;
+  }
+  final nonAscii = text.runes.where((r) => r >= 256).length;
+  if (nonAscii > total) {
+    // should not happen
+    return 1.0;
+  }
+  return nonAscii / total;
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -255,15 +255,10 @@ double nonAsciiRuneRatio(String text) {
   if (text == null || text.isEmpty) {
     return 0.0;
   }
-  // 160 - non-breaking space
-  final total = text.runes.where((r) => r > 32 && r != 160).length;
-  if (total == 0) {
+  final totalPrintable = text.runes.where((r) => r > 32).length;
+  if (totalPrintable == 0) {
     return 0.0;
   }
-  final nonAscii = text.runes.where((r) => r >= 256).length;
-  if (nonAscii > total) {
-    // should not happen
-    return 1.0;
-  }
-  return nonAscii / total;
+  final nonAscii = text.runes.where((r) => r >= 128).length;
+  return nonAscii / totalPrintable;
 }

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -18,4 +18,21 @@ void main() {
         })),
         '{"a":2,"b":[{"d":4,"e":3}]}');
   });
+
+  group('runes', () {
+    test('empty', () {
+      expect(nonAsciiRuneRatio(null), 0.0);
+      expect(nonAsciiRuneRatio(''), 0.0);
+      expect(nonAsciiRuneRatio('  \t\n\r'), 0.0);
+    });
+
+    test('ascii text', () {
+      expect(nonAsciiRuneRatio('a'), 0.0);
+      expect(nonAsciiRuneRatio('a b c'), 0.0);
+    });
+
+    test('non-ascii text', () {
+      expect(nonAsciiRuneRatio('封装http业务接口'), 0.6);
+    });
+  });
 }


### PR DESCRIPTION
There is a small, but growing portion of packages that use non-English description (and readme) to describe what the package does (e.g. [work](https://pub.dartlang.org/packages/work) or [tencent_cos](https://pub.dartlang.org/packages/tencent_cos)). We shall encourage using English, and this is a good proxy for it.