### PR TITLE
Remove 'Bad input?' log message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Code cleanup.
 
+* Reduce the amount of warning+ level log messages when tools fail.
+
 ## 0.12.7
 
 * Reduce the amount of logging when `dartfmt` fails due to an issue in the package.

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -405,20 +405,13 @@ class PackageAnalyzer {
       return null;
     }
     final output = await _toolEnv.runAnalyzer(pkgPath, dirs, usesFlutter);
-    try {
-      final list = LineSplitter.split(output)
-          .map((s) => parseCodeProblem(s, projectDir: pkgPath))
-          .where((e) => e != null)
-          .toSet()
-          .toList();
-      list.sort();
-      return list;
-    } on ArgumentError {
-      // TODO: we should figure out a way to succeed here, right?
-      // Or at least do partial results and not blow up
-      log.severe('Bad input?\n\n$output');
-      rethrow;
-    }
+    final list = LineSplitter.split(output)
+        .map((s) => parseCodeProblem(s, projectDir: pkgPath))
+        .where((e) => e != null)
+        .toSet()
+        .toList();
+    list.sort();
+    return list;
   }
 
   Set<String> _reachableLibs(Map<String, List<String>> allTransitiveLibs) {


### PR DESCRIPTION
The log message usually happens when a package gets analyzed, but the sources are incompatible with the current tooling. In such cases an exception will be thrown anyway (which gets logged at a different place), and the output will be an empty string, which makes this particular logging statement useless.