### PR TITLE
Update analysis options: cancel_subscriptions and test_types_in_equals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 0.12.9
 
-* Analysis options used in code health scoring updated remove stale options and 
-  to include latest flutter-enabled lints.
+* Analysis options used in code health scoring updated:
+  * removed stale options,
+  * included latest Flutter-enabled lints,
+  * included latest stagehand-enabled lints.
 
 ## 0.12.8
 

--- a/lib/src/analysis_options.dart
+++ b/lib/src/analysis_options.dart
@@ -13,9 +13,11 @@ const String _analysisOptions = '''
 linter:
   rules:
     - camel_case_types
+    - cancel_subscriptions
     - hash_and_equals
     - iterable_contains_unrelated_type
     - list_remove_unrelated_type
+    - test_types_in_equals
     - unrelated_type_equality_checks
     - valid_regexps
 ''';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.12.8';
+const packageVersion = '0.12.9-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.12.8
+version: 0.12.9-dev
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 

--- a/test/analysis_options_test.dart
+++ b/test/analysis_options_test.dart
@@ -14,9 +14,11 @@ void main() {
       'linter': {
         'rules': [
           'camel_case_types',
+          'cancel_subscriptions',
           'hash_and_equals',
           'iterable_contains_unrelated_type',
           'list_remove_unrelated_type',
+          'test_types_in_equals',
           'unrelated_type_equality_checks',
           'valid_regexps',
         ]
@@ -77,9 +79,11 @@ analyzer:
       'linter': {
         'rules': [
           'camel_case_types',
+          'cancel_subscriptions',
           'hash_and_equals',
           'iterable_contains_unrelated_type',
           'list_remove_unrelated_type',
+          'test_types_in_equals',
           'unrelated_type_equality_checks',
           'valid_regexps',
         ],
@@ -102,9 +106,11 @@ analyzer:
       'linter': {
         'rules': [
           'camel_case_types',
+          'cancel_subscriptions',
           'hash_and_equals',
           'iterable_contains_unrelated_type',
           'list_remove_unrelated_type',
+          'test_types_in_equals',
           'unrelated_type_equality_checks',
           'valid_regexps',
         ],


### PR DESCRIPTION
This is a follow-up for #458. The two extra options are now part of the stagehand-generated default project template.