### PR TITLE
Penalize package constraints that does not support the latest published versions of their dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Recognize `.markdown` and `.mdown` files.
 * Recognize `COPYING` and `UNLICENSE` as license file names (or prefix).
 * Accept any extension for license files.
+* Penalize package constraints that does not support the latest published versions of their dependencies.
 
 ## 0.12.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+## 0.12.18
+
+* Penalize package constraints that does not support the latest published versions of their dependencies.
+
 ## 0.12.17
 
 * Recognize `.markdown` and `.mdown` files.
 * Recognize `COPYING` and `UNLICENSE` as license file names (or prefix).
 * Accept any extension for license files.
-* Penalize package constraints that does not support the latest published versions of their dependencies.
 
 ## 0.12.16
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ A package starts with `100` points, and the following detected issues have point
 - `issue_tracker` is not helpful (e.g. pointing to `http://localhost/`) (-10 points)
 - `issue_tracker` is insecure (not using `https`) (-5 points)
 - `description` is too long (>180 characters) (-10 points)
+- does not support the latest version of its dependencies (-10 points for direct, -5 for transitive)
 - package has no example file (-10 points)
 - uses old `.analysis_options` file (-10 points)
 - uses pre-v0.1 release versioning (`0.0.*`) (-10 points)

--- a/lib/src/maintenance.dart
+++ b/lib/src/maintenance.dart
@@ -518,6 +518,7 @@ Future<Maintenance> detectMaintenance(
         score: 20.0));
   }
 
+  // Checking the dependencies that have no constraints.
   unconstrainedDeps ??= pkgResolution?.getUnconstrainedDeps(onlyDirect: true);
   if (unconstrainedDeps != null && unconstrainedDeps.isNotEmpty) {
     final count = unconstrainedDeps.length;
@@ -534,6 +535,7 @@ Future<Maintenance> detectMaintenance(
         score: 20.0));
   }
 
+  // Checking the dependencies that can't be used with their latest version.
   final outdatedDeps = pkgResolution?.outdated ?? <PkgDependency>[];
   if (outdatedDeps.isNotEmpty) {
     final count = outdatedDeps.length;

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -320,6 +320,8 @@ abstract class SuggestionCode {
       'pubspec.dependencies.failedToResolve';
   static const String pubspecDependenciesUnconstrained =
       'pubspec.dependencies.unconstrained';
+  static const String pubspecDependenciesOutdated =
+      'pubspec.dependencies.outdated';
   static const String pubspecDescriptionTooShort =
       'pubspec.description.tooShort';
   static const String pubspecDescriptionTooLong = 'pubspec.description.tooLong';

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -396,9 +396,10 @@ class PackageAnalyzer {
       _urlChecker,
       pkgDir,
       pubspec,
-      pkgResolution?.getUnconstrainedDeps(onlyDirect: true),
+      null, // unconstrainedDeps no longer used directly
       pkgPlatform: platform,
       dartdocSuccessful: dartdocSuccessful,
+      pkgResolution: pkgResolution,
     );
     suggestions.sort();
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.12.17';
+const packageVersion = '0.12.18-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.12.17
+version: 0.12.18-dev
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 

--- a/test/end2end/angular_components-0.10.0.json
+++ b/test/end2end/angular_components-0.10.0.json
@@ -110,6 +110,13 @@
     "isPreReleaseVersion": false,
     "suggestions": [
       {
+        "code": "pubspec.dependencies.outdated",
+        "level": "warning",
+        "title": "Support latest dependencies.",
+        "description": "The version constraint in `pubspec.yaml` does not support the latest published versions for 12 dependencies (5 direct: `angular`, `angular_forms`, `build_config`, `protobuf`, `quiver`).",
+        "score": 85.0
+      },
+      {
         "code": "pubspec.documentation.isNotHelpful",
         "level": "warning",
         "title": "Documentation URL isn't helpful.",
@@ -325,7 +332,7 @@
         "package": "json_annotation",
         "dependencyType": "transitive",
         "constraintType": "inherited",
-        "resolved": "2.3.0"
+        "resolved": "2.4.0"
       },
       {
         "package": "kernel",

--- a/test/end2end/dartdoc-0.24.1.json
+++ b/test/end2end/dartdoc-0.24.1.json
@@ -122,6 +122,13 @@
     "isPreReleaseVersion": false,
     "suggestions": [
       {
+        "code": "pubspec.dependencies.outdated",
+        "level": "warning",
+        "title": "Support latest dependencies.",
+        "description": "The version constraint in `pubspec.yaml` does not support the latest published versions for 5 dependencies (2 direct: `analyzer`, `html`).",
+        "score": 35.0
+      },
+      {
         "code": "pubspec.description.tooShort",
         "level": "hint",
         "title": "The package description is too short.",
@@ -221,7 +228,7 @@
         "package": "file",
         "dependencyType": "transitive",
         "constraintType": "inherited",
-        "resolved": "5.0.7"
+        "resolved": "5.0.8"
       },
       {
         "package": "front_end",

--- a/test/end2end/stream-2.0.1.json
+++ b/test/end2end/stream-2.0.1.json
@@ -212,7 +212,7 @@
         "dependencyType": "direct",
         "constraintType": "normal",
         "constraint": "any",
-        "resolved": "3.2.0+1"
+        "resolved": "3.2.1"
       },
       {
         "package": "source_span",

--- a/test/maintenance_test.dart
+++ b/test/maintenance_test.dart
@@ -135,24 +135,26 @@ final _withIssues = Maintenance.fromJson(_withIssuesJson);
 void main() {
   group('detectMaintenance', () {
     test('empty directory', () async {
+      final pkgResolution = PkgResolution([
+        PkgDependency(
+          package: 'foo',
+          dependencyType: 'direct',
+          constraintType: 'empty',
+          constraint: null,
+          resolved: null,
+          available: null,
+          errors: null,
+        ),
+      ]);
       final maintenance = await detectMaintenance(
         InspectOptions(),
         UrlChecker(),
         d.sandbox,
         Pubspec.fromJson({'name': 'sandbox', 'version': '0.0.1-alpha'}),
-        [
-          PkgDependency(
-            package: 'foo',
-            dependencyType: 'direct',
-            constraintType: 'empty',
-            constraint: null,
-            resolved: null,
-            available: null,
-            errors: null,
-          )
-        ],
+        null,
         pkgPlatform: DartPlatform.conflict('conflict description'),
         dartdocSuccessful: false,
+        pkgResolution: pkgResolution,
       );
 
       expect(json.decode(json.encode(maintenance.toJson())), _withIssuesJson);


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pub-dev/issues/2319