### PR TITLE
Deduplicate dartanalyzer output lines, and increase timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Display calculated health and maintenance scores when `pana` is called with `--scores`.
 
+* Deduplicate `dartanalyzer` output lines.
+
 ## 0.12.13+1
 
 * Support the latest `package:analyzer`.

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -165,6 +165,8 @@ class ToolEnvironment {
         params,
         environment: _environment,
         workingDirectory: packageDir,
+        deduplicate: true,
+        timeout: const Duration(minutes: 5),
       );
       final output = proc.stderr as String;
       if ('\n$output'.contains('\nUnhandled exception:\n')) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -66,6 +66,7 @@ Future<ProcessResult> runProc(
   var items = await Future.wait(<Future<Object>>[
     process.exitCode,
     byteStreamSplit(process.stdout).forEach((outLine) {
+      // TODO: Remove deduplication when https://github.com/dart-lang/sdk/issues/36062 gets fixed
       if (deduplicate && stdoutLines.contains(outLine)) {
         return;
       }
@@ -77,6 +78,7 @@ Future<ProcessResult> runProc(
       }
     }),
     byteStreamSplit(process.stderr).forEach((errLine) {
+      // TODO: Remove deduplication when https://github.com/dart-lang/sdk/issues/36062 gets fixed
       if (deduplicate && stderrLines.contains(errLine)) {
         return;
       }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -36,6 +36,7 @@ Future<ProcessResult> runProc(
   String workingDirectory,
   Map<String, String> environment,
   Duration timeout,
+  bool deduplicate = false,
 }) async {
   log.info('Running `${([executable]..addAll(arguments)).join(' ')}`...');
   var process = await Process.start(executable, arguments,
@@ -65,6 +66,9 @@ Future<ProcessResult> runProc(
   var items = await Future.wait(<Future<Object>>[
     process.exitCode,
     byteStreamSplit(process.stdout).forEach((outLine) {
+      if (deduplicate && stdoutLines.contains(outLine)) {
+        return;
+      }
       stdoutLines.add(outLine);
       // Uncomment to debug long execution
       // stderr.writeln(outLine);
@@ -73,6 +77,9 @@ Future<ProcessResult> runProc(
       }
     }),
     byteStreamSplit(process.stderr).forEach((errLine) {
+      if (deduplicate && stderrLines.contains(errLine)) {
+        return;
+      }
       stderrLines.add(errLine);
       // Uncomment to debug long execution
       // stderr.writeln(errLine);


### PR DESCRIPTION
Fixes #517, improves #515.