### PR TITLE
Use --dry-run on executing flutter format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Penalty for description using too many non-ASCII characters.
 
+* Use `--dry-run` on executing flutter format.
+
 ## 0.12.5
 
 * Increase the severity of missing SDK constraint.


### PR DESCRIPTION
- the use of `--dry-run` changes the flutter output format, it is now the same as `dartfmt`
- however, the exit codes differ
- we still can't use `--dry-run` with machine-readable output (filed https://github.com/dart-lang/sdk/issues/34961 to track it)