### PR TITLE
Fixed the use of pedantic rules following the new versioned pattern.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.16
+
+* Fixed the use of `pedantic` rules following the new versioned pattern.
+
 ## 0.12.15
 
 * Fix: delete local temporary `pedantic_analyis_options_[timestamp].g.yaml`.

--- a/lib/src/analysis_options.dart
+++ b/lib/src/analysis_options.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:resource/resource.dart';
 import 'package:yaml/yaml.dart' as yaml;
 
 String _analysisOptions(String pedanticConfigPath) => '''
@@ -99,4 +100,20 @@ String customizeAnalysisOptions(
   }
 
   return json.encode(customMap);
+}
+
+final _pedanticVersionRegExp =
+    RegExp(r'package:pedantic/analysis_options\.(.*?)\.yaml');
+
+/// Returns the content of pedantic/analysis_options.yaml (resolving linked if
+/// needed).
+Future<String> getPedanticContent() async {
+  final rootResource = const Resource('package:pedantic/analysis_options.yaml');
+  final rootContent = await rootResource.readAsString();
+  final match = _pedanticVersionRegExp.firstMatch(rootContent);
+  if (match == null) {
+    return rootContent;
+  }
+  final versionedContent = await Resource(match.group(0)).readAsString();
+  return versionedContent;
 }

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -10,7 +10,6 @@ import 'package:cli_util/cli_util.dart' as cli;
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
-import 'package:resource/resource.dart';
 
 import 'analysis_options.dart';
 import 'logging.dart';
@@ -143,9 +142,7 @@ class ToolEnvironment {
     if (await originalOptionsFile.exists()) {
       originalOptions = await originalOptionsFile.readAsString();
     }
-    final pedanticResource =
-        const Resource('package:pedantic/analysis_options.yaml');
-    final pedanticContent = await pedanticResource.readAsString();
+    final pedanticContent = await getPedanticContent();
     final pedanticFileName =
         'pedantic_analyis_options_${DateTime.now().microsecondsSinceEpoch}.g.yaml';
     final pedanticOptionsFile = File(p.join(packageDir, pedanticFileName));

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.12.15';
+const packageVersion = '0.12.16-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.12.15
+version: 0.12.16-dev
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 

--- a/test/analysis_options_test.dart
+++ b/test/analysis_options_test.dart
@@ -9,6 +9,14 @@ import 'package:test/test.dart';
 import 'package:pana/src/analysis_options.dart';
 
 void main() {
+  test('pedantic options', () async {
+    final content = await getPedanticContent();
+    expect(content, contains('linter:'));
+    expect(content, contains('rules:'));
+    expect(content, contains('avoid_empty_else'));
+    expect(content, contains('prefer_is_empty'));
+  });
+
   test('default options', () {
     expect(
       json.decode(customizeAnalysisOptions(


### PR DESCRIPTION
The new method and the test also ensures that we detect if another upgrade breaks it.