### PR TITLE
Delete temp directory in case download fails.

### DIFF
--- a/lib/src/download_utils.dart
+++ b/lib/src/download_utils.dart
@@ -43,6 +43,7 @@ Future<Directory> downloadPackage(String package, String version,
   } catch (e, st) {
     log.warning('Unable to download the archive of $package $version.', e, st);
   }
+  await temp.delete(recursive: true);
   return null;
 }
 


### PR DESCRIPTION
It is unlikely that this is related to https://github.com/dart-lang/pub-dartlang-dart/issues/1868, but making sure that we don't have any leftover from the download hanging there.