### PR TITLE
Fix pedantic analysis of package:pedantic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.13
+
+* Fix `pedantic` analyzing `package:pedantic`.
+
 ## 0.12.12
 
 * Link to package layout conventions in example-related suggestions.

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -436,7 +436,17 @@ class ToolEnvironment {
     final parsed = yamlToJson(original);
     parsed.remove('dev_dependencies');
     parsed.remove('dependency_overrides');
-    if (parsed['name'] != 'pedantic') {
+
+    // Adding pedantic as a dev dependency, because the analysis_options.yaml
+    // file references its ruleset.
+    //
+    // If the package under analysis is pedantic, or pedantic is already a
+    // dependency of the package, we don't need to add it.
+    final isPedantic = parsed['name'] == 'pedantic';
+    final dependencies = parsed['dependencies'];
+    final hasPedantic =
+        (dependencies is Map) && (dependencies.keys.contains('pedantic'));
+    if (!isPedantic && !hasPedantic) {
       parsed['dev_dependencies'] = {'pedantic': '^1.0.0'};
     }
 

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -436,7 +436,9 @@ class ToolEnvironment {
     final parsed = yamlToJson(original);
     parsed.remove('dev_dependencies');
     parsed.remove('dependency_overrides');
-    parsed['dev_dependencies'] = {'pedantic': '^1.0.0'};
+    if (parsed['name'] != 'pedantic') {
+      parsed['dev_dependencies'] = {'pedantic': '^1.0.0'};
+    }
 
     await pubspec.rename(backup.path);
     await pubspec.writeAsString(json.encode(parsed));

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.12.12';
+const packageVersion = '0.12.13-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.12.12
+version: 0.12.13-dev
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
fun fact: you cannot validate `package:pedantic` with arbitrary version of `pedantic`, as it would be a duplicate dependency and won't resolve.