### PR TITLE
Lenient and strict parsing of pubspec.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Maintenance score penalty for:
   * non-https URLs
   * `git` dependencies
+  * strict parsing errors of `pubspec.yaml`
 
 ## 0.12.10
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Otherwise the score starts with `1.0`, and
 ### Maintenance score
 
 A package starts with `100` points, and the following detected issues have point reductions:
+- unable to parse `pubspec.yaml` with strict parsing (100 points)
 - uses `strong-mode: false` in `analysis_options.yaml` (-50 points)
 - SDK constraint is missing from `pubspec.yaml` (-50 points)
 - using `git` dependencies (-100 points, -50 if using commit hashes)

--- a/lib/src/maintenance.dart
+++ b/lib/src/maintenance.dart
@@ -10,6 +10,7 @@ import 'dart:math';
 
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+import 'package:pubspec_parse/pubspec_parse.dart' as pubspek;
 import 'package:yaml/yaml.dart' as yaml;
 
 import 'dartdoc_analyzer.dart';
@@ -129,6 +130,16 @@ Suggestion getAgeSuggestion(Duration age) {
   }
 
   return null;
+}
+
+/// Returns a suggestion for pubspec.yaml parse error.
+Suggestion pubspecParseError(error) {
+  return Suggestion.error(
+    SuggestionCode.pubspecParseError,
+    'Error while parsing `pubspec.yaml`.',
+    'Parsing throw an exception:\n\n```\n$error\n```.',
+    score: 100.0,
+  );
 }
 
 /// Creates [Maintenance] with suggestions.
@@ -445,6 +456,12 @@ Future<Maintenance> detectMaintenance(
         'The `pubspec.yaml` contains $pluralized without version constraints. '
         'Specify version ranges for the following dependencies: $names.',
         score: 20.0));
+  }
+
+  try {
+    pubspek.Pubspec.fromJson(pubspec.toJson(), lenient: false);
+  } catch (e) {
+    maintenanceSuggestions.add(pubspecParseError(e));
   }
 
   maintenanceSuggestions.sort();

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -123,11 +123,7 @@ class PackageAnalyzer {
       pubspec = Pubspec.parseFromDir(pkgDir);
     } catch (e, st) {
       log.info('Unable to read pubspec.yaml', e, st);
-      suggestions.add(Suggestion.error(
-        SuggestionCode.pubspecParseError,
-        'Error while parsing `pubspec.yaml`.',
-        'Parsing throw an exception:\n\n```\n$e\n```.',
-      ));
+      suggestions.add(pubspecParseError(e));
       return Summary(
         runtimeInfo: _toolEnv.runtimeInfo,
         packageName: null,

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -16,7 +16,7 @@ class Pubspec {
   Set<String> _dependentSdks;
 
   Pubspec(Map content)
-      : _inner = pubspek.Pubspec.fromJson(content),
+      : _inner = pubspek.Pubspec.fromJson(content, lenient: true),
         _content = content;
 
   factory Pubspec.parseFromDir(String packageDir) {

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -246,8 +246,13 @@ class ToolEnvironment {
   }
 
   Future<bool> detectFlutterUse(String packageDir) async {
-    final pubspec = Pubspec.parseFromDir(packageDir);
-    return pubspec.usesFlutter;
+    try {
+      final pubspec = Pubspec.parseFromDir(packageDir);
+      return pubspec.usesFlutter;
+    } catch (e, st) {
+      _logger.info('Unable to read pubspec.yaml', e, st);
+    }
+    return false;
   }
 
   Future<ProcessResult> runUpgrade(String packageDir, bool usesFlutter,

--- a/test/end2end/syntax-0.2.0.json
+++ b/test/end2end/syntax-0.2.0.json
@@ -12,7 +12,8 @@
       "code": "pubspec.parseError",
       "level": "error",
       "title": "Error while parsing `pubspec.yaml`.",
-      "description": "Parsing throw an exception:\n\n```\nError on line 5, column 1: Duplicate mapping key.\n  ╷\n5 │ description:  Syntax library includes lexer and parser.\n  │ ^^^^^^^^^^^\n  ╵\n```."
+      "description": "Parsing throw an exception:\n\n```\nError on line 5, column 1: Duplicate mapping key.\n  ╷\n5 │ description:  Syntax library includes lexer and parser.\n  │ ^^^^^^^^^^^\n  ╵\n```.",
+      "score": 100.0
     }
   ]
 }


### PR DESCRIPTION
- lenient parsing in Pubspec and extra exception guard in tool_env (e.g. to cover for deep parsing issues)
- 100% penalty for strict parsing errors

https://github.com/dart-lang/pub-dartlang-dart/issues/1960