### PR TITLE
Update references to pub.dev site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Usage: pana [<options>] <published package name> [<version>]
 Options:
       --flutter-sdk     The directory of the Flutter SDK.
   -j, --json            Output log items as JSON.
-  -s, --source          The source where the package is located (hosted on https://pub.dartlang.org, or local directory path).
+  -s, --source          The source where the package is located (hosted on https://pub.dev, or local directory path).
                         [hosted (default), path]
   
       --hosted-url      The server that hosts <package>.
-                        (defaults to "https://pub.dartlang.org")
+                        (defaults to "https://pub.dev")
   
   -l, --line-length     The line length to use with dartfmt.
       --verbosity       Configure the details in the output.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A library for analyzing Dart packages. It invokes executables from the Dart SDK
 (or from the Flutter SDK if the package uses Flutter).
 
 * Checks for outdated dependencies (calls `pub upgrade` or `flutter pub upgrade`).
-* Validates the code using [Dart Analyzer](https://www.dartlang.org/tools/analyzer).
+* Validates the code using [Dart Analyzer](https://dart.dev/tools/dartanalyzer).
 * Checks code formatting (`dartfmt` or `flutter format`).
 * Infers supported platforms: Flutter, web, and/or other (e.g console/server).
 * Creates suggestions to improve the package.
 
-Used by the [Dart Package site](https://pub.dartlang.org/).
+Used by the [Dart Package site](https://pub.dev/).
 
 ## Use as an executable
 
@@ -60,7 +60,7 @@ Otherwise the score starts with `1.0`, and
 
 `health = 0.75^errors * 0.95^warnings * 0.995^hints - 0.25*conflicts`
 
-[Pub site](https://pub.dartlang.org/) transforms this score into the [0 - 100] range.
+[Pub site](https://pub.dev/) transforms this score into the [0 - 100] range.
 
 ### Maintenance score
 
@@ -99,6 +99,6 @@ A package starts with `100` points, and the following detected issues have point
 - `changelog.md`, `readme.md` or example content is too large (-1 point per every 1kb above 128kb).
 - `pubspec.yaml` too large (-1 point per every 1kb above 32kb).
 
-On top of that, [pub site](https://pub.dartlang.org/) applies an age restriction:
+On top of that, [pub site](https://pub.dev/) applies an age restriction:
  - outdated packages (age older than two years) are reduced to 0
  - old packages (age between 1 and 2 years) get linear reduction (1.5 years old get 50% reduction)

--- a/bin/pana.dart
+++ b/bin/pana.dart
@@ -14,7 +14,7 @@ import 'package:io/io.dart';
 import 'package:logging/logging.dart' as log;
 import 'package:pana/pana.dart';
 
-const defaultHostedUrl = 'https://pub.dartlang.org';
+const defaultHostedUrl = 'https://pub.dev';
 
 final _parser = ArgParser()
   ..addOption('flutter-sdk', help: 'The directory of the Flutter SDK.')

--- a/test/bin_pana_test.dart
+++ b/test/bin_pana_test.dart
@@ -43,11 +43,11 @@ final _helpOutput =
 Options:
       --flutter-sdk     The directory of the Flutter SDK.
   -j, --json            Output log items as JSON.
-  -s, --source          The source where the package is located (hosted on https://pub.dartlang.org, or local directory path).
+  -s, --source          The source where the package is located (hosted on https://pub.dev, or local directory path).
                         [hosted (default), path]
   
       --hosted-url      The server that hosts <package>.
-                        (defaults to "https://pub.dartlang.org")
+                        (defaults to "https://pub.dev")
   
   -l, --line-length     The line length to use with dartfmt.
       --verbosity       Configure the details in the output.


### PR DESCRIPTION
@jonasfj: I've updated the references in the CLI help too, but that is debatable, as the pub client will continue to use `pub.dartlang.org`...  or will the new version use `pub.dev` and we keep supporting the old ones on the old domain?