### PR TITLE
Don't block platform classification on hints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.13
+
+* Don't block platform classification on hints.
+
 ## 0.12.12
 
 * Link to package layout conventions in example-related suggestions.

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -718,6 +718,17 @@ class Health {
     score -= 0.25 * platformConflictCount;
     return math.max(0.0, score);
   }
+
+  bool get hasPlatformBlockingIssues {
+    // should not classify platform if any of the processes fail
+    if (anyProcessFailed) {
+      return true;
+    }
+    // calculate base score without (pedantic) hints
+    var score =
+        calculateBaseHealth(analyzerErrorCount, analyzerWarningCount, 0);
+    return score < 0.33;
+  }
 }
 
 /// Returns the part of the health score that is calculated from the number of

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -382,7 +382,7 @@ class PackageAnalyzer {
           'Error(s) prevent platform classification:\n\n$pkgPlatformConflict');
     }
     platform ??= classifyPkgPlatform(pubspec, allTransitiveLibs);
-    if (!platform.hasConflict && health.healthScore < 0.33) {
+    if (!platform.hasConflict && health.hasPlatformBlockingIssues) {
       platform = DartPlatform.conflict(
           'Low code quality prevents platform classification.');
     }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.12.12';
+const packageVersion = '0.12.13-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.12.12
+version: 0.12.13-dev
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 


### PR DESCRIPTION
`pedantic` introduced way more hints, and in a few rare cases these now prevent platform classification. I think we should allow these to slip, and still do the classification if there are not too many errors or warnings.