### PR TITLE
Use package:pedantic as default package analysis ruleset.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Link to package layout conventions in example-related suggestions.
 
+* Use `package:pedantic` as default package analysis ruleset.
+
 ## 0.12.11
 
 * Maintenance score penalty for:

--- a/lib/src/analysis_options.dart
+++ b/lib/src/analysis_options.dart
@@ -7,19 +7,20 @@ import 'dart:convert';
 import 'package:yaml/yaml.dart' as yaml;
 
 const String _analysisOptions = '''
-# Source of linter options:
-# https://dart-lang.github.io/linter/lints/options/options.html
+# Defines a default set of lint rules enforced for
+# projects at Google. For details and rationale,
+# see https://github.com/dart-lang/pedantic#enabled-lints.
+include: package:pedantic/analysis_options.yaml
 
-linter:
-  rules:
-    - camel_case_types
-    - cancel_subscriptions
-    - hash_and_equals
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
-    - test_types_in_equals
-    - unrelated_type_equality_checks
-    - valid_regexps
+# For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
+# Uncomment to specify additional rules.
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
 ''';
 
 // Keep it updated with

--- a/lib/src/pkg_resolution.dart
+++ b/lib/src/pkg_resolution.dart
@@ -176,6 +176,14 @@ List<PkgDependency> _buildDeps(Pubspec pubspec,
     }
   });
 
+  // We are adding pedantic to the dev_dependencies before running `pub upgrade`.
+  // If the package does not reference it directly, we should remove it from the
+  // analysis.
+  if (!pubspec.dependencies.containsKey('pedantic') &&
+      !pubspec.devDependencies.containsKey('pedantic')) {
+    deps.removeWhere((p) => p.package == 'pedantic');
+  }
+
   deps.sort((a, b) => a.package.compareTo(b.package));
   return deps;
 }

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -436,6 +436,7 @@ class ToolEnvironment {
     final parsed = yamlToJson(original);
     parsed.remove('dev_dependencies');
     parsed.remove('dependency_overrides');
+    parsed['dev_dependencies'] = {'pedantic': '^1.0.0'};
 
     await pubspec.rename(backup.path);
     await pubspec.writeAsString(json.encode(parsed));

--- a/test/analysis_options_test.dart
+++ b/test/analysis_options_test.dart
@@ -11,18 +11,7 @@ import 'package:pana/src/analysis_options.dart';
 void main() {
   test('default options', () {
     expect(json.decode(customizeAnalysisOptions(null, false)), {
-      'linter': {
-        'rules': [
-          'camel_case_types',
-          'cancel_subscriptions',
-          'hash_and_equals',
-          'iterable_contains_unrelated_type',
-          'list_remove_unrelated_type',
-          'test_types_in_equals',
-          'unrelated_type_equality_checks',
-          'valid_regexps',
-        ]
-      },
+      'include': 'package:pedantic/analysis_options.yaml',
     });
   });
 
@@ -73,20 +62,9 @@ analyzer:
     todo: ignore
 ''';
     expect(json.decode(customizeAnalysisOptions(original, false)), {
+      'include': 'package:pedantic/analysis_options.yaml',
       'analyzer': {
         'errors': {},
-      },
-      'linter': {
-        'rules': [
-          'camel_case_types',
-          'cancel_subscriptions',
-          'hash_and_equals',
-          'iterable_contains_unrelated_type',
-          'list_remove_unrelated_type',
-          'test_types_in_equals',
-          'unrelated_type_equality_checks',
-          'valid_regexps',
-        ],
       },
     });
   });
@@ -98,22 +76,11 @@ analyzer:
     uri_has_not_been_generated: ignore
 ''';
     expect(json.decode(customizeAnalysisOptions(original, false)), {
+      'include': 'package:pedantic/analysis_options.yaml',
       'analyzer': {
         'errors': {
           'uri_has_not_been_generated': 'ignore',
         },
-      },
-      'linter': {
-        'rules': [
-          'camel_case_types',
-          'cancel_subscriptions',
-          'hash_and_equals',
-          'iterable_contains_unrelated_type',
-          'list_remove_unrelated_type',
-          'test_types_in_equals',
-          'unrelated_type_equality_checks',
-          'valid_regexps',
-        ],
       },
     });
   });

--- a/test/end2end/angular_components-0.10.0.json
+++ b/test/end2end/angular_components-0.10.0.json
@@ -63,7 +63,7 @@
     "resolveProcessFailed": false,
     "analyzerErrorCount": 0,
     "analyzerWarningCount": 0,
-    "analyzerHintCount": 102,
+    "analyzerHintCount": 92,
     "platformConflictCount": 0,
     "suggestions": [
       {
@@ -93,9 +93,9 @@
       {
         "code": "bulk",
         "level": "hint",
-        "title": "Fix additional 42 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files:\n\n- `lib/material_input/material_auto_suggest_input.dart` (5 hints)\n- `lib/material_input/material_input_multiline.dart` (5 hints)\n- `lib/material_stepper/material_step.dart` (5 hints)\n- `lib/material_input/material_input.dart` (4 hints)\n- `lib/model/menu/menu.dart` (4 hints)\n- `lib/src/model/selection/single_selection_model_impl.dart` (4 hints)\n- `lib/laminate/ruler/module.dart` (3 hints)\n- `lib/model/selection/selection_container.dart` (3 hints)\n- `lib/laminate/overlay/module.dart` (2 hints)\n- `lib/laminate/portal/portal.dart` (2 hints)\n- `lib/material_menu/menu_item_groups.dart` (2 hints)\n- `lib/model/date/time_zone_aware_clock.dart` (2 hints)\n- `lib/src/utils/angular/managed_zone/managed_zone.dart` (2 hints)\n- `lib/utils/angular/reference/reference.dart` (2 hints)\n- `lib/utils/comparators/comparators.dart` (2 hints)\n- `lib/dynamic_component/dynamic_component.dart` (1 hint)\n- `lib/material_datepicker/date_input.dart` (1 hint)\n- `lib/material_datepicker/date_range_editor.dart` (1 hint)\n- `lib/material_datepicker/material_calendar_picker.dart` (1 hint)\n- `lib/material_datepicker/material_date_grid_base.dart` (1 hint)\n- `lib/material_datepicker/module.dart` (1 hint)\n- `lib/material_input/base_material_input.dart` (1 hint)\n- `lib/material_menu/menu_popup_wrapper.dart` (1 hint)\n- `lib/material_popup/material_popup.dart` (1 hint)\n- `lib/material_select/dropdown_button.dart` (1 hint)\n- `lib/material_select/material_select.dart` (1 hint)\n- `lib/material_select/material_select_dropdown_item.dart` (1 hint)\n- `lib/material_stepper/material_stepper.dart` (1 hint)\n- `lib/mixins/highlight_assistant_mixin.dart` (1 hint)\n- `lib/model/date/date.dart` (1 hint)\n- `lib/model/menu/selectable_menu.dart` (1 hint)\n- `lib/src/laminate/popup/popup_hierarchy.dart` (1 hint)\n- `lib/src/material_datepicker/calendar/model.dart` (1 hint)\n- `lib/src/material_tree/material_tree_root.dart` (1 hint)\n- `lib/src/utils/angular/scroll_host/pan_controller_impl.dart` (1 hint)\n- `lib/src/utils/angular/scroll_host/position_sticky_controller.dart` (1 hint)\n- `lib/src/utils/angular/scroll_host/sticky_controller_impl.dart` (1 hint)\n- `lib/src/utils/async/simple_stream.dart` (1 hint)\n- `lib/utils/angular/managed_zone/interface.dart` (1 hint)\n- `lib/utils/angular/scroll_host/angular_2.dart` (1 hint)\n- `lib/utils/browser/dom_service/dom_service.dart` (1 hint)\n- `lib/utils/browser/events/events.dart` (1 hint)\n",
-        "score": 36.89
+        "title": "Fix additional 33 files with analysis or formatting issues.",
+        "description": "Additional issues in the following files:\n\n- `lib/material_input/material_auto_suggest_input.dart` (5 hints)\n- `lib/material_input/material_input_multiline.dart` (5 hints)\n- `lib/material_stepper/material_step.dart` (5 hints)\n- `lib/material_input/material_input.dart` (4 hints)\n- `lib/model/menu/menu.dart` (4 hints)\n- `lib/src/model/selection/single_selection_model_impl.dart` (4 hints)\n- `lib/laminate/ruler/module.dart` (3 hints)\n- `lib/model/selection/selection_container.dart` (3 hints)\n- `lib/laminate/overlay/module.dart` (2 hints)\n- `lib/laminate/portal/portal.dart` (2 hints)\n- `lib/material_menu/menu_item_groups.dart` (2 hints)\n- `lib/model/date/time_zone_aware_clock.dart` (2 hints)\n- `lib/src/utils/angular/managed_zone/managed_zone.dart` (2 hints)\n- `lib/utils/angular/reference/reference.dart` (2 hints)\n- `lib/dynamic_component/dynamic_component.dart` (1 hint)\n- `lib/material_datepicker/date_input.dart` (1 hint)\n- `lib/material_datepicker/date_range_editor.dart` (1 hint)\n- `lib/material_datepicker/module.dart` (1 hint)\n- `lib/material_input/base_material_input.dart` (1 hint)\n- `lib/material_menu/menu_popup_wrapper.dart` (1 hint)\n- `lib/material_popup/material_popup.dart` (1 hint)\n- `lib/material_select/dropdown_button.dart` (1 hint)\n- `lib/material_select/material_select.dart` (1 hint)\n- `lib/material_select/material_select_dropdown_item.dart` (1 hint)\n- `lib/material_stepper/material_stepper.dart` (1 hint)\n- `lib/mixins/highlight_assistant_mixin.dart` (1 hint)\n- `lib/model/menu/selectable_menu.dart` (1 hint)\n- `lib/src/laminate/popup/popup_hierarchy.dart` (1 hint)\n- `lib/src/material_tree/material_tree_root.dart` (1 hint)\n- `lib/utils/angular/managed_zone/interface.dart` (1 hint)\n- `lib/utils/angular/scroll_host/angular_2.dart` (1 hint)\n- `lib/utils/browser/dom_service/dom_service.dart` (1 hint)\n- `lib/utils/browser/events/events.dart` (1 hint)\n",
+        "score": 31.89
       }
     ]
   },
@@ -204,7 +204,7 @@
         "package": "built_value",
         "dependencyType": "transitive",
         "constraintType": "inherited",
-        "resolved": "6.2.0"
+        "resolved": "6.3.0"
       },
       {
         "package": "charcode",
@@ -388,7 +388,7 @@
         "constraintType": "normal",
         "constraint": "^0.10.2",
         "resolved": "0.10.8",
-        "available": "0.12.0"
+        "available": "0.13.0"
       },
       {
         "package": "pub_semver",
@@ -11139,17 +11139,7 @@
       "uri": "package:angular_components/material_datepicker/material_calendar_picker.dart",
       "size": 31550,
       "isFormatted": true,
-      "codeProblems": [
-        {
-          "severity": "INFO",
-          "errorType": "LINT",
-          "errorCode": "hash_and_equals",
-          "file": "lib/material_datepicker/material_calendar_picker.dart",
-          "line": 947,
-          "col": 17,
-          "description": "Always override `hashCode` if overriding `==`."
-        }
-      ],
+      "codeProblems": [],
       "directLibs": [
         "dart:async",
         "dart:html",
@@ -11407,17 +11397,7 @@
       "uri": "package:angular_components/material_datepicker/material_date_grid_base.dart",
       "size": 10402,
       "isFormatted": true,
-      "codeProblems": [
-        {
-          "severity": "INFO",
-          "errorType": "LINT",
-          "errorCode": "cancel_subscriptions",
-          "file": "lib/material_datepicker/material_date_grid_base.dart",
-          "line": 125,
-          "col": 22,
-          "description": "Cancel instances of dart.async.StreamSubscription."
-        }
-      ],
+      "codeProblems": [],
       "directLibs": [
         "dart:async",
         "dart:html",
@@ -31429,17 +31409,7 @@
       "uri": "package:angular_components/model/date/date.dart",
       "size": 9786,
       "isFormatted": true,
-      "codeProblems": [
-        {
-          "severity": "INFO",
-          "errorType": "LINT",
-          "errorCode": "hash_and_equals",
-          "file": "lib/model/date/date.dart",
-          "line": 105,
-          "col": 11,
-          "description": "Always override `hashCode` if overriding `==`."
-        }
-      ],
+      "codeProblems": [],
       "directLibs": [
         "dart:async",
         "package:angular_components/model/observable/observable.dart",
@@ -34413,17 +34383,7 @@
       "uri": "package:angular_components/src/material_datepicker/calendar/model.dart",
       "size": 13766,
       "isFormatted": true,
-      "codeProblems": [
-        {
-          "severity": "INFO",
-          "errorType": "LINT",
-          "errorCode": "hash_and_equals",
-          "file": "lib/src/material_datepicker/calendar/model.dart",
-          "line": 351,
-          "col": 17,
-          "description": "Always override `hashCode` if overriding `==`."
-        }
-      ]
+      "codeProblems": []
     },
     "lib/src/material_datepicker/calendar/month.dart": {
       "uri": "package:angular_components/src/material_datepicker/calendar/month.dart",
@@ -34887,33 +34847,13 @@
       "uri": "package:angular_components/src/utils/angular/scroll_host/pan_controller_impl.dart",
       "size": 7342,
       "isFormatted": true,
-      "codeProblems": [
-        {
-          "severity": "INFO",
-          "errorType": "LINT",
-          "errorCode": "hash_and_equals",
-          "file": "lib/src/utils/angular/scroll_host/pan_controller_impl.dart",
-          "line": 240,
-          "col": 17,
-          "description": "Always override `hashCode` if overriding `==`."
-        }
-      ]
+      "codeProblems": []
     },
     "lib/src/utils/angular/scroll_host/position_sticky_controller.dart": {
       "uri": "package:angular_components/src/utils/angular/scroll_host/position_sticky_controller.dart",
       "size": 8531,
       "isFormatted": true,
-      "codeProblems": [
-        {
-          "severity": "INFO",
-          "errorType": "LINT",
-          "errorCode": "cancel_subscriptions",
-          "file": "lib/src/utils/angular/scroll_host/position_sticky_controller.dart",
-          "line": 241,
-          "col": 49,
-          "description": "Cancel instances of dart.async.StreamSubscription."
-        }
-      ]
+      "codeProblems": []
     },
     "lib/src/utils/angular/scroll_host/scroll_host_base.dart": {
       "uri": "package:angular_components/src/utils/angular/scroll_host/scroll_host_base.dart",
@@ -34943,17 +34883,7 @@
       "uri": "package:angular_components/src/utils/angular/scroll_host/sticky_controller_impl.dart",
       "size": 19097,
       "isFormatted": true,
-      "codeProblems": [
-        {
-          "severity": "INFO",
-          "errorType": "LINT",
-          "errorCode": "hash_and_equals",
-          "file": "lib/src/utils/angular/scroll_host/sticky_controller_impl.dart",
-          "line": 376,
-          "col": 17,
-          "description": "Always override `hashCode` if overriding `==`."
-        }
-      ]
+      "codeProblems": []
     },
     "lib/src/utils/async/async_update_scheduler.dart": {
       "uri": "package:angular_components/src/utils/async/async_update_scheduler.dart",
@@ -35001,17 +34931,7 @@
       "uri": "package:angular_components/src/utils/async/simple_stream.dart",
       "size": 13694,
       "isFormatted": true,
-      "codeProblems": [
-        {
-          "severity": "INFO",
-          "errorType": "LINT",
-          "errorCode": "cancel_subscriptions",
-          "file": "lib/src/utils/async/simple_stream.dart",
-          "line": 173,
-          "col": 11,
-          "description": "Cancel instances of dart.async.StreamSubscription."
-        }
-      ]
+      "codeProblems": []
     },
     "lib/src/utils/async/throttle_stream.dart": {
       "uri": "package:angular_components/src/utils/async/throttle_stream.dart",
@@ -37774,26 +37694,7 @@
       "uri": "package:angular_components/utils/comparators/comparators.dart",
       "size": 1205,
       "isFormatted": true,
-      "codeProblems": [
-        {
-          "severity": "INFO",
-          "errorType": "LINT",
-          "errorCode": "hash_and_equals",
-          "file": "lib/utils/comparators/comparators.dart",
-          "line": 17,
-          "col": 17,
-          "description": "Always override `hashCode` if overriding `==`."
-        },
-        {
-          "severity": "INFO",
-          "errorType": "LINT",
-          "errorCode": "hash_and_equals",
-          "file": "lib/utils/comparators/comparators.dart",
-          "line": 33,
-          "col": 17,
-          "description": "Always override `hashCode` if overriding `==`."
-        }
-      ],
+      "codeProblems": [],
       "directLibs": [],
       "transitiveLibs": [],
       "platform": {

--- a/test/end2end/dartdoc-0.24.1.json
+++ b/test/end2end/dartdoc-0.24.1.json
@@ -75,24 +75,39 @@
     "resolveProcessFailed": false,
     "analyzerErrorCount": 0,
     "analyzerWarningCount": 0,
-    "analyzerHintCount": 6,
+    "analyzerHintCount": 57,
     "platformConflictCount": 0,
     "suggestions": [
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
         "title": "Fix `lib/src/model.dart`.",
-        "description": "Analysis of `lib/src/model.dart` reported 4 hints:\n\nline 1070 col 12: 'getMembersInheritedFromClasses' is deprecated and shouldn't be used.\n\nline 1072 col 12: 'getMembersInheritedFromInterfaces' is deprecated and shouldn't be used.\n\nline 1207 col 17: Always override `hashCode` if overriding `==`.\n\nline 2386 col 25: Invocation of Iterable<E>.contains with references of unrelated types.",
+        "description": "Analysis of `lib/src/model.dart` reported 15 hints, including:\n\nline 1070 col 12: 'getMembersInheritedFromClasses' is deprecated and shouldn't be used.\n\nline 1072 col 12: 'getMembersInheritedFromInterfaces' is deprecated and shouldn't be used.\n\nline 1473 col 9: Use isNotEmpty instead of length\n\nline 1481 col 12: Use `isNotEmpty` for Iterables and Maps.\n\nline 1890 col 11: Use isEmpty instead of length",
         "file": "lib/src/model.dart",
-        "score": 1.99
+        "score": 7.24
+      },
+      {
+        "code": "dartanalyzer.warning",
+        "level": "hint",
+        "title": "Fix `lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart`.",
+        "description": "Analysis of `lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart` reported 10 hints, including:\n\nline 49 col 3: Avoid return types on setters.\n\nline 61 col 3: Avoid return types on setters.\n\nline 168 col 58: Use `=` to separate a named parameter from its default value.\n\nline 191 col 58: Use `=` to separate a named parameter from its default value.\n\nline 207 col 58: Use `=` to separate a named parameter from its default value.",
+        "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+        "score": 4.89
       },
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
         "title": "Fix `lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart`.",
-        "description": "Analysis of `lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart` reported 2 hints:\n\nline 274 col 12: Equality operator `==` invocation with references of unrelated types.\n\nline 274 col 23: Equality operator `==` invocation with references of unrelated types.",
+        "description": "Analysis of `lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart` reported 9 hints, including:\n\nline 72 col 8: Don't explicitly initialize variables to null.\n\nline 72 col 22: Use `=` to separate a named parameter from its default value.\n\nline 73 col 34: Use `=` to separate a named parameter from its default value.\n\nline 74 col 41: Use `=` to separate a named parameter from its default value.\n\nline 127 col 12: Use `=` to separate a named parameter from its default value.",
         "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
-        "score": 1.0
+        "score": 4.41
+      },
+      {
+        "code": "bulk",
+        "level": "hint",
+        "title": "Fix additional 9 files with analysis or formatting issues.",
+        "description": "Additional issues in the following files:\n\n- `lib/src/dartdoc_options.dart` (6 hints)\n- `lib/src/third_party/pkg/mustache4dart/lib/src/mustache.dart` (4 hints)\n- `lib/src/io_utils.dart` (3 hints)\n- `lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart` (3 hints)\n- `bin/dartdoc.dart` (2 hints)\n- `lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart` (2 hints)\n- `lib/src/html/html_generator.dart` (1 hint)\n- `lib/src/markdown_processor.dart` (1 hint)\n- `lib/src/third_party/pkg/mustache4dart/example/simpleusage.dart` (1 hint)\n",
+        "score": 11.43
       }
     ]
   },
@@ -410,7 +425,26 @@
       "uri": "asset:dartdoc/bin/dartdoc.dart",
       "size": 3783,
       "isFormatted": true,
-      "codeProblems": [],
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "bin/dartdoc.dart",
+          "line": 94,
+          "col": 55,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "bin/dartdoc.dart",
+          "line": 100,
+          "col": 56,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ],
       "directLibs": [
         "dart:async",
         "dart:io",
@@ -1004,7 +1038,62 @@
       "uri": "package:dartdoc/src/dartdoc_options.dart",
       "size": 52754,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_types_as_parameter_names",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 479,
+          "col": 28,
+          "description": "Avoid types as parameter names."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_types_as_parameter_names",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 654,
+          "col": 30,
+          "description": "Avoid types as parameter names."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 706,
+          "col": 18,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 711,
+          "col": 35,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 758,
+          "col": 18,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 761,
+          "col": 35,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/element_type.dart": {
       "uri": "package:dartdoc/src/element_type.dart",
@@ -1022,7 +1111,17 @@
       "uri": "package:dartdoc/src/html/html_generator.dart",
       "size": 7857,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 130,
+          "col": 27,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/html/html_generator_instance.dart": {
       "uri": "package:dartdoc/src/html/html_generator_instance.dart",
@@ -1058,7 +1157,35 @@
       "uri": "package:dartdoc/src/io_utils.dart",
       "size": 7591,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/io_utils.dart",
+          "line": 23,
+          "col": 20,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unawaited_futures",
+          "file": "lib/src/io_utils.dart",
+          "line": 86,
+          "col": 5,
+          "description": "`Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/io_utils.dart",
+          "line": 109,
+          "col": 21,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/line_number_cache.dart": {
       "uri": "package:dartdoc/src/line_number_cache.dart",
@@ -1076,7 +1203,17 @@
       "uri": "package:dartdoc/src/markdown_processor.dart",
       "size": 33534,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 157,
+          "col": 46,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/model.dart": {
       "uri": "package:dartdoc/src/model.dart",
@@ -1104,20 +1241,119 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
-          "errorCode": "hash_and_equals",
+          "errorCode": "prefer_is_empty",
           "file": "lib/src/model.dart",
-          "line": 1207,
-          "col": 17,
-          "description": "Always override `hashCode` if overriding `==`."
+          "line": 1473,
+          "col": 9,
+          "description": "Use isNotEmpty instead of length"
         },
         {
           "severity": "INFO",
           "errorType": "LINT",
-          "errorCode": "iterable_contains_unrelated_type",
+          "errorCode": "prefer_is_not_empty",
           "file": "lib/src/model.dart",
-          "line": 2386,
+          "line": 1481,
+          "col": 12,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_empty",
+          "file": "lib/src/model.dart",
+          "line": 1890,
+          "col": 11,
+          "description": "Use isEmpty instead of length"
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/model.dart",
+          "line": 3299,
+          "col": 15,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/model.dart",
+          "line": 3732,
           "col": 25,
-          "description": "Invocation of Iterable<E>.contains with references of unrelated types."
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/model.dart",
+          "line": 3732,
+          "col": 47,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/model.dart",
+          "line": 3732,
+          "col": 71,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/model.dart",
+          "line": 3804,
+          "col": 12,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/model.dart",
+          "line": 3869,
+          "col": 13,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/model.dart",
+          "line": 4355,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/model.dart",
+          "line": 5053,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/model.dart",
+          "line": 5061,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_empty",
+          "file": "lib/src/model.dart",
+          "line": 6437,
+          "col": 32,
+          "description": "Use isEmpty instead of length"
         }
       ]
     },
@@ -1143,7 +1379,17 @@
       "uri": "package:dartdoc/src/third_party/pkg/mustache4dart/example/simpleusage.dart",
       "size": 573,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_relative_lib_imports",
+          "file": "lib/src/third_party/pkg/mustache4dart/example/simpleusage.dart",
+          "line": 3,
+          "col": 8,
+          "description": "Avoid relative imports for files in `lib/`."
+        }
+      ]
     },
     "lib/src/third_party/pkg/mustache4dart/lib/mustache4dart.dart": {
       "uri": "package:dartdoc/src/third_party/pkg/mustache4dart/lib/mustache4dart.dart",
@@ -1155,25 +1401,172 @@
       "uri": "package:dartdoc/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
       "size": 5395,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_relative_lib_imports",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
+          "line": 5,
+          "col": 8,
+          "description": "Avoid relative imports for files in `lib/`."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
+          "line": 15,
+          "col": 61,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart": {
       "uri": "package:dartdoc/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
       "size": 3155,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 5,
+          "col": 39,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_empty",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 105,
+          "col": 24,
+          "description": "Always true because length is always greater or equal 0."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 125,
+          "col": 24,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/third_party/pkg/mustache4dart/lib/src/mustache.dart": {
       "uri": "package:dartdoc/src/third_party/pkg/mustache4dart/lib/src/mustache.dart",
       "size": 793,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mustache.dart",
+          "line": 6,
+          "col": 17,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mustache.dart",
+          "line": 8,
+          "col": 32,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mustache.dart",
+          "line": 9,
+          "col": 39,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mustache.dart",
+          "line": 18,
+          "col": 57,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart": {
       "uri": "package:dartdoc/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
       "size": 7211,
       "isFormatted": true,
       "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_init_to_null",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 72,
+          "col": 8,
+          "description": "Don't explicitly initialize variables to null."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 72,
+          "col": 22,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 73,
+          "col": 34,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 74,
+          "col": 41,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 127,
+          "col": 12,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 135,
+          "col": 12,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_init_to_null",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 238,
+          "col": 8,
+          "description": "Don't explicitly initialize variables to null."
+        },
         {
           "severity": "INFO",
           "errorType": "LINT",
@@ -1198,7 +1591,98 @@
       "uri": "package:dartdoc/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
       "size": 9340,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 49,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 61,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 168,
+          "col": 58,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 191,
+          "col": 58,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 207,
+          "col": 58,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 237,
+          "col": 58,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 246,
+          "col": 58,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 274,
+          "col": 58,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 324,
+          "col": 58,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 332,
+          "col": 58,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/tool_runner.dart": {
       "uri": "package:dartdoc/src/tool_runner.dart",

--- a/test/end2end/http-0.11.3-17.json
+++ b/test/end2end/http-0.11.3-17.json
@@ -47,36 +47,39 @@
     "resolveProcessFailed": false,
     "analyzerErrorCount": 0,
     "analyzerWarningCount": 0,
-    "analyzerHintCount": 2,
+    "analyzerHintCount": 17,
     "platformConflictCount": 0,
     "suggestions": [
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
-        "title": "Fix `lib/src/base_client.dart`.",
-        "description": "Analysis of `lib/src/base_client.dart` reported 2 hints:\n\nline 163 col 44: 'typed' is deprecated and shouldn't be used.\n\nline 165 col 44: 'typed' is deprecated and shouldn't be used.",
-        "file": "lib/src/base_client.dart",
-        "score": 1.0
+        "title": "Fix `lib/src/response.dart`.",
+        "description": "Analysis of `lib/src/response.dart` reported 6 hints, including:\n\nline 34 col 35: Use `=` to separate a named parameter from its default value.\n\nline 35 col 23: Use `=` to separate a named parameter from its default value.\n\nline 36 col 33: Use `=` to separate a named parameter from its default value.\n\nline 52 col 35: Use `=` to separate a named parameter from its default value.\n\nline 53 col 23: Use `=` to separate a named parameter from its default value.",
+        "file": "lib/src/response.dart",
+        "score": 2.96
       },
       {
-        "code": "dartfmt.warning",
+        "code": "dartanalyzer.warning",
         "level": "hint",
-        "title": "Format `lib/browser_client.dart`.",
-        "description": "Run `dartfmt` to format `lib/browser_client.dart`.",
-        "file": "lib/browser_client.dart"
+        "title": "Fix `lib/src/base_response.dart`.",
+        "description": "Analysis of `lib/src/base_response.dart` reported 3 hints:\n\nline 43 col 20: Use `=` to separate a named parameter from its default value.\n\nline 44 col 23: Use `=` to separate a named parameter from its default value.\n\nline 45 col 33: Use `=` to separate a named parameter from its default value.",
+        "file": "lib/src/base_response.dart",
+        "score": 1.49
       },
       {
-        "code": "dartfmt.warning",
+        "code": "dartanalyzer.warning",
         "level": "hint",
-        "title": "Format `lib/http.dart`.",
-        "description": "Run `dartfmt` to format `lib/http.dart`.",
-        "file": "lib/http.dart"
+        "title": "Fix `lib/src/streamed_response.dart`.",
+        "description": "Analysis of `lib/src/streamed_response.dart` reported 3 hints:\n\nline 26 col 35: Use `=` to separate a named parameter from its default value.\n\nline 27 col 23: Use `=` to separate a named parameter from its default value.\n\nline 28 col 33: Use `=` to separate a named parameter from its default value.",
+        "file": "lib/src/streamed_response.dart",
+        "score": 1.49
       },
       {
         "code": "bulk",
         "level": "hint",
         "title": "Fix additional 14 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files:\n\n- `lib/src/base_request.dart` (Run `dartfmt` to format `lib/src/base_request.dart`.)\n- `lib/src/base_response.dart` (Run `dartfmt` to format `lib/src/base_response.dart`.)\n- `lib/src/boundary_characters.dart` (Run `dartfmt` to format `lib/src/boundary_characters.dart`.)\n- `lib/src/byte_stream.dart` (Run `dartfmt` to format `lib/src/byte_stream.dart`.)\n- `lib/src/client.dart` (Run `dartfmt` to format `lib/src/client.dart`.)\n- `lib/src/io_client.dart` (Run `dartfmt` to format `lib/src/io_client.dart`.)\n- `lib/src/mock_client.dart` (Run `dartfmt` to format `lib/src/mock_client.dart`.)\n- `lib/src/multipart_file.dart` (Run `dartfmt` to format `lib/src/multipart_file.dart`.)\n- `lib/src/multipart_request.dart` (Run `dartfmt` to format `lib/src/multipart_request.dart`.)\n- `lib/src/request.dart` (Run `dartfmt` to format `lib/src/request.dart`.)\n- `lib/src/response.dart` (Run `dartfmt` to format `lib/src/response.dart`.)\n- `lib/src/streamed_request.dart` (Run `dartfmt` to format `lib/src/streamed_request.dart`.)\n- `lib/src/streamed_response.dart` (Run `dartfmt` to format `lib/src/streamed_response.dart`.)\n- `lib/src/utils.dart` (Run `dartfmt` to format `lib/src/utils.dart`.)\n"
+        "description": "Additional issues in the following files:\n\n- `lib/browser_client.dart` (2 hints)\n- `lib/src/base_client.dart` (2 hints)\n- `lib/src/multipart_request.dart` (1 hint)\n- `lib/http.dart` (Run `dartfmt` to format `lib/http.dart`.)\n- `lib/src/base_request.dart` (Run `dartfmt` to format `lib/src/base_request.dart`.)\n- `lib/src/boundary_characters.dart` (Run `dartfmt` to format `lib/src/boundary_characters.dart`.)\n- `lib/src/byte_stream.dart` (Run `dartfmt` to format `lib/src/byte_stream.dart`.)\n- `lib/src/client.dart` (Run `dartfmt` to format `lib/src/client.dart`.)\n- `lib/src/io_client.dart` (Run `dartfmt` to format `lib/src/io_client.dart`.)\n- `lib/src/mock_client.dart` (Run `dartfmt` to format `lib/src/mock_client.dart`.)\n- `lib/src/multipart_file.dart` (Run `dartfmt` to format `lib/src/multipart_file.dart`.)\n- `lib/src/request.dart` (Run `dartfmt` to format `lib/src/request.dart`.)\n- `lib/src/streamed_request.dart` (Run `dartfmt` to format `lib/src/streamed_request.dart`.)\n- `lib/src/utils.dart` (Run `dartfmt` to format `lib/src/utils.dart`.)\n",
+        "score": 2.5
       }
     ]
   },
@@ -192,7 +195,26 @@
       "uri": "package:http/browser_client.dart",
       "size": 3638,
       "isFormatted": false,
-      "codeProblems": [],
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unawaited_futures",
+          "file": "lib/browser_client.dart",
+          "line": 52,
+          "col": 5,
+          "description": "`Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unawaited_futures",
+          "file": "lib/browser_client.dart",
+          "line": 78,
+          "col": 5,
+          "description": "`Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`."
+        }
+      ],
       "directLibs": [
         "dart:async",
         "dart:html",
@@ -550,7 +572,35 @@
       "uri": "package:http/src/base_response.dart",
       "size": 1727,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/base_response.dart",
+          "line": 43,
+          "col": 20,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/base_response.dart",
+          "line": 44,
+          "col": 23,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/base_response.dart",
+          "line": 45,
+          "col": 33,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/boundary_characters.dart": {
       "uri": "package:http/src/boundary_characters.dart",
@@ -598,7 +648,17 @@
       "uri": "package:http/src/multipart_request.dart",
       "size": 5905,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/multipart_request.dart",
+          "line": 77,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        }
+      ]
     },
     "lib/src/request.dart": {
       "uri": "package:http/src/request.dart",
@@ -610,7 +670,62 @@
       "uri": "package:http/src/response.dart",
       "size": 3431,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/response.dart",
+          "line": 34,
+          "col": 35,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/response.dart",
+          "line": 35,
+          "col": 23,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/response.dart",
+          "line": 36,
+          "col": 33,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/response.dart",
+          "line": 52,
+          "col": 35,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/response.dart",
+          "line": 53,
+          "col": 23,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/response.dart",
+          "line": 54,
+          "col": 33,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/streamed_request.dart": {
       "uri": "package:http/src/streamed_request.dart",
@@ -622,7 +737,35 @@
       "uri": "package:http/src/streamed_response.dart",
       "size": 1326,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/streamed_response.dart",
+          "line": 26,
+          "col": 35,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/streamed_response.dart",
+          "line": 27,
+          "col": 23,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/streamed_response.dart",
+          "line": 28,
+          "col": 33,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/utils.dart": {
       "uri": "package:http/src/utils.dart",

--- a/test/end2end/pub_server-0.1.4-2.json
+++ b/test/end2end/pub_server-0.1.4-2.json
@@ -56,8 +56,18 @@
     "resolveProcessFailed": false,
     "analyzerErrorCount": 0,
     "analyzerWarningCount": 0,
-    "analyzerHintCount": 0,
-    "platformConflictCount": 0
+    "analyzerHintCount": 4,
+    "platformConflictCount": 0,
+    "suggestions": [
+      {
+        "code": "dartanalyzer.warning",
+        "level": "hint",
+        "title": "Fix `lib/shelf_pubserver.dart`.",
+        "description": "Analysis of `lib/shelf_pubserver.dart` reported 4 hints:\n\nline 245 col 9: Use isEmpty instead of length\n\nline 414 col 53: Use isNotEmpty instead of length\n\nline 470 col 62: Use `=` to separate a named parameter from its default value.\n\nline 475 col 53: Use `=` to separate a named parameter from its default value.",
+        "file": "lib/shelf_pubserver.dart",
+        "score": 1.99
+      }
+    ]
   },
   "maintenance": {
     "missingChangelog": false,
@@ -268,7 +278,44 @@
       "uri": "package:pub_server/shelf_pubserver.dart",
       "size": 17239,
       "isFormatted": true,
-      "codeProblems": [],
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_empty",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 245,
+          "col": 9,
+          "description": "Use isEmpty instead of length"
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_empty",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 414,
+          "col": 53,
+          "description": "Use isNotEmpty instead of length"
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 470,
+          "col": 62,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 475,
+          "col": 53,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ],
       "directLibs": [
         "dart:async",
         "package:dart2_constant/convert.dart",

--- a/test/end2end/stream-2.0.1.json
+++ b/test/end2end/stream-2.0.1.json
@@ -52,37 +52,39 @@
     "resolveProcessFailed": false,
     "analyzerErrorCount": 1,
     "analyzerWarningCount": 0,
-    "analyzerHintCount": 1,
+    "analyzerHintCount": 117,
     "platformConflictCount": 0,
     "suggestions": [
       {
         "code": "dartanalyzer.warning",
         "level": "error",
         "title": "Fix `lib/src/rsp_util.dart`.",
-        "description": "Analysis of `lib/src/rsp_util.dart` failed with 1 error:\n\nline 170 col 47: The getter 'dart' isn't defined for the class 'Browser'.",
+        "description": "Analysis of `lib/src/rsp_util.dart` failed with 1 error, 4 hints:\n\nline 170 col 47: The getter 'dart' isn't defined for the class 'Browser'.\n\nline 25 col 34: Use `isNotEmpty` for Iterables and Maps.\n\nline 75 col 57: Use `=` to separate a named parameter from its default value.\n\nline 75 col 76: Use `=` to separate a named parameter from its default value.\n\nline 76 col 8: Use `=` to separate a named parameter from its default value.",
         "file": "lib/src/rsp_util.dart",
-        "score": 25.0
+        "score": 26.49
       },
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
-        "title": "Fix `lib/src/plugin/loader.dart`.",
-        "description": "Analysis of `lib/src/plugin/loader.dart` reported 1 hint:\n\nline 83 col 16: Always override `hashCode` if overriding `==`.",
-        "file": "lib/src/plugin/loader.dart",
-        "score": 0.5
+        "title": "Fix `lib/src/server_impl.dart`.",
+        "description": "Analysis of `lib/src/server_impl.dart` reported 20 hints, including:\n\nline 186 col 31: Use isNotEmpty instead of length\n\nline 213 col 3: Avoid return types on setters.\n\nline 222 col 3: Avoid return types on setters.\n\nline 236 col 3: Avoid return types on setters.\n\nline 253 col 3: Avoid return types on setters.",
+        "file": "lib/src/server_impl.dart",
+        "score": 9.54
       },
       {
-        "code": "dartfmt.warning",
+        "code": "dartanalyzer.warning",
         "level": "hint",
-        "title": "Format `lib/proxy.dart`.",
-        "description": "Run `dartfmt` to format `lib/proxy.dart`.",
-        "file": "lib/proxy.dart"
+        "title": "Fix `lib/src/rspc/compiler.dart`.",
+        "description": "Analysis of `lib/src/rspc/compiler.dart` reported 18 hints, including:\n\nline 30 col 59: Use `=` to separate a named parameter from its default value.\n\nline 31 col 19: Use `=` to separate a named parameter from its default value.\n\nline 31 col 43: Use `=` to separate a named parameter from its default value.\n\nline 128 col 15: Use `isNotEmpty` for Iterables and Maps.\n\nline 175 col 13: Use `isNotEmpty` for Iterables and Maps.",
+        "file": "lib/src/rspc/compiler.dart",
+        "score": 8.63
       },
       {
         "code": "bulk",
         "level": "hint",
         "title": "Fix additional 11 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files:\n\n- `lib/src/connect.dart` (Run `dartfmt` to format `lib/src/connect.dart`.)\n- `lib/src/connect_impl.dart` (Run `dartfmt` to format `lib/src/connect_impl.dart`.)\n- `lib/src/plugin/loader_impl.dart` (Run `dartfmt` to format `lib/src/plugin/loader_impl.dart`.)\n- `lib/src/plugin/router.dart` (Run `dartfmt` to format `lib/src/plugin/router.dart`.)\n- `lib/src/rspc/build.dart` (Run `dartfmt` to format `lib/src/rspc/build.dart`.)\n- `lib/src/rspc/compiler.dart` (Run `dartfmt` to format `lib/src/rspc/compiler.dart`.)\n- `lib/src/rspc/main.dart` (Run `dartfmt` to format `lib/src/rspc/main.dart`.)\n- `lib/src/rspc/tag.dart` (Run `dartfmt` to format `lib/src/rspc/tag.dart`.)\n- `lib/src/rspc/tag_util.dart` (Run `dartfmt` to format `lib/src/rspc/tag_util.dart`.)\n- `lib/src/server.dart` (Run `dartfmt` to format `lib/src/server.dart`.)\n- `lib/src/server_impl.dart` (Run `dartfmt` to format `lib/src/server_impl.dart`.)\n"
+        "description": "Additional issues in the following files:\n\n- `lib/src/server.dart` (17 hints)\n- `lib/src/connect_impl.dart` (15 hints)\n- `lib/src/rspc/build.dart` (14 hints)\n- `lib/src/plugin/router.dart` (9 hints)\n- `lib/src/rspc/tag_util.dart` (8 hints)\n- `lib/src/connect.dart` (4 hints)\n- `lib/proxy.dart` (2 hints)\n- `lib/src/rspc/main.dart` (2 hints)\n- `lib/src/rspc/tag.dart` (2 hints)\n- `lib/src/plugin/loader.dart` (1 hint)\n- `lib/src/plugin/loader_impl.dart` (1 hint)\n",
+        "score": 36.52
       }
     ]
   },
@@ -306,7 +308,26 @@
       "uri": "package:stream/proxy.dart",
       "size": 5111,
       "isFormatted": false,
-      "codeProblems": [],
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/proxy.dart",
+          "line": 141,
+          "col": 24,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/proxy.dart",
+          "line": 141,
+          "col": 46,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ],
       "directLibs": [
         "dart:async",
         "dart:io",
@@ -518,13 +539,186 @@
       "uri": "package:stream/src/connect.dart",
       "size": 15015,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/connect.dart",
+          "line": 125,
+          "col": 65,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/connect.dart",
+          "line": 166,
+          "col": 40,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/connect.dart",
+          "line": 275,
+          "col": 40,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect.dart",
+          "line": 296,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        }
+      ]
     },
     "lib/src/connect_impl.dart": {
       "uri": "package:stream/src/connect_impl.dart",
       "size": 10184,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/connect_impl.dart",
+          "line": 73,
+          "col": 40,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/connect_impl.dart",
+          "line": 122,
+          "col": 13,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect_impl.dart",
+          "line": 189,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect_impl.dart",
+          "line": 261,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/connect_impl.dart",
+          "line": 272,
+          "col": 49,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect_impl.dart",
+          "line": 293,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect_impl.dart",
+          "line": 299,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect_impl.dart",
+          "line": 302,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect_impl.dart",
+          "line": 305,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect_impl.dart",
+          "line": 308,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect_impl.dart",
+          "line": 314,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect_impl.dart",
+          "line": 317,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect_impl.dart",
+          "line": 320,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/connect_impl.dart",
+          "line": 323,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/connect_impl.dart",
+          "line": 329,
+          "col": 75,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/plugin/loader.dart": {
       "uri": "package:stream/src/plugin/loader.dart",
@@ -534,11 +728,11 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
-          "errorCode": "hash_and_equals",
+          "errorCode": "prefer_is_not_empty",
           "file": "lib/src/plugin/loader.dart",
-          "line": 83,
-          "col": 16,
-          "description": "Always override `hashCode` if overriding `==`."
+          "line": 237,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
         }
       ]
     },
@@ -546,19 +740,147 @@
       "uri": "package:stream/src/plugin/loader_impl.dart",
       "size": 10276,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 223,
+          "col": 11,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        }
+      ]
     },
     "lib/src/plugin/router.dart": {
       "uri": "package:stream/src/plugin/router.dart",
       "size": 14486,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/plugin/router.dart",
+          "line": 19,
+          "col": 43,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/plugin/router.dart",
+          "line": 28,
+          "col": 59,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/plugin/router.dart",
+          "line": 72,
+          "col": 20,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/plugin/router.dart",
+          "line": 72,
+          "col": 43,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/plugin/router.dart",
+          "line": 132,
+          "col": 43,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/plugin/router.dart",
+          "line": 148,
+          "col": 59,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/plugin/router.dart",
+          "line": 239,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/plugin/router.dart",
+          "line": 308,
+          "col": 11,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/plugin/router.dart",
+          "line": 379,
+          "col": 35,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        }
+      ]
     },
     "lib/src/rsp_util.dart": {
       "uri": "package:stream/src/rsp_util.dart",
       "size": 6231,
       "isFormatted": false,
       "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rsp_util.dart",
+          "line": 25,
+          "col": 34,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rsp_util.dart",
+          "line": 75,
+          "col": 57,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rsp_util.dart",
+          "line": 75,
+          "col": 76,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rsp_util.dart",
+          "line": 76,
+          "col": 8,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
         {
           "severity": "ERROR",
           "errorType": "STATIC_TYPE_WARNING",
@@ -574,43 +896,779 @@
       "uri": "package:stream/src/rspc/build.dart",
       "size": 6337,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/build.dart",
+          "line": 12,
+          "col": 22,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/build.dart",
+          "line": 12,
+          "col": 42,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/build.dart",
+          "line": 12,
+          "col": 66,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/build.dart",
+          "line": 31,
+          "col": 17,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/build.dart",
+          "line": 31,
+          "col": 36,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/build.dart",
+          "line": 32,
+          "col": 20,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/build.dart",
+          "line": 32,
+          "col": 46,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unawaited_futures",
+          "file": "lib/src/rspc/build.dart",
+          "line": 84,
+          "col": 5,
+          "description": "`Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unawaited_futures",
+          "file": "lib/src/rspc/build.dart",
+          "line": 114,
+          "col": 5,
+          "description": "`Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/build.dart",
+          "line": 130,
+          "col": 22,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unawaited_futures",
+          "file": "lib/src/rspc/build.dart",
+          "line": 163,
+          "col": 11,
+          "description": "`Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unawaited_futures",
+          "file": "lib/src/rspc/build.dart",
+          "line": 169,
+          "col": 9,
+          "description": "`Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_contains",
+          "file": "lib/src/rspc/build.dart",
+          "line": 178,
+          "col": 19,
+          "description": "Use contains instead of indexOf"
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_contains",
+          "file": "lib/src/rspc/build.dart",
+          "line": 178,
+          "col": 52,
+          "description": "Use contains instead of indexOf"
+        }
+      ]
     },
     "lib/src/rspc/compiler.dart": {
       "uri": "package:stream/src/rspc/compiler.dart",
       "size": 26182,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 30,
+          "col": 59,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 31,
+          "col": 19,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 31,
+          "col": 43,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 128,
+          "col": 15,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 175,
+          "col": 13,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 197,
+          "col": 30,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 202,
+          "col": 27,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 205,
+          "col": 13,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 209,
+          "col": 26,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 223,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 340,
+          "col": 25,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 357,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 518,
+          "col": 48,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 535,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 538,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 555,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 653,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 816,
+          "col": 30,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        }
+      ]
     },
     "lib/src/rspc/main.dart": {
       "uri": "package:stream/src/rspc/main.dart",
       "size": 3448,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/main.dart",
+          "line": 16,
+          "col": 46,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unawaited_futures",
+          "file": "lib/src/rspc/main.dart",
+          "line": 60,
+          "col": 7,
+          "description": "`Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`."
+        }
+      ]
     },
     "lib/src/rspc/tag.dart": {
       "uri": "package:stream/src/rspc/tag.dart",
       "size": 15588,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 180,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 194,
+          "col": 9,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        }
+      ]
     },
     "lib/src/rspc/tag_util.dart": {
       "uri": "package:stream/src/rspc/tag_util.dart",
       "size": 8297,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 32,
+          "col": 33,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 44,
+          "col": 11,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_contains",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 56,
+          "col": 10,
+          "description": "Use contains instead of indexOf"
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_contains",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 57,
+          "col": 5,
+          "description": "Use contains instead of indexOf"
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 166,
+          "col": 20,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 166,
+          "col": 43,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 170,
+          "col": 27,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 191,
+          "col": 17,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        }
+      ]
     },
     "lib/src/server.dart": {
       "uri": "package:stream/src/server.dart",
       "size": 16918,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 96,
+          "col": 38,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 106,
+          "col": 22,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 205,
+          "col": 47,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 205,
+          "col": 66,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 206,
+          "col": 16,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 206,
+          "col": 36,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 206,
+          "col": 55,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 231,
+          "col": 25,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 232,
+          "col": 18,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 232,
+          "col": 56,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 233,
+          "col": 18,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 233,
+          "col": 34,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 233,
+          "col": 53,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 253,
+          "col": 55,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/server.dart",
+          "line": 371,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 385,
+          "col": 43,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server.dart",
+          "line": 393,
+          "col": 59,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/src/server_impl.dart": {
       "uri": "package:stream/src/server_impl.dart",
       "size": 12006,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_empty",
+          "file": "lib/src/server_impl.dart",
+          "line": 186,
+          "col": 31,
+          "description": "Use isNotEmpty instead of length"
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/server_impl.dart",
+          "line": 213,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/server_impl.dart",
+          "line": 222,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/server_impl.dart",
+          "line": 236,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "avoid_return_types_on_setters",
+          "file": "lib/src/server_impl.dart",
+          "line": 253,
+          "col": 3,
+          "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_is_not_empty",
+          "file": "lib/src/server_impl.dart",
+          "line": 258,
+          "col": 25,
+          "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 260,
+          "col": 47,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 260,
+          "col": 66,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 261,
+          "col": 18,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 261,
+          "col": 38,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 261,
+          "col": 57,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 275,
+          "col": 25,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 276,
+          "col": 18,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 276,
+          "col": 56,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 277,
+          "col": 18,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 277,
+          "col": 34,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 277,
+          "col": 53,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 298,
+          "col": 55,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 379,
+          "col": 43,
+          "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_equal_for_default_values",
+          "file": "lib/src/server_impl.dart",
+          "line": 383,
+          "col": 59,
+          "description": "Use `=` to separate a named parameter from its default value."
+        }
+      ]
     },
     "lib/stream.dart": {
       "uri": "package:stream/stream.dart",


### PR DESCRIPTION
Fixes #459.

We need to add `package:pedantic` in the `dev_dependencies`, and subsequently remove it from the list of resolved packages (unless it is referenced in the original `pubspec.yaml`).