### PR TITLE
Update end2end tests to match analyzer 0.36.4

### DIFF
--- a/lib/src/license.dart
+++ b/lib/src/license.dart
@@ -16,8 +16,7 @@ import 'model.dart';
 Future<List<LicenseFile>> detectLicensesInDir(String baseDir) async {
   final rootFiles = await Directory(baseDir).list().toList();
   final licenseCandidates = rootFiles
-      .where((fse) => fse is File)
-      .cast<File>()
+      .whereType<File>()
       .where(_isLicenseFile)
       .take(5) // only the first 5 files are considered
       .toList();

--- a/test/end2end/angular_components-0.10.0.json
+++ b/test/end2end/angular_components-0.10.0.json
@@ -63,7 +63,7 @@
     "resolveProcessFailed": false,
     "analyzerErrorCount": 0,
     "analyzerWarningCount": 2,
-    "analyzerHintCount": 112,
+    "analyzerHintCount": 125,
     "platformConflictCount": 0,
     "suggestions": [
       {
@@ -93,9 +93,9 @@
       {
         "code": "bulk",
         "level": "hint",
-        "title": "Fix additional 47 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files:\n\n- `lib/src/model/selection/delegating_selection_model.dart` (7 hints)\n- `lib/material_input/material_input_multiline.dart` (6 hints)\n- `lib/material_input/material_auto_suggest_input.dart` (5 hints)\n- `lib/material_stepper/material_step.dart` (5 hints)\n- `lib/material_input/material_input.dart` (4 hints)\n- `lib/model/menu/menu.dart` (4 hints)\n- `lib/src/model/selection/single_selection_model_impl.dart` (4 hints)\n- `lib/laminate/ruler/module.dart` (3 hints)\n- `lib/material_menu/menu_item_groups.dart` (3 hints)\n- `lib/model/selection/selection_container.dart` (3 hints)\n- `lib/laminate/overlay/module.dart` (2 hints)\n- `lib/laminate/portal/portal.dart` (2 hints)\n- `lib/material_datepicker/date_range_input.dart` (2 hints)\n- `lib/material_datepicker/material_calendar_picker.dart` (2 hints)\n- `lib/model/date/time_zone_aware_clock.dart` (2 hints)\n- `lib/src/material_tree/material_tree_node.dart` (2 hints)\n- `lib/src/utils/angular/managed_zone/managed_zone.dart` (2 hints)\n- `lib/utils/angular/reference/reference.dart` (2 hints)\n- `lib/utils/browser/events/events.dart` (2 hints)\n- `lib/dynamic_component/dynamic_component.dart` (1 hint)\n- `lib/material_datepicker/date_input.dart` (1 hint)\n- `lib/material_datepicker/date_range_editor.dart` (1 hint)\n- `lib/material_datepicker/material_date_range_picker.dart` (1 hint)\n- `lib/material_datepicker/material_month_picker.dart` (1 hint)\n- `lib/material_datepicker/module.dart` (1 hint)\n- `lib/material_dialog/material_dialog.dart` (1 hint)\n- `lib/material_input/base_material_input.dart` (1 hint)\n- `lib/material_input/material_number_validators.dart` (1 hint)\n- `lib/material_menu/menu_popup_wrapper.dart` (1 hint)\n- `lib/material_popup/material_popup.dart` (1 hint)\n- `lib/material_ripple/material_ripple.dart` (1 hint)\n- `lib/material_select/dropdown_button.dart` (1 hint)\n- `lib/material_select/material_dropdown_select.dart` (1 hint)\n- `lib/material_select/material_select.dart` (1 hint)\n- `lib/material_select/material_select_dropdown_item.dart` (1 hint)\n- `lib/material_spinner/material_spinner.dart` (1 hint)\n- `lib/material_stepper/material_stepper.dart` (1 hint)\n- `lib/mixins/highlight_assistant_mixin.dart` (1 hint)\n- `lib/mixins/track_layout_changes.dart` (1 hint)\n- `lib/model/date/date_formatter.dart` (1 hint)\n- `lib/model/menu/selectable_menu.dart` (1 hint)\n- `lib/src/laminate/popup/popup_hierarchy.dart` (1 hint)\n- `lib/src/material_tree/material_tree_root.dart` (1 hint)\n- `lib/utils/angular/managed_zone/interface.dart` (1 hint)\n- `lib/utils/angular/scroll_host/angular_2.dart` (1 hint)\n- `lib/utils/browser/dom_service/dom_service.dart` (1 hint)\n- `lib/utils/angular/properties/properties.dart` (Run `dartfmt` to format `lib/utils/angular/properties/properties.dart`.)\n",
-        "score": 44.309999999999995
+        "title": "Fix additional 49 files with analysis or formatting issues.",
+        "description": "Additional issues in the following files:\n\n- `lib/material_datepicker/proto/date_range.pb.dart` (8 hints)\n- `lib/src/model/selection/delegating_selection_model.dart` (7 hints)\n- `lib/material_input/material_input_multiline.dart` (6 hints)\n- `lib/material_input/material_auto_suggest_input.dart` (5 hints)\n- `lib/material_input/material_input.dart` (5 hints)\n- `lib/material_stepper/material_step.dart` (5 hints)\n- `lib/material_datepicker/proto/date.pb.dart` (4 hints)\n- `lib/model/menu/menu.dart` (4 hints)\n- `lib/src/model/selection/single_selection_model_impl.dart` (4 hints)\n- `lib/laminate/ruler/module.dart` (3 hints)\n- `lib/material_menu/menu_item_groups.dart` (3 hints)\n- `lib/model/selection/selection_container.dart` (3 hints)\n- `lib/laminate/overlay/module.dart` (2 hints)\n- `lib/laminate/portal/portal.dart` (2 hints)\n- `lib/material_datepicker/date_range_input.dart` (2 hints)\n- `lib/material_datepicker/material_calendar_picker.dart` (2 hints)\n- `lib/model/date/time_zone_aware_clock.dart` (2 hints)\n- `lib/src/material_tree/material_tree_node.dart` (2 hints)\n- `lib/src/utils/angular/managed_zone/managed_zone.dart` (2 hints)\n- `lib/utils/angular/reference/reference.dart` (2 hints)\n- `lib/utils/browser/events/events.dart` (2 hints)\n- `lib/dynamic_component/dynamic_component.dart` (1 hint)\n- `lib/material_datepicker/date_input.dart` (1 hint)\n- `lib/material_datepicker/date_range_editor.dart` (1 hint)\n- `lib/material_datepicker/material_date_range_picker.dart` (1 hint)\n- `lib/material_datepicker/material_month_picker.dart` (1 hint)\n- `lib/material_datepicker/module.dart` (1 hint)\n- `lib/material_dialog/material_dialog.dart` (1 hint)\n- `lib/material_input/base_material_input.dart` (1 hint)\n- `lib/material_input/material_number_validators.dart` (1 hint)\n- `lib/material_menu/menu_popup_wrapper.dart` (1 hint)\n- `lib/material_popup/material_popup.dart` (1 hint)\n- `lib/material_ripple/material_ripple.dart` (1 hint)\n- `lib/material_select/dropdown_button.dart` (1 hint)\n- `lib/material_select/material_dropdown_select.dart` (1 hint)\n- `lib/material_select/material_select.dart` (1 hint)\n- `lib/material_select/material_select_dropdown_item.dart` (1 hint)\n- `lib/material_spinner/material_spinner.dart` (1 hint)\n- `lib/material_stepper/material_stepper.dart` (1 hint)\n- `lib/mixins/highlight_assistant_mixin.dart` (1 hint)\n- `lib/mixins/track_layout_changes.dart` (1 hint)\n- `lib/model/date/date_formatter.dart` (1 hint)\n- `lib/model/menu/selectable_menu.dart` (1 hint)\n- `lib/src/laminate/popup/popup_hierarchy.dart` (1 hint)\n- `lib/src/material_tree/material_tree_root.dart` (1 hint)\n- `lib/utils/angular/managed_zone/interface.dart` (1 hint)\n- `lib/utils/angular/scroll_host/angular_2.dart` (1 hint)\n- `lib/utils/browser/dom_service/dom_service.dart` (1 hint)\n- `lib/utils/angular/properties/properties.dart` (Run `dartfmt` to format `lib/utils/angular/properties/properties.dart`.)\n",
+        "score": 50.71999999999999
       }
     ]
   },
@@ -146,7 +146,7 @@
         "dependencyType": "transitive",
         "constraintType": "inherited",
         "resolved": "0.35.4",
-        "available": "0.36.4"
+        "available": "0.37.0"
       },
       {
         "package": "angular",
@@ -204,7 +204,7 @@
         "constraintType": "normal",
         "constraint": ">=0.2.6 <0.4.0",
         "resolved": "0.3.2",
-        "available": "0.4.0"
+        "available": "0.4.1"
       },
       {
         "package": "built_collection",
@@ -260,8 +260,8 @@
         "package": "csslib",
         "dependencyType": "transitive",
         "constraintType": "inherited",
-        "resolved": "0.14.6",
-        "available": "0.16.0"
+        "resolved": "0.14.6+1",
+        "available": "0.16.1"
       },
       {
         "package": "dart2_constant",
@@ -280,7 +280,7 @@
         "dependencyType": "transitive",
         "constraintType": "inherited",
         "resolved": "1.2.4",
-        "available": "1.2.8"
+        "available": "1.2.9"
       },
       {
         "package": "fixnum",
@@ -294,7 +294,7 @@
         "dependencyType": "transitive",
         "constraintType": "inherited",
         "resolved": "0.1.14",
-        "available": "0.1.19"
+        "available": "0.1.20"
       },
       {
         "package": "glob",
@@ -339,7 +339,7 @@
         "dependencyType": "transitive",
         "constraintType": "inherited",
         "resolved": "0.3.14",
-        "available": "0.3.19"
+        "available": "0.3.20"
       },
       {
         "package": "logging",
@@ -391,7 +391,7 @@
         "package": "pedantic",
         "dependencyType": "transitive",
         "constraintType": "inherited",
-        "resolved": "1.7.0"
+        "resolved": "1.8.0+1"
       },
       {
         "package": "protobuf",
@@ -399,7 +399,7 @@
         "constraintType": "normal",
         "constraint": "^0.10.2",
         "resolved": "0.10.8",
-        "available": "0.13.12"
+        "available": "0.13.14"
       },
       {
         "package": "pub_semver",
@@ -425,7 +425,7 @@
         "package": "sass",
         "dependencyType": "transitive",
         "constraintType": "inherited",
-        "resolved": "1.22.1"
+        "resolved": "1.22.3"
       },
       {
         "package": "sass_builder",
@@ -14184,7 +14184,44 @@
       "uri": "package:angular_components/material_datepicker/proto/date.pb.dart",
       "size": 1898,
       "isFormatted": true,
-      "codeProblems": [],
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date.pb.dart",
+          "line": 13,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date.pb.dart",
+          "line": 28,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date.pb.dart",
+          "line": 32,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date.pb.dart",
+          "line": 33,
+          "col": 47,
+          "description": "Unnecessary new keyword."
+        }
+      ],
       "directLibs": [
         "package:protobuf/protobuf.dart"
       ],
@@ -14210,7 +14247,80 @@
       "uri": "package:angular_components/material_datepicker/proto/date_range.pb.dart",
       "size": 5797,
       "isFormatted": true,
-      "codeProblems": [],
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date_range.pb.dart",
+          "line": 15,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date_range.pb.dart",
+          "line": 40,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date_range.pb.dart",
+          "line": 44,
+          "col": 42,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date_range.pb.dart",
+          "line": 46,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date_range.pb.dart",
+          "line": 144,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date_range.pb.dart",
+          "line": 160,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date_range.pb.dart",
+          "line": 164,
+          "col": 32,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_datepicker/proto/date_range.pb.dart",
+          "line": 165,
+          "col": 52,
+          "description": "Unnecessary new keyword."
+        }
+      ],
       "directLibs": [
         "package:angular_components/material_datepicker/proto/date.pb.dart",
         "package:protobuf/protobuf.dart"
@@ -16809,6 +16919,15 @@
           "line": 115,
           "col": 3,
           "description": "'ElementRef' is deprecated and shouldn't be used."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/material_input/material_input.dart",
+          "line": 130,
+          "col": 19,
+          "description": "Unnecessary new keyword."
         }
       ],
       "directLibs": [

--- a/test/end2end/dartdoc-0.24.1.json
+++ b/test/end2end/dartdoc-0.24.1.json
@@ -75,39 +75,39 @@
     "resolveProcessFailed": false,
     "analyzerErrorCount": 0,
     "analyzerWarningCount": 0,
-    "analyzerHintCount": 143,
+    "analyzerHintCount": 810,
     "platformConflictCount": 0,
     "suggestions": [
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
         "title": "Fix `lib/src/model.dart`.",
-        "description": "Analysis of `lib/src/model.dart` reported 52 hints, including:\n\nline 18 col 59: Use `lowercase_with_underscores` when specifying a library prefix.\n\nline 56 col 36: Use `lowercase_with_underscores` when specifying a library prefix.\n\nline 493 col 47: Use `;` instead of `{}` for empty constructor bodies.\n\nline 695 col 11: DO use curly braces for all flow control structures.\n\nline 799 col 7: DO use curly braces for all flow control structures.",
+        "description": "Analysis of `lib/src/model.dart` reported 322 hints, including:\n\nline 18 col 59: Use `lowercase_with_underscores` when specifying a library prefix.\n\nline 56 col 36: Use `lowercase_with_underscores` when specifying a library prefix.\n\nline 68 col 39: Avoid const keyword.\n\nline 94 col 33: Unnecessary new keyword.\n\nline 95 col 38: Unnecessary new keyword.",
         "file": "lib/src/model.dart",
-        "score": 22.95
+        "score": 80.09
+      },
+      {
+        "code": "dartanalyzer.warning",
+        "level": "hint",
+        "title": "Fix `lib/src/dartdoc_options.dart`.",
+        "description": "Analysis of `lib/src/dartdoc_options.dart` reported 100 hints, including:\n\nline 23 col 36: Use `lowercase_with_underscores` when specifying a library prefix.\n\nline 29 col 38: Avoid const keyword.\n\nline 30 col 44: Avoid const keyword.\n\nline 88 col 12: Unnecessary new keyword.\n\nline 105 col 16: Unnecessary new keyword.",
+        "file": "lib/src/dartdoc_options.dart",
+        "score": 39.42
       },
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
         "title": "Fix `lib/src/html/template_data.dart`.",
-        "description": "Analysis of `lib/src/html/template_data.dart` reported 22 hints, including:\n\nline 147 col 7: DO use curly braces for all flow control structures.\n\nline 149 col 7: DO use curly braces for all flow control structures.\n\nline 151 col 7: DO use curly braces for all flow control structures.\n\nline 153 col 7: DO use curly braces for all flow control structures.\n\nline 155 col 7: DO use curly braces for all flow control structures.",
+        "description": "Analysis of `lib/src/html/template_data.dart` reported 50 hints, including:\n\nline 79 col 15: Unnecessary new keyword.\n\nline 107 col 13: Unnecessary new keyword.\n\nline 147 col 7: DO use curly braces for all flow control structures.\n\nline 147 col 13: Unnecessary new keyword.\n\nline 149 col 7: DO use curly braces for all flow control structures.",
         "file": "lib/src/html/template_data.dart",
-        "score": 10.44
-      },
-      {
-        "code": "dartanalyzer.warning",
-        "level": "hint",
-        "title": "Fix `lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart`.",
-        "description": "Analysis of `lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart` reported 16 hints, including:\n\nline 3 col 1: Prefer using /// for doc comments.\n\nline 39 col 7: DO use curly braces for all flow control structures.\n\nline 49 col 3: Avoid return types on setters.\n\nline 56 col 3: Prefer using /// for doc comments.\n\nline 61 col 3: Avoid return types on setters.",
-        "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
-        "score": 7.71
+        "score": 22.17
       },
       {
         "code": "bulk",
         "level": "hint",
-        "title": "Fix additional 16 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files:\n\n- `lib/src/dartdoc_options.dart` (10 hints)\n- `lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart` (9 hints)\n- `lib/src/io_utils.dart` (5 hints)\n- `lib/src/third_party/pkg/mustache4dart/lib/src/mustache.dart` (4 hints)\n- `lib/dartdoc.dart` (3 hints)\n- `lib/src/markdown_processor.dart` (3 hints)\n- `lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart` (3 hints)\n- `lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart` (3 hints)\n- `bin/dartdoc.dart` (2 hints)\n- `lib/src/html/html_generator.dart` (2 hints)\n- `lib/src/html/html_generator_instance.dart` (2 hints)\n- `lib/src/package_meta.dart` (2 hints)\n- `lib/src/tool_runner.dart` (2 hints)\n- `lib/src/element_type.dart` (1 hint)\n- `lib/src/model_utils.dart` (1 hint)\n- `lib/src/third_party/pkg/mustache4dart/example/simpleusage.dart` (1 hint)\n",
-        "score": 26.229999999999997
+        "title": "Fix additional 24 files with analysis or formatting issues.",
+        "description": "Additional issues in the following files:\n\n- `lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart` (35 hints)\n- `lib/src/markdown_processor.dart` (32 hints)\n- `lib/src/package_meta.dart` (30 hints)\n- `lib/src/warnings.dart` (29 hints)\n- `lib/dartdoc.dart` (27 hints)\n- `lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart` (23 hints)\n- `lib/src/html/html_generator_instance.dart` (21 hints)\n- `lib/src/html/html_generator.dart` (19 hints)\n- `lib/src/element_type.dart` (17 hints)\n- `lib/src/model_utils.dart` (17 hints)\n- `lib/src/io_utils.dart` (16 hints)\n- `lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart` (15 hints)\n- `lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart` (11 hints)\n- `bin/dartdoc.dart` (7 hints)\n- `lib/src/html/templates.dart` (6 hints)\n- `lib/src/logging.dart` (6 hints)\n- `lib/src/special_elements.dart` (6 hints)\n- `lib/src/third_party/pkg/mustache4dart/lib/src/mustache.dart` (6 hints)\n- `lib/src/line_number_cache.dart` (5 hints)\n- `lib/src/tool_runner.dart` (3 hints)\n- `lib/src/utils.dart` (3 hints)\n- `lib/src/third_party/pkg/mustache4dart/example/simpleusage.dart` (2 hints)\n- `lib/src/html/resource_loader.dart` (1 hint)\n- `lib/src/html/resources.g.dart` (1 hint)\n",
+        "score": 160.42000000000004
       }
     ]
   },
@@ -152,7 +152,7 @@
         "constraintType": "normal",
         "constraint": "^0.33.0",
         "resolved": "0.33.6+1",
-        "available": "0.36.4"
+        "available": "0.37.0"
       },
       {
         "package": "args",
@@ -216,7 +216,7 @@
         "dependencyType": "transitive",
         "constraintType": "inherited",
         "resolved": "0.15.0",
-        "available": "0.16.0"
+        "available": "0.16.1"
       },
       {
         "package": "dhttpd",
@@ -235,7 +235,7 @@
         "dependencyType": "transitive",
         "constraintType": "inherited",
         "resolved": "0.1.6+9",
-        "available": "0.1.19"
+        "available": "0.1.20"
       },
       {
         "package": "glob",
@@ -288,7 +288,7 @@
         "dependencyType": "transitive",
         "constraintType": "inherited",
         "resolved": "0.3.6+9",
-        "available": "0.3.19"
+        "available": "0.3.20"
       },
       {
         "package": "logging",
@@ -369,7 +369,7 @@
         "dependencyType": "direct",
         "constraintType": "normal",
         "constraint": "^2.1.2",
-        "resolved": "2.1.5"
+        "resolved": "2.1.6"
       },
       {
         "package": "source_span",
@@ -438,6 +438,51 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "bin/dartdoc.dart",
+          "line": 27,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "bin/dartdoc.dart",
+          "line": 29,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "bin/dartdoc.dart",
+          "line": 64,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "bin/dartdoc.dart",
+          "line": 67,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "bin/dartdoc.dart",
+          "line": 79,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "bin/dartdoc.dart",
           "line": 94,
@@ -490,6 +535,132 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 55,
+          "col": 36,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 60,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 63,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 72,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 78,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 92,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 95,
+          "col": 47,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 113,
+          "col": 45,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 126,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 139,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 172,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 179,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 184,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 197,
+          "col": 42,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/dartdoc.dart",
           "line": 228,
@@ -499,11 +670,101 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 242,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 280,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 296,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 303,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 307,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 310,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 362,
+          "col": 43,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 364,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "empty_catches",
           "file": "lib/dartdoc.dart",
           "line": 370,
           "col": 31,
           "description": "Avoid empty catch blocks."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 383,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/dartdoc.dart",
+          "line": 404,
+          "col": 33,
+          "description": "Unnecessary new keyword."
         }
       ],
       "directLibs": [
@@ -1088,11 +1349,236 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 29,
+          "col": 38,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 30,
+          "col": 44,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 88,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 105,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 106,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 111,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 114,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 146,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 167,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 176,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 181,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 189,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 194,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 200,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 203,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 213,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 218,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 220,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 257,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 273,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 277,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 350,
+          "col": 33,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 385,
+          "col": 36,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 385,
+          "col": 58,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/dartdoc_options.dart",
           "line": 396,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 453,
+          "col": 48,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1106,11 +1592,47 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 459,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "avoid_types_as_parameter_names",
           "file": "lib/src/dartdoc_options.dart",
           "line": 479,
           "col": 28,
           "description": "Avoid types as parameter names."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 603,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 616,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 636,
+          "col": 34,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1160,11 +1682,560 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 797,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 883,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 888,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 898,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 900,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 907,
+          "col": 32,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 908,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 914,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 921,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 961,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 978,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1014,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1028,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "unnecessary_null_in_if_null_operators",
           "file": "lib/src/dartdoc_options.dart",
           "line": 1052,
           "col": 23,
           "description": "Avoid using `null` in `if null` operators."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1071,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1093,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1095,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1104,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1105,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1111,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1118,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1181,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1184,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1188,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1192,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1196,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1201,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1225,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1229,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1231,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1235,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1242,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1247,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1249,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1256,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1258,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1261,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1263,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1273,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1275,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1282,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1290,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1308,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1312,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1314,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1317,
+          "col": 35,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1319,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1325,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1329,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1331,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1338,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1345,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1347,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1349,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1351,
+          "col": 33,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1352,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1354,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1359,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1363,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1365,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1369,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/dartdoc_options.dart",
+          "line": 1372,
+          "col": 5,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -1176,11 +2247,155 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 24,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 27,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 35,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 39,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 43,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 50,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 55,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 60,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 120,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 143,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 215,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 228,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 245,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 271,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "empty_constructor_bodies",
           "file": "lib/src/element_type.dart",
           "line": 321,
           "col": 55,
           "description": "Use `;` instead of `{}` for empty constructor bodies."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 335,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/element_type.dart",
+          "line": 344,
+          "col": 21,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -1207,11 +2422,164 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 45,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 51,
+          "col": 36,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 63,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 64,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 80,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 86,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 97,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 106,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "lib/src/html/html_generator.dart",
           "line": 130,
           "col": 27,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 138,
+          "col": 34,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 182,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 186,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 191,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 198,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 216,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 220,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 223,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator.dart",
+          "line": 227,
+          "col": 5,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -1232,11 +2600,182 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 43,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 51,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 82,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 83,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/html_generator_instance.dart",
           "line": 88,
           "col": 9,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 244,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 255,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 267,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 275,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 282,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 289,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 297,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 306,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 315,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 324,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 333,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 342,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 351,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 360,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/html_generator_instance.dart",
+          "line": 371,
+          "col": 15,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -1244,13 +2783,33 @@
       "uri": "package:dartdoc/src/html/resource_loader.dart",
       "size": 1060,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/resource_loader.dart",
+          "line": 28,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/html/resources.g.dart": {
       "uri": "package:dartdoc/src/html/resources.g.dart",
       "size": 707,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/html/resources.g.dart",
+          "line": 3,
+          "col": 37,
+          "description": "Avoid const keyword."
+        }
+      ]
     },
     "lib/src/html/template_data.dart": {
       "uri": "package:dartdoc/src/html/template_data.dart",
@@ -1260,11 +2819,38 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 79,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 107,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 147,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 147,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1278,11 +2864,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 149,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 151,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 151,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1296,11 +2900,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 153,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 155,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 155,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1314,11 +2936,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 157,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 159,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 159,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1332,11 +2972,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 161,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 189,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 189,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1350,11 +3008,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 191,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 193,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 193,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1368,11 +3044,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 195,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 197,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 197,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1386,11 +3080,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 199,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 201,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 201,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1404,11 +3116,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 256,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 258,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 258,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1422,11 +3152,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 260,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 262,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 262,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1440,6 +3188,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 264,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 266,
@@ -1449,11 +3206,65 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 266,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/html/template_data.dart",
           "line": 268,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 268,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 329,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 330,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 331,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/template_data.dart",
+          "line": 332,
+          "col": 9,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -1461,7 +3272,62 @@
       "uri": "package:dartdoc/src/html/templates.dart",
       "size": 5611,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/html/templates.dart",
+          "line": 13,
+          "col": 19,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/templates.dart",
+          "line": 54,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/templates.dart",
+          "line": 61,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/templates.dart",
+          "line": 66,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/templates.dart",
+          "line": 111,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/html/templates.dart",
+          "line": 139,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/io_utils.dart": {
       "uri": "package:dartdoc/src/io_utils.dart",
@@ -1489,6 +3355,87 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_utils.dart",
+          "line": 27,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_utils.dart",
+          "line": 33,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_utils.dart",
+          "line": 35,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_utils.dart",
+          "line": 38,
+          "col": 32,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_utils.dart",
+          "line": 63,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_utils.dart",
+          "line": 64,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_utils.dart",
+          "line": 65,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_utils.dart",
+          "line": 67,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_utils.dart",
+          "line": 74,
+          "col": 35,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "unawaited_futures",
           "file": "lib/src/io_utils.dart",
           "line": 86,
@@ -1512,6 +3459,24 @@
           "line": 147,
           "col": 33,
           "description": "Avoid empty catch blocks."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_utils.dart",
+          "line": 150,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_utils.dart",
+          "line": 214,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -1519,13 +3484,114 @@
       "uri": "package:dartdoc/src/line_number_cache.dart",
       "size": 2024,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/line_number_cache.dart",
+          "line": 26,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/line_number_cache.dart",
+          "line": 37,
+          "col": 41,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/line_number_cache.dart",
+          "line": 58,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/line_number_cache.dart",
+          "line": 64,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/line_number_cache.dart",
+          "line": 71,
+          "col": 46,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/logging.dart": {
       "uri": "package:dartdoc/src/logging.dart",
       "size": 3616,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/logging.dart",
+          "line": 12,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/logging.dart",
+          "line": 17,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/logging.dart",
+          "line": 22,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/logging.dart",
+          "line": 72,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/logging.dart",
+          "line": 121,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/logging.dart",
+          "line": 124,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/markdown_processor.dart": {
       "uri": "package:dartdoc/src/markdown_processor.dart",
@@ -1535,11 +3601,128 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 20,
+          "col": 23,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 122,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 125,
+          "col": 36,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 129,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 132,
+          "col": 30,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 137,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 139,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 144,
+          "col": 3,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 145,
+          "col": 3,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 152,
+          "col": 30,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "lib/src/markdown_processor.dart",
           "line": 157,
           "col": 46,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 193,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 211,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 226,
+          "col": 12,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1553,11 +3736,155 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 231,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 239,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 249,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 257,
+          "col": 10,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 327,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 678,
+          "col": 38,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 679,
+          "col": 36,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 752,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 785,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 795,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 812,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 836,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "empty_constructor_bodies",
           "file": "lib/src/markdown_processor.dart",
           "line": 843,
           "col": 43,
           "description": "Use `;` instead of `{}` for empty constructor bodies."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 895,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 900,
+          "col": 33,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 914,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/markdown_processor.dart",
+          "line": 925,
+          "col": 18,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -1587,11 +3914,155 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/model.dart",
+          "line": 68,
+          "col": 39,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 94,
+          "col": 33,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 95,
+          "col": 38,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 122,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 279,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 283,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 331,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 459,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "empty_constructor_bodies",
           "file": "lib/src/model.dart",
           "line": 493,
           "col": 47,
           "description": "Use `;` instead of `{}` for empty constructor bodies."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 527,
+          "col": 36,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 559,
+          "col": 43,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 564,
+          "col": 39,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 576,
+          "col": 34,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 583,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 587,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 668,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 692,
+          "col": 24,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1605,11 +4076,83 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 695,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 711,
+          "col": 47,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 738,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 799,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 815,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 827,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 853,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 967,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1047,
+          "col": 20,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1632,11 +4175,146 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1083,
+          "col": 55,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_iterable_whereType",
+          "file": "lib/src/model.dart",
+          "line": 1085,
+          "col": 12,
+          "description": "Prefer to use whereType on iterable."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1090,
+          "col": 62,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1141,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1143,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1173,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1180,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1192,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1202,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1203,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1227,
+          "col": 40,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 1242,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1325,
+          "col": 32,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1326,
+          "col": 35,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1328,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1457,
+          "col": 39,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1659,6 +4337,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1513,
+          "col": 46,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1542,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 1597,
@@ -1668,11 +4364,65 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1654,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1668,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1680,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 1688,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1722,
+          "col": 36,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1780,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1814,
+          "col": 31,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1695,6 +4445,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1843,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_is_empty",
           "file": "lib/src/model.dart",
           "line": 1890,
@@ -1713,11 +4472,191 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1914,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 1928,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2024,
+          "col": 32,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2026,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2055,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2059,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2062,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 2095,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2126,
+          "col": 43,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2142,
+          "col": 36,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2143,
+          "col": 61,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2149,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2186,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2188,
+          "col": 46,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2189,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_iterable_whereType",
+          "file": "lib/src/model.dart",
+          "line": 2222,
+          "col": 10,
+          "description": "Prefer to use whereType on iterable."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2226,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2244,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2265,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_iterable_whereType",
+          "file": "lib/src/model.dart",
+          "line": 2271,
+          "col": 10,
+          "description": "Prefer to use whereType on iterable."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2275,
+          "col": 14,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1731,11 +4670,92 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2292,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2337,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2358,
+          "col": 46,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_iterable_whereType",
+          "file": "lib/src/model.dart",
+          "line": 2366,
+          "col": 10,
+          "description": "Prefer to use whereType on iterable."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2369,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2379,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2396,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2425,
+          "col": 45,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 2439,
           "col": 9,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2439,
+          "col": 18,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1749,11 +4769,155 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2442,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2443,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2480,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2500,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2501,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2530,
+          "col": 41,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2545,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2547,
+          "col": 67,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2550,
+          "col": 52,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2590,
+          "col": 34,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2592,
+          "col": 32,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2638,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2645,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 2659,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2696,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2754,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2765,
+          "col": 10,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1767,11 +4931,191 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2828,
+          "col": 30,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2830,
+          "col": 30,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2832,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2869,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2877,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2884,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2889,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2891,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2893,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2897,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2902,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2907,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2912,
+          "col": 33,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2917,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2924,
+          "col": 33,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2928,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2931,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2935,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2940,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 2944,
           "col": 13,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2944,
+          "col": 31,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1785,11 +5129,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2946,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 2952,
           "col": 13,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2952,
+          "col": 31,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1803,6 +5165,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2954,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2966,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 2974,
@@ -1812,11 +5192,119 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2975,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 2977,
           "col": 15,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2977,
+          "col": 33,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2981,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2985,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 2988,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3001,
+          "col": 41,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3003,
+          "col": 38,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3057,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3123,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3131,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3138,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3208,
+          "col": 31,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1839,11 +5327,110 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3312,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 3336,
           "col": 13,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3537,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3541,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3550,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3588,
+          "col": 49,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3589,
+          "col": 44,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3611,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3633,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3635,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3656,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3674,
+          "col": 24,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1884,11 +5471,38 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3740,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_is_not_empty",
           "file": "lib/src/model.dart",
           "line": 3804,
           "col": 12,
           "description": "Use `isNotEmpty` for Iterables and Maps."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3854,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3866,
+          "col": 26,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1902,11 +5516,119 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3939,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 3943,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4003,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4006,
+          "col": 34,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4008,
+          "col": 35,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4020,
+          "col": 32,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4177,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4214,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4234,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4256,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4289,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 4301,
           "col": 9,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4333,
+          "col": 24,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1938,11 +5660,218 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4441,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 4451,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4478,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/model.dart",
+          "line": 4494,
+          "col": 52,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4572,
+          "col": 30,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4579,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4580,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4581,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4590,
+          "col": 5,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4605,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4633,
+          "col": 30,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4637,
+          "col": 66,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4639,
+          "col": 52,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4649,
+          "col": 53,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4657,
+          "col": 38,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4661,
+          "col": 33,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4664,
+          "col": 50,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4681,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4699,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4715,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4736,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4760,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4764,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4769,
+          "col": 20,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1965,6 +5894,60 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4974,
+          "col": 67,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 4988,
+          "col": 67,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5001,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5015,
+          "col": 46,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5028,
+          "col": 52,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5034,
+          "col": 49,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_is_not_empty",
           "file": "lib/src/model.dart",
           "line": 5053,
@@ -1983,6 +5966,96 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5108,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5120,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5150,
+          "col": 54,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5215,
+          "col": 38,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5216,
+          "col": 39,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5218,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5220,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5238,
+          "col": 35,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_iterable_whereType",
+          "file": "lib/src/model.dart",
+          "line": 5245,
+          "col": 14,
+          "description": "Prefer to use whereType on iterable."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5265,
+          "col": 40,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 5292,
@@ -1992,11 +6065,254 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5292,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 5294,
           "col": 13,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5294,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5296,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5326,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5329,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5330,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5489,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5516,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5535,
+          "col": 41,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5663,
+          "col": 30,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5664,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5715,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5735,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5737,
+          "col": 38,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5763,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5837,
+          "col": 35,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5885,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5889,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_iterable_whereType",
+          "file": "lib/src/model.dart",
+          "line": 5892,
+          "col": 12,
+          "description": "Prefer to use whereType on iterable."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5922,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5923,
+          "col": 32,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5981,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 5990,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6094,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6100,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6115,
+          "col": 71,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6187,
+          "col": 31,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2019,6 +6335,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6289,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6300,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/model.dart",
           "line": 6305,
@@ -2028,11 +6362,434 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6319,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6365,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6366,
+          "col": 44,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6373,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6380,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6389,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6390,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6397,
+          "col": 48,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6426,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6433,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6434,
+          "col": 41,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_is_empty",
           "file": "lib/src/model.dart",
           "line": 6437,
           "col": 32,
           "description": "Use isEmpty instead of length"
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6440,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6451,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6454,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6458,
+          "col": 35,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6465,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6466,
+          "col": 43,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6467,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6474,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6478,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6479,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6492,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6532,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6533,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6540,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6544,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6554,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6563,
+          "col": 30,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6565,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6572,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6574,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6575,
+          "col": 33,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6577,
+          "col": 30,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6589,
+          "col": 54,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6619,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6624,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6648,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6667,
+          "col": 41,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6670,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6670,
+          "col": 56,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6679,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6681,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6695,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6695,
+          "col": 42,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6712,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6713,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model.dart",
+          "line": 6714,
+          "col": 23,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -2049,6 +6806,150 @@
           "line": 17,
           "col": 36,
           "description": "Use `lowercase_with_underscores` when specifying a library prefix."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 43,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 53,
+          "col": 50,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 67,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 159,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 228,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 230,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 267,
+          "col": 57,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 283,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 290,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 297,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 305,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 314,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 324,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 334,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 345,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/model_utils.dart",
+          "line": 365,
+          "col": 25,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -2069,11 +6970,263 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 19,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 48,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 63,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/package_meta.dart",
           "line": 89,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 89,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 89,
+          "col": 38,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 90,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 91,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 95,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 95,
+          "col": 36,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 106,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 115,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 118,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 120,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 204,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 221,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 249,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 262,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 279,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 282,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 303,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 310,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 318,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 339,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "prefer_iterable_whereType",
+          "file": "lib/src/package_meta.dart",
+          "line": 339,
+          "col": 42,
+          "description": "Prefer to use whereType on iterable."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 374,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 391,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 393,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/package_meta.dart",
+          "line": 395,
+          "col": 29,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -2081,7 +7234,62 @@
       "uri": "package:dartdoc/src/special_elements.dart",
       "size": 4682,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/special_elements.dart",
+          "line": 67,
+          "col": 3,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/special_elements.dart",
+          "line": 69,
+          "col": 3,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/special_elements.dart",
+          "line": 72,
+          "col": 3,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/special_elements.dart",
+          "line": 103,
+          "col": 36,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/special_elements.dart",
+          "line": 104,
+          "col": 36,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/special_elements.dart",
+          "line": 123,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/third_party/pkg/mustache4dart/example/simpleusage.dart": {
       "uri": "package:dartdoc/src/third_party/pkg/mustache4dart/example/simpleusage.dart",
@@ -2096,6 +7304,15 @@
           "line": 3,
           "col": 8,
           "description": "Avoid relative imports for files in `lib/`."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/example/simpleusage.dart",
+          "line": 23,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -2131,11 +7348,83 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
+          "line": 37,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
+          "line": 44,
+          "col": 10,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
+          "line": 49,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "type_init_formals",
           "file": "lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
           "line": 58,
           "col": 8,
           "description": "Don't type annotate initializing formals."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
+          "line": 88,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
+          "line": 153,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
+          "line": 156,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
+          "line": 177,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/mustache_context.dart",
+          "line": 195,
+          "col": 17,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -2144,6 +7433,15 @@
       "size": 3155,
       "isFormatted": true,
       "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 3,
+          "col": 21,
+          "description": "Avoid const keyword."
+        },
         {
           "severity": "INFO",
           "errorType": "LINT",
@@ -2156,11 +7454,110 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 7,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 10,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 14,
+          "col": 10,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 23,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 44,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 50,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 52,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 63,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 65,
+          "col": 34,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 69,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_is_empty",
           "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
           "line": 105,
           "col": 24,
           "description": "Always true because length is always greater or equal 0."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mirrors.dart",
+          "line": 116,
+          "col": 22,
+          "description": "Avoid const keyword."
         },
         {
           "severity": "INFO",
@@ -2213,6 +7610,24 @@
           "line": 18,
           "col": 57,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mustache.dart",
+          "line": 20,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/mustache.dart",
+          "line": 22,
+          "col": 10,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -2221,6 +7636,33 @@
       "size": 7211,
       "isFormatted": true,
       "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 9,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 11,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 44,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
         {
           "severity": "INFO",
           "errorType": "LINT",
@@ -2260,11 +7702,65 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 75,
+          "col": 34,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 94,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 115,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 120,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 123,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
           "line": 127,
           "col": 12,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 130,
+          "col": 16,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2278,11 +7774,56 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 136,
+          "col": 10,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 164,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 182,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "avoid_init_to_null",
           "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
           "line": 238,
           "col": 8,
           "description": "Don't explicitly initialize variables to null."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 248,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tmpl.dart",
+          "line": 264,
+          "col": 20,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2321,11 +7862,56 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 21,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 24,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 31,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 33,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
           "line": 39,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 39,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2384,6 +7970,78 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 143,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 150,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 152,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 154,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 156,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 158,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 160,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 162,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
           "line": 168,
@@ -2402,11 +8060,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 198,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
           "line": 207,
           "col": 58,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 218,
+          "col": 26,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2429,11 +8105,38 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 249,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
           "line": 274,
           "col": 58,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 283,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 305,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2452,6 +8155,15 @@
           "line": 332,
           "col": 58,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/third_party/pkg/mustache4dart/lib/src/tokens.dart",
+          "line": 336,
+          "col": 26,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -2468,6 +8180,15 @@
           "line": 9,
           "col": 36,
           "description": "Use `lowercase_with_underscores` when specifying a library prefix."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/tool_runner.dart",
+          "line": 40,
+          "col": 12,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2490,7 +8211,35 @@
       "uri": "package:dartdoc/src/utils.dart",
       "size": 2348,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/utils.dart",
+          "line": 6,
+          "col": 34,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/utils.dart",
+          "line": 9,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/utils.dart",
+          "line": 41,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/version.dart": {
       "uri": "package:dartdoc/src/version.dart",
@@ -2502,7 +8251,269 @@
       "uri": "package:dartdoc/src/warnings.dart",
       "size": 12261,
       "isFormatted": true,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 24,
+          "col": 41,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 28,
+          "col": 37,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 32,
+          "col": 7,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 41,
+          "col": 39,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 45,
+          "col": 36,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 49,
+          "col": 38,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 53,
+          "col": 55,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 57,
+          "col": 54,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 61,
+          "col": 42,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 65,
+          "col": 30,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 69,
+          "col": 32,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 73,
+          "col": 32,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 77,
+          "col": 31,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 81,
+          "col": 42,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 85,
+          "col": 30,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 89,
+          "col": 36,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 93,
+          "col": 29,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 97,
+          "col": 30,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/warnings.dart",
+          "line": 101,
+          "col": 36,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/warnings.dart",
+          "line": 155,
+          "col": 59,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/warnings.dart",
+          "line": 160,
+          "col": 46,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/warnings.dart",
+          "line": 162,
+          "col": 42,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/warnings.dart",
+          "line": 163,
+          "col": 40,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/warnings.dart",
+          "line": 210,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/warnings.dart",
+          "line": 211,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/warnings.dart",
+          "line": 256,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/warnings.dart",
+          "line": 263,
+          "col": 50,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/warnings.dart",
+          "line": 275,
+          "col": 50,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/warnings.dart",
+          "line": 278,
+          "col": 57,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     }
   },
   "stats": {

--- a/test/end2end/http-0.11.3-17.json
+++ b/test/end2end/http-0.11.3-17.json
@@ -47,39 +47,39 @@
     "resolveProcessFailed": false,
     "analyzerErrorCount": 0,
     "analyzerWarningCount": 0,
-    "analyzerHintCount": 17,
+    "analyzerHintCount": 92,
     "platformConflictCount": 0,
     "suggestions": [
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
-        "title": "Fix `lib/src/response.dart`.",
-        "description": "Analysis of `lib/src/response.dart` reported 6 hints, including:\n\nline 34 col 35: Use `=` to separate a named parameter from its default value.\n\nline 35 col 23: Use `=` to separate a named parameter from its default value.\n\nline 36 col 33: Use `=` to separate a named parameter from its default value.\n\nline 52 col 35: Use `=` to separate a named parameter from its default value.\n\nline 53 col 23: Use `=` to separate a named parameter from its default value.",
-        "file": "lib/src/response.dart",
-        "score": 2.96
+        "title": "Fix `lib/browser_client.dart`.",
+        "description": "Analysis of `lib/browser_client.dart` reported 11 hints, including:\n\nline 30 col 17: Unnecessary new keyword.\n\nline 44 col 15: Unnecessary new keyword.\n\nline 51 col 21: Unnecessary new keyword.\n\nline 52 col 5: `Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`.\n\nline 55 col 41: Unnecessary new keyword.",
+        "file": "lib/browser_client.dart",
+        "score": 5.36
       },
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
-        "title": "Fix `lib/src/base_response.dart`.",
-        "description": "Analysis of `lib/src/base_response.dart` reported 3 hints:\n\nline 43 col 20: Use `=` to separate a named parameter from its default value.\n\nline 44 col 23: Use `=` to separate a named parameter from its default value.\n\nline 45 col 33: Use `=` to separate a named parameter from its default value.",
-        "file": "lib/src/base_response.dart",
-        "score": 1.49
+        "title": "Fix `lib/src/multipart_file.dart`.",
+        "description": "Analysis of `lib/src/multipart_file.dart` reported 9 hints, including:\n\nline 49 col 11: Unnecessary new keyword.\n\nline 57 col 18: Unnecessary new keyword.\n\nline 58 col 12: Unnecessary new keyword.\n\nline 71 col 41: Unnecessary new keyword.\n\nline 76 col 12: Unnecessary new keyword.",
+        "file": "lib/src/multipart_file.dart",
+        "score": 4.41
       },
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
-        "title": "Fix `lib/src/streamed_response.dart`.",
-        "description": "Analysis of `lib/src/streamed_response.dart` reported 3 hints:\n\nline 26 col 35: Use `=` to separate a named parameter from its default value.\n\nline 27 col 23: Use `=` to separate a named parameter from its default value.\n\nline 28 col 33: Use `=` to separate a named parameter from its default value.",
-        "file": "lib/src/streamed_response.dart",
-        "score": 1.49
+        "title": "Fix `lib/src/request.dart`.",
+        "description": "Analysis of `lib/src/request.dart` reported 9 hints, including:\n\nline 24 col 11: Unnecessary new keyword.\n\nline 88 col 22: Unnecessary new keyword.\n\nline 112 col 13: Unnecessary new keyword.\n\nline 122 col 22: Unnecessary new keyword.\n\nline 124 col 13: Unnecessary new keyword.",
+        "file": "lib/src/request.dart",
+        "score": 4.41
       },
       {
         "code": "bulk",
         "level": "hint",
         "title": "Fix additional 14 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files:\n\n- `lib/browser_client.dart` (2 hints)\n- `lib/src/base_client.dart` (2 hints)\n- `lib/src/multipart_request.dart` (1 hint)\n- `lib/http.dart` (Run `dartfmt` to format `lib/http.dart`.)\n- `lib/src/base_request.dart` (Run `dartfmt` to format `lib/src/base_request.dart`.)\n- `lib/src/boundary_characters.dart` (Run `dartfmt` to format `lib/src/boundary_characters.dart`.)\n- `lib/src/byte_stream.dart` (Run `dartfmt` to format `lib/src/byte_stream.dart`.)\n- `lib/src/client.dart` (Run `dartfmt` to format `lib/src/client.dart`.)\n- `lib/src/io_client.dart` (Run `dartfmt` to format `lib/src/io_client.dart`.)\n- `lib/src/mock_client.dart` (Run `dartfmt` to format `lib/src/mock_client.dart`.)\n- `lib/src/multipart_file.dart` (Run `dartfmt` to format `lib/src/multipart_file.dart`.)\n- `lib/src/request.dart` (Run `dartfmt` to format `lib/src/request.dart`.)\n- `lib/src/streamed_request.dart` (Run `dartfmt` to format `lib/src/streamed_request.dart`.)\n- `lib/src/utils.dart` (Run `dartfmt` to format `lib/src/utils.dart`.)\n",
-        "score": 2.5
+        "description": "Additional issues in the following files:\n\n- `lib/src/response.dart` (9 hints)\n- `lib/src/multipart_request.dart` (8 hints)\n- `lib/src/utils.dart` (8 hints)\n- `lib/src/base_request.dart` (7 hints)\n- `lib/src/base_client.dart` (5 hints)\n- `lib/src/base_response.dart` (5 hints)\n- `lib/src/byte_stream.dart` (5 hints)\n- `lib/src/io_client.dart` (4 hints)\n- `lib/src/mock_client.dart` (4 hints)\n- `lib/src/streamed_response.dart` (3 hints)\n- `lib/src/streamed_request.dart` (2 hints)\n- `lib/http.dart` (1 hint)\n- `lib/src/boundary_characters.dart` (1 hint)\n- `lib/src/client.dart` (1 hint)\n",
+        "score": 31.129999999999995
       }
     ]
   },
@@ -199,6 +199,33 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/browser_client.dart",
+          "line": 30,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/browser_client.dart",
+          "line": 44,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/browser_client.dart",
+          "line": 51,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "unawaited_futures",
           "file": "lib/browser_client.dart",
           "line": 52,
@@ -208,11 +235,65 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/browser_client.dart",
+          "line": 55,
+          "col": 41,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/browser_client.dart",
+          "line": 56,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/browser_client.dart",
+          "line": 60,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/browser_client.dart",
+          "line": 61,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/browser_client.dart",
+          "line": 71,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "unawaited_futures",
           "file": "lib/browser_client.dart",
           "line": 78,
           "col": 5,
           "description": "`Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/browser_client.dart",
+          "line": 82,
+          "col": 11,
+          "description": "Unnecessary new keyword."
         }
       ],
       "directLibs": [
@@ -373,7 +454,17 @@
       "uri": "package:http/http.dart",
       "size": 7234,
       "isFormatted": false,
-      "codeProblems": [],
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/http.dart",
+          "line": 165,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        }
+      ],
       "directLibs": [
         "dart:async",
         "dart:convert",
@@ -544,6 +635,15 @@
       "codeProblems": [
         {
           "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_client.dart",
+          "line": 155,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
           "errorType": "HINT",
           "errorCode": "DEPRECATED_MEMBER_USE",
           "file": "lib/src/base_client.dart",
@@ -559,6 +659,24 @@
           "line": 165,
           "col": 44,
           "description": "'typed' is deprecated and shouldn't be used."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_client.dart",
+          "line": 167,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_client.dart",
+          "line": 182,
+          "col": 11,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -566,7 +684,71 @@
       "uri": "package:http/src/base_request.dart",
       "size": 4739,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_request.dart",
+          "line": 37,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_request.dart",
+          "line": 86,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_request.dart",
+          "line": 101,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_request.dart",
+          "line": 113,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_request.dart",
+          "line": 118,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_request.dart",
+          "line": 119,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_request.dart",
+          "line": 136,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/base_response.dart": {
       "uri": "package:http/src/base_response.dart",
@@ -599,6 +781,24 @@
           "line": 45,
           "col": 33,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_response.dart",
+          "line": 48,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/base_response.dart",
+          "line": 50,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -606,19 +806,85 @@
       "uri": "package:http/src/boundary_characters.dart",
       "size": 953,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/boundary_characters.dart",
+          "line": 12,
+          "col": 39,
+          "description": "Avoid const keyword."
+        }
+      ]
     },
     "lib/src/byte_stream.dart": {
       "uri": "package:http/src/byte_stream.dart",
       "size": 1391,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/byte_stream.dart",
+          "line": 17,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/byte_stream.dart",
+          "line": 17,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/byte_stream.dart",
+          "line": 21,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/byte_stream.dart",
+          "line": 22,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/byte_stream.dart",
+          "line": 23,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/client.dart": {
       "uri": "package:http/src/client.dart",
       "size": 6152,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/client.dart",
+          "line": 30,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/exception.dart": {
       "uri": "package:http/src/exception.dart",
@@ -630,19 +896,175 @@
       "uri": "package:http/src/io_client.dart",
       "size": 2530,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_client.dart",
+          "line": 23,
+          "col": 52,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_client.dart",
+          "line": 50,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_client.dart",
+          "line": 52,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/io_client.dart",
+          "line": 64,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/mock_client.dart": {
       "uri": "package:http/src/mock_client.dart",
       "size": 3320,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/mock_client.dart",
+          "line": 33,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/mock_client.dart",
+          "line": 43,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/mock_client.dart",
+          "line": 44,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/mock_client.dart",
+          "line": 60,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/multipart_file.dart": {
       "uri": "package:http/src/multipart_file.dart",
       "size": 4431,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_file.dart",
+          "line": 49,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_file.dart",
+          "line": 57,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_file.dart",
+          "line": 58,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_file.dart",
+          "line": 71,
+          "col": 41,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_file.dart",
+          "line": 76,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_file.dart",
+          "line": 93,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_file.dart",
+          "line": 95,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_file.dart",
+          "line": 96,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_file.dart",
+          "line": 106,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/multipart_request.dart": {
       "uri": "package:http/src/multipart_request.dart",
@@ -652,11 +1074,74 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_request.dart",
+          "line": 15,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_request.dart",
+          "line": 40,
+          "col": 33,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "avoid_return_types_on_setters",
           "file": "lib/src/multipart_request.dart",
           "line": 77,
           "col": 3,
           "description": "Avoid return types on setters."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_request.dart",
+          "line": 78,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_request.dart",
+          "line": 90,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_request.dart",
+          "line": 118,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_request.dart",
+          "line": 159,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/multipart_request.dart",
+          "line": 163,
+          "col": 22,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -664,7 +1149,89 @@
       "uri": "package:http/src/request.dart",
       "size": 5952,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/request.dart",
+          "line": 24,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/request.dart",
+          "line": 88,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/request.dart",
+          "line": 112,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/request.dart",
+          "line": 122,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/request.dart",
+          "line": 124,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/request.dart",
+          "line": 134,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/request.dart",
+          "line": 141,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/request.dart",
+          "line": 149,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/request.dart",
+          "line": 159,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/response.dart": {
       "uri": "package:http/src/response.dart",
@@ -724,6 +1291,33 @@
           "line": 54,
           "col": 33,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/response.dart",
+          "line": 70,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/response.dart",
+          "line": 93,
+          "col": 35,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/response.dart",
+          "line": 94,
+          "col": 10,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -731,7 +1325,26 @@
       "uri": "package:http/src/streamed_request.dart",
       "size": 1650,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/streamed_request.dart",
+          "line": 31,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/streamed_request.dart",
+          "line": 39,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/src/streamed_response.dart": {
       "uri": "package:http/src/streamed_response.dart",
@@ -771,7 +1384,80 @@
       "uri": "package:http/src/utils.dart",
       "size": 4843,
       "isFormatted": false,
-      "codeProblems": []
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/utils.dart",
+          "line": 56,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/utils.dart",
+          "line": 61,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/utils.dart",
+          "line": 74,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/utils.dart",
+          "line": 76,
+          "col": 10,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/utils.dart",
+          "line": 83,
+          "col": 10,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/utils.dart",
+          "line": 90,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/utils.dart",
+          "line": 99,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/utils.dart",
+          "line": 113,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        }
+      ]
     },
     "lib/testing.dart": {
       "uri": "package:http/testing.dart",

--- a/test/end2end/pub_server-0.1.4-2.json
+++ b/test/end2end/pub_server-0.1.4-2.json
@@ -54,16 +54,24 @@
     "resolveProcessFailed": false,
     "analyzerErrorCount": 0,
     "analyzerWarningCount": 0,
-    "analyzerHintCount": 4,
+    "analyzerHintCount": 39,
     "platformConflictCount": 0,
     "suggestions": [
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
         "title": "Fix `lib/shelf_pubserver.dart`.",
-        "description": "Analysis of `lib/shelf_pubserver.dart` reported 4 hints:\n\nline 245 col 9: Use isEmpty instead of length\n\nline 414 col 53: Use isNotEmpty instead of length\n\nline 470 col 62: Use `=` to separate a named parameter from its default value.\n\nline 475 col 53: Use `=` to separate a named parameter from its default value.",
+        "description": "Analysis of `lib/shelf_pubserver.dart` reported 31 hints, including:\n\nline 19 col 24: Unnecessary new keyword.\n\nline 131 col 40: Unnecessary new keyword.\n\nline 134 col 7: Unnecessary new keyword.\n\nline 137 col 7: Unnecessary new keyword.\n\nline 140 col 7: Unnecessary new keyword.",
         "file": "lib/shelf_pubserver.dart",
-        "score": 1.99
+        "score": 14.39
+      },
+      {
+        "code": "dartanalyzer.warning",
+        "level": "hint",
+        "title": "Fix `lib/repository.dart`.",
+        "description": "Analysis of `lib/repository.dart` reported 8 hints, including:\n\nline 27 col 15: Unnecessary new keyword.\n\nline 109 col 7: Unnecessary new keyword.\n\nline 130 col 13: Unnecessary new keyword.\n\nline 144 col 13: Unnecessary new keyword.\n\nline 148 col 13: Unnecessary new keyword.",
+        "file": "lib/repository.dart",
+        "score": 3.93
       }
     ]
   },
@@ -226,7 +234,80 @@
       "uri": "package:pub_server/repository.dart",
       "size": 5615,
       "isFormatted": true,
-      "codeProblems": [],
+      "codeProblems": [
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/repository.dart",
+          "line": 27,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/repository.dart",
+          "line": 109,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/repository.dart",
+          "line": 130,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/repository.dart",
+          "line": 144,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/repository.dart",
+          "line": 148,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/repository.dart",
+          "line": 158,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/repository.dart",
+          "line": 165,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/repository.dart",
+          "line": 169,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        }
+      ],
       "directLibs": [
         "dart:async",
         "package:pub_semver/pub_semver.dart"
@@ -280,11 +361,182 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 19,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 131,
+          "col": 40,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 134,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 137,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 140,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 143,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 177,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 189,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 201,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 208,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 221,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 231,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_is_empty",
           "file": "lib/shelf_pubserver.dart",
           "line": 245,
           "col": 9,
           "description": "Use isEmpty instead of length"
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 246,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 286,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 304,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 308,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 372,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 390,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 394,
+          "col": 14,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -298,6 +550,33 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 451,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 458,
+          "col": 44,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 464,
+          "col": 49,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "lib/shelf_pubserver.dart",
           "line": 470,
@@ -307,11 +586,56 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 471,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 472,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "lib/shelf_pubserver.dart",
           "line": 475,
           "col": 53,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 476,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 505,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/shelf_pubserver.dart",
+          "line": 523,
+          "col": 19,
+          "description": "Unnecessary new keyword."
         }
       ],
       "directLibs": [

--- a/test/end2end/stream-2.0.1.json
+++ b/test/end2end/stream-2.0.1.json
@@ -52,39 +52,39 @@
     "resolveProcessFailed": false,
     "analyzerErrorCount": 1,
     "analyzerWarningCount": 0,
-    "analyzerHintCount": 495,
+    "analyzerHintCount": 645,
     "platformConflictCount": 0,
     "suggestions": [
       {
         "code": "dartanalyzer.warning",
         "level": "error",
         "title": "Fix `lib/src/rsp_util.dart`.",
-        "description": "Analysis of `lib/src/rsp_util.dart` failed with 1 error, 22 hints, including:\n\nline 170 col 47: The getter 'dart' isn't defined for the class 'Browser'.\n\nline 6 col 1: Prefer using /// for doc comments.\n\nline 12 col 3: Prefer using /// for doc comments.\n\nline 25 col 34: Use `isNotEmpty` for Iterables and Maps.\n\nline 26 col 9: DO use curly braces for all flow control structures.",
+        "description": "Analysis of `lib/src/rsp_util.dart` failed with 1 error, 24 hints, including:\n\nline 170 col 47: The getter 'dart' isn't defined for the class 'Browser'.\n\nline 6 col 1: Prefer using /// for doc comments.\n\nline 12 col 3: Prefer using /// for doc comments.\n\nline 25 col 34: Use `isNotEmpty` for Iterables and Maps.\n\nline 26 col 9: DO use curly braces for all flow control structures.",
         "file": "lib/src/rsp_util.dart",
-        "score": 32.83
+        "score": 33.5
       },
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
         "title": "Fix `lib/src/rspc/compiler.dart`.",
-        "description": "Analysis of `lib/src/rspc/compiler.dart` reported 100 hints, including:\n\nline 6 col 1: Prefer using /// for doc comments.\n\nline 30 col 59: Use `=` to separate a named parameter from its default value.\n\nline 31 col 19: Use `=` to separate a named parameter from its default value.\n\nline 31 col 43: Use `=` to separate a named parameter from its default value.\n\nline 44 col 7: DO use curly braces for all flow control structures.",
+        "description": "Analysis of `lib/src/rspc/compiler.dart` reported 118 hints, including:\n\nline 6 col 1: Prefer using /// for doc comments.\n\nline 30 col 59: Use `=` to separate a named parameter from its default value.\n\nline 31 col 19: Use `=` to separate a named parameter from its default value.\n\nline 31 col 43: Use `=` to separate a named parameter from its default value.\n\nline 35 col 29: Unnecessary new keyword.",
         "file": "lib/src/rspc/compiler.dart",
-        "score": 39.42
+        "score": 44.65
       },
       {
         "code": "dartanalyzer.warning",
         "level": "hint",
         "title": "Fix `lib/src/plugin/router.dart`.",
-        "description": "Analysis of `lib/src/plugin/router.dart` reported 57 hints, including:\n\nline 6 col 1: Prefer using /// for doc comments.\n\nline 10 col 3: Prefer using /// for doc comments.\n\nline 19 col 43: Use `=` to separate a named parameter from its default value.\n\nline 20 col 3: Prefer using /// for doc comments.\n\nline 28 col 59: Use `=` to separate a named parameter from its default value.",
+        "description": "Analysis of `lib/src/plugin/router.dart` reported 80 hints, including:\n\nline 6 col 1: Prefer using /// for doc comments.\n\nline 10 col 3: Prefer using /// for doc comments.\n\nline 19 col 43: Use `=` to separate a named parameter from its default value.\n\nline 20 col 3: Prefer using /// for doc comments.\n\nline 28 col 59: Use `=` to separate a named parameter from its default value.",
         "file": "lib/src/plugin/router.dart",
-        "score": 24.85
+        "score": 33.04
       },
       {
         "code": "bulk",
         "level": "hint",
         "title": "Fix additional 14 files with analysis or formatting issues.",
-        "description": "Additional issues in the following files:\n\n- `lib/src/rspc/tag.dart` (52 hints)\n- `lib/src/server.dart` (43 hints)\n- `lib/src/server_impl.dart` (39 hints)\n- `lib/src/plugin/loader.dart` (35 hints)\n- `lib/src/rspc/tag_util.dart` (31 hints)\n- `lib/src/connect.dart` (30 hints)\n- `lib/src/rspc/build.dart` (26 hints)\n- `lib/src/connect_impl.dart` (24 hints)\n- `lib/src/plugin/loader_impl.dart` (19 hints)\n- `lib/src/rspc/main.dart` (9 hints)\n- `lib/proxy.dart` (5 hints)\n- `lib/plugin.dart` (1 hint)\n- `lib/rspc.dart` (1 hint)\n- `lib/stream.dart` (1 hint)\n",
-        "score": 145.56000000000003
+        "description": "Additional issues in the following files:\n\n- `lib/src/rspc/tag.dart` (71 hints)\n- `lib/src/server_impl.dart` (60 hints)\n- `lib/src/server.dart` (46 hints)\n- `lib/src/plugin/loader.dart` (45 hints)\n- `lib/src/connect_impl.dart` (38 hints)\n- `lib/src/rspc/build.dart` (36 hints)\n- `lib/src/rspc/tag_util.dart` (36 hints)\n- `lib/src/connect.dart` (34 hints)\n- `lib/src/plugin/loader_impl.dart` (32 hints)\n- `lib/src/rspc/main.dart` (13 hints)\n- `lib/proxy.dart` (9 hints)\n- `lib/plugin.dart` (1 hint)\n- `lib/rspc.dart` (1 hint)\n- `lib/stream.dart` (1 hint)\n",
+        "score": 189.76999999999998
       }
     ]
   },
@@ -205,7 +205,7 @@
         "package": "pedantic",
         "dependencyType": "transitive",
         "constraintType": "inherited",
-        "resolved": "1.7.0"
+        "resolved": "1.8.0+1"
       },
       {
         "package": "rikulo_commons",
@@ -328,6 +328,33 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/proxy.dart",
+          "line": 38,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/proxy.dart",
+          "line": 41,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/proxy.dart",
+          "line": 49,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/proxy.dart",
           "line": 53,
@@ -369,6 +396,15 @@
           "line": 141,
           "col": 46,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/proxy.dart",
+          "line": 142,
+          "col": 19,
+          "description": "Unnecessary new keyword."
         }
       ],
       "directLibs": [
@@ -686,11 +722,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect.dart",
+          "line": 111,
+          "col": 6,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "slash_for_doc_comments",
           "file": "lib/src/connect.dart",
           "line": 112,
           "col": 3,
           "description": "Prefer using /// for doc comments."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect.dart",
+          "line": 116,
+          "col": 6,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -709,6 +763,24 @@
           "line": 125,
           "col": 65,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect.dart",
+          "line": 128,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect.dart",
+          "line": 129,
+          "col": 7,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -873,6 +945,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 18,
+          "col": 38,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 20,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/connect_impl.dart",
           "line": 33,
@@ -891,6 +981,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 102,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 117,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_is_not_empty",
           "file": "lib/src/connect_impl.dart",
           "line": 122,
@@ -900,11 +1008,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 123,
+          "col": 32,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/connect_impl.dart",
           "line": 125,
           "col": 13,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 136,
+          "col": 65,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -936,6 +1062,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 203,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 208,
+          "col": 9,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "avoid_return_types_on_setters",
           "file": "lib/src/connect_impl.dart",
           "line": 261,
@@ -954,11 +1098,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 267,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "lib/src/connect_impl.dart",
           "line": 272,
           "col": 49,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 273,
+          "col": 11,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1071,6 +1233,33 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 352,
+          "col": 10,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 352,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 357,
+          "col": 59,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/connect_impl.dart",
           "line": 364,
@@ -1085,6 +1274,15 @@
           "line": 366,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/connect_impl.dart",
+          "line": 373,
+          "col": 34,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -1101,6 +1299,15 @@
           "line": 6,
           "col": 1,
           "description": "Prefer using /// for doc comments."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader.dart",
+          "line": 20,
+          "col": 6,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1213,6 +1420,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader.dart",
+          "line": 127,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "slash_for_doc_comments",
           "file": "lib/src/plugin/loader.dart",
           "line": 133,
@@ -1285,6 +1501,33 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader.dart",
+          "line": 205,
+          "col": 6,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader.dart",
+          "line": 205,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader.dart",
+          "line": 212,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/loader.dart",
           "line": 214,
@@ -1294,11 +1537,38 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader.dart",
+          "line": 214,
+          "col": 33,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader.dart",
+          "line": 216,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/loader.dart",
           "line": 217,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader.dart",
+          "line": 219,
+          "col": 11,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1330,6 +1600,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader.dart",
+          "line": 248,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/loader.dart",
           "line": 256,
@@ -1344,6 +1623,15 @@
           "line": 259,
           "col": 5,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader.dart",
+          "line": 264,
+          "col": 7,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1418,6 +1706,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 35,
+          "col": 43,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/loader_impl.dart",
           "line": 56,
@@ -1436,6 +1733,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 71,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/loader_impl.dart",
           "line": 76,
@@ -1450,6 +1756,33 @@
           "line": 84,
           "col": 5,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 84,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 86,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 88,
+          "col": 26,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1486,6 +1819,33 @@
           "line": 129,
           "col": 5,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 160,
+          "col": 40,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_const",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 165,
+          "col": 29,
+          "description": "Avoid const keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 183,
+          "col": 12,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1535,6 +1895,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 220,
+          "col": 30,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_is_not_empty",
           "file": "lib/src/plugin/loader_impl.dart",
           "line": 223,
@@ -1549,6 +1918,15 @@
           "line": 224,
           "col": 9,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 231,
+          "col": 26,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1571,11 +1949,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 250,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/loader_impl.dart",
           "line": 277,
           "col": 9,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 298,
+          "col": 12,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1585,6 +1981,15 @@
           "line": 299,
           "col": 7,
           "description": "This function has a return type of 'Future', but doesn't end with a return statement."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/loader_impl.dart",
+          "line": 314,
+          "col": 12,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -1668,6 +2073,33 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 55,
+          "col": 42,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 58,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 61,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "slash_for_doc_comments",
           "file": "lib/src/plugin/router.dart",
           "line": 63,
@@ -1722,6 +2154,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 81,
+          "col": 23,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/router.dart",
           "line": 85,
@@ -1754,6 +2195,24 @@
           "line": 94,
           "col": 13,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 94,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 96,
+          "col": 17,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1794,11 +2253,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 113,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/router.dart",
           "line": 115,
           "col": 11,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 115,
+          "col": 17,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1830,6 +2307,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 134,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "slash_for_doc_comments",
           "file": "lib/src/plugin/router.dart",
           "line": 140,
@@ -1857,6 +2343,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 150,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/router.dart",
           "line": 157,
@@ -1871,6 +2366,15 @@
           "line": 163,
           "col": 11,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 169,
+          "col": 17,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1916,6 +2420,15 @@
           "line": 202,
           "col": 11,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 212,
+          "col": 18,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -1974,11 +2487,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 251,
+          "col": 53,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/router.dart",
           "line": 273,
           "col": 9,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 273,
+          "col": 15,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2010,6 +2541,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 296,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 298,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_is_not_empty",
           "file": "lib/src/plugin/router.dart",
           "line": 308,
@@ -2037,11 +2586,47 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 334,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 338,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 341,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/router.dart",
           "line": 360,
           "col": 13,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 366,
+          "col": 24,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2073,6 +2658,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 400,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/router.dart",
           "line": 405,
@@ -2100,11 +2694,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 448,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/plugin/router.dart",
           "line": 452,
           "col": 9,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/plugin/router.dart",
+          "line": 459,
+          "col": 56,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -2206,6 +2818,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rsp_util.dart",
+          "line": 59,
+          "col": 46,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "slash_for_doc_comments",
           "file": "lib/src/rsp_util.dart",
           "line": 61,
@@ -2274,6 +2895,15 @@
           "line": 127,
           "col": 3,
           "description": "Prefer using /// for doc comments."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rsp_util.dart",
+          "line": 131,
+          "col": 36,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2366,6 +2996,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/build.dart",
+          "line": 14,
+          "col": 3,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "slash_for_doc_comments",
           "file": "lib/src/rspc/build.dart",
           "line": 19,
@@ -2411,6 +3050,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/build.dart",
+          "line": 34,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/build.dart",
+          "line": 47,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "unawaited_futures",
           "file": "lib/src/rspc/build.dart",
           "line": 84,
@@ -2429,6 +3086,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/build.dart",
+          "line": 98,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/build.dart",
+          "line": 101,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/build.dart",
           "line": 102,
@@ -2438,11 +3113,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/build.dart",
+          "line": 103,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/build.dart",
           "line": 111,
           "col": 5,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/build.dart",
+          "line": 112,
+          "col": 15,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2461,6 +3154,15 @@
           "line": 114,
           "col": 5,
           "description": "`Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/build.dart",
+          "line": 116,
+          "col": 10,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2483,6 +3185,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/build.dart",
+          "line": 131,
+          "col": 31,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/build.dart",
           "line": 146,
@@ -2497,6 +3208,15 @@
           "line": 152,
           "col": 9,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/build.dart",
+          "line": 161,
+          "col": 26,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2607,6 +3327,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 35,
+          "col": 29,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/compiler.dart",
           "line": 44,
@@ -2652,6 +3381,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 81,
+          "col": 26,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/compiler.dart",
           "line": 99,
@@ -2666,6 +3404,15 @@
           "line": 113,
           "col": 15,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 126,
+          "col": 20,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2715,6 +3462,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 168,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/compiler.dart",
           "line": 171,
@@ -2747,6 +3503,15 @@
           "line": 176,
           "col": 11,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 184,
+          "col": 18,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -2877,6 +3642,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 238,
+          "col": 59,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/compiler.dart",
           "line": 240,
@@ -3003,6 +3777,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 360,
+          "col": 16,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/compiler.dart",
           "line": 363,
@@ -3039,11 +3822,29 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 382,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/compiler.dart",
           "line": 395,
           "col": 21,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 397,
+          "col": 26,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -3147,6 +3948,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 524,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/compiler.dart",
           "line": 526,
@@ -3237,11 +4047,47 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 571,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 577,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/compiler.dart",
           "line": 580,
           "col": 9,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 589,
+          "col": 24,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 589,
+          "col": 54,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -3336,6 +4182,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 656,
+          "col": 19,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/compiler.dart",
           "line": 662,
@@ -3417,6 +4272,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 708,
+          "col": 11,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 721,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/compiler.dart",
           "line": 803,
@@ -3467,6 +4340,15 @@
           "line": 821,
           "col": 17,
           "description": "Avoid empty catch blocks."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/compiler.dart",
+          "line": 831,
+          "col": 24,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -3532,6 +4414,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/main.dart",
+          "line": 34,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/main.dart",
           "line": 36,
@@ -3541,11 +4432,38 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/main.dart",
+          "line": 38,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/main.dart",
+          "line": 46,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "unawaited_futures",
           "file": "lib/src/rspc/main.dart",
           "line": 60,
           "col": 7,
           "description": "`Future` results in `async` function bodies must be `await`ed or marked `unawaited` using `package:pedantic`."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/main.dart",
+          "line": 68,
+          "col": 21,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -3665,6 +4583,132 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 106,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 107,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 107,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 107,
+          "col": 52,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 108,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 108,
+          "col": 25,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 108,
+          "col": 43,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 109,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 109,
+          "col": 22,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 109,
+          "col": 39,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 110,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 110,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 110,
+          "col": 37,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 110,
+          "col": 50,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/tag.dart",
           "line": 111,
@@ -3746,6 +4790,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 228,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 229,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/tag.dart",
           "line": 236,
@@ -3791,6 +4853,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 269,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 270,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/tag.dart",
           "line": 277,
@@ -3814,6 +4894,15 @@
           "line": 287,
           "col": 1,
           "description": "Prefer using /// for doc comments."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag.dart",
+          "line": 293,
+          "col": 21,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -4095,6 +5184,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 36,
+          "col": 14,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/tag_util.dart",
           "line": 43,
@@ -4145,6 +5243,15 @@
           "line": 57,
           "col": 5,
           "description": "Use contains instead of indexOf"
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 79,
+          "col": 9,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -4275,6 +5382,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 198,
+          "col": 20,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/rspc/tag_util.dart",
           "line": 202,
@@ -4289,6 +5405,15 @@
           "line": 205,
           "col": 11,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 209,
+          "col": 12,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -4316,6 +5441,15 @@
           "line": 250,
           "col": 13,
           "description": "Don't type annotate initializing formals."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/rspc/tag_util.dart",
+          "line": 256,
+          "col": 24,
+          "description": "Unnecessary new keyword."
         }
       ]
     },
@@ -4354,6 +5488,24 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server.dart",
+          "line": 97,
+          "col": 6,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server.dart",
+          "line": 98,
+          "col": 7,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "slash_for_doc_comments",
           "file": "lib/src/server.dart",
           "line": 102,
@@ -4368,6 +5520,15 @@
           "line": 106,
           "col": 22,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server.dart",
+          "line": 107,
+          "col": 6,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -4721,11 +5882,47 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 33,
+          "col": 12,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 46,
+          "col": 10,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/server_impl.dart",
           "line": 47,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 47,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 48,
+          "col": 18,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -4744,6 +5941,24 @@
           "line": 69,
           "col": 9,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 76,
+          "col": 28,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 82,
+          "col": 28,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -4784,6 +5999,33 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 119,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 130,
+          "col": 27,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 136,
+          "col": 17,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/server_impl.dart",
           "line": 150,
@@ -4798,6 +6040,15 @@
           "line": 157,
           "col": 9,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 179,
+          "col": 30,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -4874,6 +6125,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 226,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "avoid_return_types_on_setters",
           "file": "lib/src/server_impl.dart",
           "line": 236,
@@ -4888,6 +6148,15 @@
           "line": 238,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 238,
+          "col": 13,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -4964,6 +6233,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 268,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "lib/src/server_impl.dart",
           "line": 275,
@@ -5027,6 +6305,15 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 285,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "prefer_equal_for_default_values",
           "file": "lib/src/server_impl.dart",
           "line": 298,
@@ -5036,11 +6323,65 @@
         {
           "severity": "INFO",
           "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 299,
+          "col": 21,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 300,
+          "col": 15,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 323,
+          "col": 18,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 326,
+          "col": 35,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
           "errorCode": "curly_braces_in_flow_control_structures",
           "file": "lib/src/server_impl.dart",
           "line": 371,
           "col": 7,
           "description": "DO use curly braces for all flow control structures."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 371,
+          "col": 13,
+          "description": "Unnecessary new keyword."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 372,
+          "col": 30,
+          "description": "Unnecessary new keyword."
         },
         {
           "severity": "INFO",
@@ -5068,6 +6409,15 @@
           "line": 383,
           "col": 59,
           "description": "Use `=` to separate a named parameter from its default value."
+        },
+        {
+          "severity": "INFO",
+          "errorType": "LINT",
+          "errorCode": "unnecessary_new",
+          "file": "lib/src/server_impl.dart",
+          "line": 392,
+          "col": 29,
+          "description": "Unnecessary new keyword."
         }
       ]
     },


### PR DESCRIPTION
- Fixes CI tests (which auto-upgrades the dependencies including `package:analyzer`).
- We can't upgrade to 0.37.0 yet because json_serializable does not support it yet.