### PR TITLE
Fix: penalize outdated package constraints only for direct dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.19
+
+* Fix: penalize outdated package constraints only for direct dependencies.
+
 ## 0.12.18
 
 * Penalize package constraints that does not support the latest published versions of their dependencies.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ A package starts with `100` points, and the following detected issues have point
 - `issue_tracker` is not helpful (e.g. pointing to `http://localhost/`) (-10 points)
 - `issue_tracker` is insecure (not using `https`) (-5 points)
 - `description` is too long (>180 characters) (-10 points)
-- does not support the latest version of its dependencies (-10 points for direct, -5 for transitive)
+- does not support the latest version of its direct dependencies (-10 points)
 - package has no example file (-10 points)
 - uses old `.analysis_options` file (-10 points)
 - uses pre-v0.1 release versioning (`0.0.*`) (-10 points)

--- a/lib/src/maintenance.dart
+++ b/lib/src/maintenance.dart
@@ -535,18 +535,17 @@ Future<Maintenance> detectMaintenance(
         score: 20.0));
   }
 
-  // Checking the dependencies that can't be used with their latest version.
-  final outdatedDeps = pkgResolution?.outdated ?? <PkgDependency>[];
-  if (outdatedDeps.isNotEmpty) {
-    final count = outdatedDeps.length;
+  // Checking the direct dependencies that can't be used with their latest version.
+  final outdatedPackages = pkgResolution?.outdated
+          ?.where((pd) => pd.isDirect)
+          ?.map((p) => p.package)
+          ?.toList() ??
+      <PkgDependency>[];
+  if (outdatedPackages.isNotEmpty) {
+    final count = outdatedPackages.length;
     final pluralized = count == 1 ? '1 dependency' : '$count dependencies';
-    final directPkgs =
-        outdatedDeps.where((pd) => pd.isDirect).map((p) => p.package).toList();
-    final nonDirectCount = count - directPkgs.length;
-    final penalty = directPkgs.length * 10.0 + nonDirectCount * 5.0;
-    final extraDescr = directPkgs.isEmpty
-        ? ''
-        : ' (${directPkgs.length} direct: ${directPkgs.map((s) => '`$s`').join(', ')})';
+    final penalty = count * 10.0;
+    final extraDescr = ' (${outdatedPackages.map((s) => '`$s`').join(', ')})';
     maintenanceSuggestions.add(Suggestion.warning(
         SuggestionCode.pubspecDependenciesOutdated,
         'Support latest dependencies.',

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.12.18';
+const packageVersion = '0.12.19-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.12.18
+version: 0.12.19-dev
 homepage: https://github.com/dart-lang/pana
 author: Dart Team <misc@dartlang.org>
 

--- a/test/end2end/angular_components-0.10.0.json
+++ b/test/end2end/angular_components-0.10.0.json
@@ -113,8 +113,8 @@
         "code": "pubspec.dependencies.outdated",
         "level": "warning",
         "title": "Support latest dependencies.",
-        "description": "The version constraint in `pubspec.yaml` does not support the latest published versions for 12 dependencies (5 direct: `angular`, `angular_forms`, `build_config`, `protobuf`, `quiver`).",
-        "score": 85.0
+        "description": "The version constraint in `pubspec.yaml` does not support the latest published versions for 5 dependencies (`angular`, `angular_forms`, `build_config`, `protobuf`, `quiver`).",
+        "score": 50.0
       },
       {
         "code": "pubspec.documentation.isNotHelpful",
@@ -504,7 +504,7 @@
         "package": "yaml",
         "dependencyType": "transitive",
         "constraintType": "inherited",
-        "resolved": "2.1.15"
+        "resolved": "2.1.16"
       }
     ]
   },

--- a/test/end2end/dartdoc-0.24.1.json
+++ b/test/end2end/dartdoc-0.24.1.json
@@ -125,8 +125,8 @@
         "code": "pubspec.dependencies.outdated",
         "level": "warning",
         "title": "Support latest dependencies.",
-        "description": "The version constraint in `pubspec.yaml` does not support the latest published versions for 5 dependencies (2 direct: `analyzer`, `html`).",
-        "score": 35.0
+        "description": "The version constraint in `pubspec.yaml` does not support the latest published versions for 2 dependencies (`analyzer`, `html`).",
+        "score": 20.0
       },
       {
         "code": "pubspec.description.tooShort",
@@ -425,7 +425,7 @@
         "dependencyType": "direct",
         "constraintType": "normal",
         "constraint": "^2.1.0",
-        "resolved": "2.1.15"
+        "resolved": "2.1.16"
       }
     ]
   },

--- a/test/end2end/pub_server-0.1.4-2.json
+++ b/test/end2end/pub_server-0.1.4-2.json
@@ -217,7 +217,7 @@
         "dependencyType": "direct",
         "constraintType": "normal",
         "constraint": "^2.1.2",
-        "resolved": "2.1.15"
+        "resolved": "2.1.16"
       }
     ]
   },


### PR DESCRIPTION
https://github.com/dart-lang/pub-dev/issues/2380