### PR TITLE
Draft of a step abstraction

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -201,7 +201,7 @@ class Suggestion implements Comparable<Suggestion> {
 
   /// The potential score gain if the suggestion is applied and the issue gets
   /// fixed in the package. Values are between 0.0 and 100.0.
-  final double score;
+  final double score; // TODO: Change this to penalty in range [0.0 - 1.0]
 
   Suggestion(
     this.code,

--- a/lib/src/steps/common/changelog.dart
+++ b/lib/src/steps/common/changelog.dart
@@ -1,0 +1,78 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert' show utf8;
+import 'package:file/file.dart' show File;
+import 'package:source_span/source_span.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import '../step.dart';
+
+final _changelogFilePattern = RegExp(r'^CHANGELOG($|\.)', caseSensitive: false);
+
+/// The changelog [Step] will check that:
+///  1. A changelog file exists,
+///  2. The changelog is valid UTF-8 encoded,
+///  3. The changelog mentioned the current version.
+final changelog = Step('changelog', (ctx) async {
+  // Find the changelog file
+  final changelogFile = await ctx.packageFolder.list().firstWhere(
+        (e) => e is File && _changelogFilePattern.hasMatch(e.basename),
+        orElse: () => null,
+      ) as File;
+  // If there is no changelog file, then we'll leave a hint and be done.
+  if (changelogFile == null) {
+    BreakStep.hint(
+      kind: 'changelog-not-found',
+      title: 'CHANGELOG.md missing',
+      description: 'Consider including a `CHANGELOG.md` file outlining the '
+          'changes from one version to the next.',
+      penalty: 0.1,
+    );
+  }
+
+  final pubspecFile = ctx.packageFolder.childFile('pubspec.yaml');
+  if (!await pubspecFile.exists()) {
+    return; // Someone else will handle this
+  }
+  final pubspec = Pubspec.parse(
+    await pubspecFile.readAsString(),
+    lenient: true,
+    sourceUrl: pubspecFile.path,
+  );
+
+  // Read the changelog file
+  final changelogBytes = await changelogFile.readAsBytes();
+  String changelog;
+  try {
+    changelog = utf8.decode(changelogBytes);
+  } on FormatException {
+    ctx.add.warning(
+      kind: 'changelog-encoding',
+      title: 'Changelog encoding',
+      description: 'Use utf8 encoding for `${changelogFile.basename}`',
+      location: SourceFile.decoded(
+        changelogBytes,
+        url: changelogFile.path,
+      ).span(0),
+      penalty: 0.5,
+    );
+    // Do a best effort decoding and continue
+    changelog = utf8.decode(changelogBytes, allowMalformed: true);
+  }
+
+  if (!changelog.contains(pubspec.version.toString())) {
+    final f = SourceFile.fromString(
+      changelog,
+      url: changelogFile.path,
+    );
+    ctx.add.hint(
+      kind: 'changelog-entry-missing',
+      title: 'Changelog entry missing',
+      description: 'The changelog in `${changelogFile.basename}` is missing an '
+          'entry for the current version `${pubspec.version}`',
+      location: f.span(0, 0),
+      penalty: 0.1,
+    );
+  }
+});

--- a/lib/src/steps/result.dart
+++ b/lib/src/steps/result.dart
@@ -1,0 +1,312 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection' show UnmodifiableListView;
+import 'dart:math' show min, max;
+
+import 'package:collection/collection.dart' show UnmodifiableSetView;
+import 'package:source_span/source_span.dart';
+import 'package:meta/meta.dart' show required, sealed;
+
+import '../model.dart' show Suggestion, SuggestionLevel;
+import 'run.dart' show run;
+import 'step.dart' show Step;
+import 'tags.dart';
+
+/// Data class for holding all analysis results.
+@sealed
+class Result {
+  final Set<String> tags;
+  final List<Suggestion> suggestions;
+
+  Result._({
+    this.tags,
+    this.suggestions,
+  });
+}
+
+@sealed
+class ResultBuilder {
+  final String _suggestionCodePrefix;
+  final List<Suggestion> _suggestions = [];
+  final Set<String> _tags = {};
+
+  ResultBuilder(this._suggestionCodePrefix);
+
+  /// Create a _suggestion_ with severity **error**.
+  ///
+  /// Severity **error** should be used when:
+  ///  * An issue _will_ casuse problems for users of the package,
+  ///  * The package is fundamentally broken,
+  ///  * The issue is to sever to warrent a [warning] or [hint].
+  ///
+  /// **Examples** include:
+  ///  * Static code errors,
+  ///  * Missing dependencies.
+  ///
+  /// A suggestion have following parameters:
+  ///  * [kind], (optional) kind identifier for statistics and grouping,
+  ///  * [title], a human-readable title for the suggestion,
+  ///  * [description], a human-readable markdown description of the suggestion,
+  ///  * [location], (optional) span of source code that caused this suggestion,
+  ///  * [penalty], (optional) penalty for package score ranging from 0 to 1.
+  void error({
+    String kind,
+    @required String title,
+    @required String description,
+    SourceSpan location,
+    double penalty = 0,
+  }) =>
+      _addSuggestion(
+        kind,
+        SuggestionLevel.error,
+        title,
+        description,
+        location,
+        penalty,
+      );
+
+  /// Create a _suggestion_ with severity **warning**.
+  ///
+  /// Severity **warning** should be used when:
+  ///  * An issue _may_ cause problems for users of the package,
+  ///  * An issue _will_ seriously impair usability of the package,
+  ///  * The issue doesn't qualify as [error], and is worse than an [hint].
+  ///
+  /// **Examples** include:
+  ///  * Out-dated dependencies,
+  ///  * Version pinning,
+  ///  * Unawaited futures,
+  ///  * Missing `README.md`.
+  ///
+  /// A suggestion have following parameters:
+  ///  * [kind], (optional) kind identifier for statistics and grouping,
+  ///  * [title], a human-readable title for the suggestion,
+  ///  * [description], a human-readable markdown description of the suggestion,
+  ///  * [location], (optional) span of source code that caused this suggestion,
+  ///  * [penalty], (optional) penalty for package score ranging from 0 to 1.
+  void warning({
+    String kind,
+    @required String title,
+    @required String description,
+    SourceSpan location,
+    double penalty = 0,
+  }) =>
+      _addSuggestion(
+        kind,
+        SuggestionLevel.warning,
+        title,
+        description,
+        location,
+        penalty,
+      );
+
+  /// Create a _suggestion_ with severity **hint**.
+  ///
+  /// Severity **hint** should be used when:
+  ///  * An issue may impair usability for users of the package,
+  ///  * The packages does not follow best practices,
+  ///  * The issue doesn't qualify as [warning] or [error].
+  ///
+  /// **Examples** include:
+  ///  * Few documentation comments,
+  ///  * Poorly named variables.
+  ///
+  /// A suggestion have following parameters:
+  ///  * [kind], (optional) kind identifier for statistics and grouping,
+  ///  * [title], a human-readable title for the suggestion,
+  ///  * [description], a human-readable markdown description of the suggestion,
+  ///  * [location], (optional) span of source code that caused this suggestion,
+  ///  * [penalty], (optional) penalty for package score ranging from 0 to 1.
+  void hint({
+    String kind,
+    @required String title,
+    @required String description,
+    SourceSpan location,
+    double penalty = 0,
+  }) =>
+      _addSuggestion(
+        kind,
+        SuggestionLevel.hint,
+        title,
+        description,
+        location,
+        penalty,
+      );
+
+  void _addSuggestion(
+    String kind,
+    String level,
+    String title,
+    String description,
+    SourceSpan loc,
+    double penalty,
+  ) {
+    ArgumentError.checkNotNull(title, 'title');
+    ArgumentError.checkNotNull(description, 'decription');
+    ArgumentError.checkNotNull(penalty, 'penalty');
+    if (title.isEmpty) {
+      throw ArgumentError.value(title, 'title', 'cannot be an empty string');
+    }
+    if (description.isEmpty) {
+      throw ArgumentError.value(
+          description, 'description', 'cannot be an empty string');
+    }
+
+    // We don't want production errors because penalty is out-of-range, instead
+    // we just limit to the range and have an assert that it's in our range.
+    assert(0.0 <= penalty && penalty <= 1.0);
+    penalty = min(max(penalty, 1.0), 0.0);
+
+    _suggestions.add(Suggestion(
+      kind != null ? '$_suggestionCodePrefix.$kind' : _suggestionCodePrefix,
+      level,
+      title,
+      description,
+      file: loc?.sourceUrl?.path,
+      score: 100 - (penalty * 100),
+    ));
+  }
+
+  /// Add [tag] to the result for the current package.
+  ///
+  /// On `pub.dev` package search queries can be filter by tags, such that it is
+  /// possible to limit a search query to packages with a given tag. Or exclude
+  /// packages which has a given tag.
+  ///
+  /// Tags must match a [TagPattern] registered in [tagPatterns], this ensures
+  /// that all tags are documented, and prevents the namespace from overlapping.
+  void tag(String tag) {
+    if (!isValidTag(tag)) {
+      throw ArgumentError.value(
+          tag, 'tag', 'tag is invalid, ensure the pattern is registered');
+    }
+    _tags.add(tag);
+  }
+
+  /// Create a [Result] from a list of [builders].
+  static Result build(Iterable<ResultBuilder> builders) {
+    return Result._(
+      tags: UnmodifiableSetView(builders
+          .map((b) => b._tags)
+          .reduce((s1, s2) => {...s1, ...s2})
+          .toSet()),
+      suggestions: UnmodifiableListView(
+        builders
+            .map((b) => b._suggestions)
+            .reduce((s1, s2) => [...s1, ...s2])
+            .toSet()
+            .toList(),
+      ),
+    );
+  }
+}
+
+/// The [BreakStep] exception can be thrown from an [Step] to abort analysis.
+///
+/// If the [Step] was invoked from [run] the suggestion from the [BreakStep]
+/// exception will be added to the [ResultBuilder]. This is a convinient way to
+/// report a suggestion and return in a single statement, that even works from
+/// an auxiliary method.
+///
+/// Step authors can also catch a [BreakStep] exception from a utility function
+/// and either report it with [report], `rethrow` or ignore it. When caught
+/// step authors can use the [kind] to determine which action to take.
+class BreakStep implements Exception {
+  final String kind;
+  final String _level;
+  final String _title;
+  final String _description;
+  final SourceSpan _loc;
+  final double _penalty;
+
+  BreakStep._({
+    this.kind,
+    String level,
+    @required String title,
+    @required String description,
+    SourceSpan location,
+    double penalty = 0,
+  })  : _title = title,
+        _level = level,
+        _description = description,
+        _loc = location,
+        _penalty = penalty {
+    ArgumentError.checkNotNull(title, 'title');
+    ArgumentError.checkNotNull(description, 'decription');
+    ArgumentError.checkNotNull(penalty, 'penalty');
+    if (title.isEmpty) {
+      throw ArgumentError.value(title, 'title', 'cannot be an empty string');
+    }
+    if (description.isEmpty) {
+      throw ArgumentError.value(
+          description, 'description', 'cannot be an empty string');
+    }
+
+    // We don't want production errors because penalty is out-of-range, instead
+    // we just limit to the range and have an assert that it's in our range.
+    assert(0.0 <= penalty && penalty <= 1.0);
+  }
+
+  /// Throw a [BreakStep] with a suggestion for [ResultBuilder.error].
+  static void error({
+    String kind,
+    @required String title,
+    @required String description,
+    SourceSpan location,
+    double penalty = 0,
+  }) =>
+      throw BreakStep._(
+        kind: kind,
+        level: SuggestionLevel.error,
+        title: title,
+        description: description,
+        location: location,
+        penalty: penalty,
+      );
+
+  /// Throw a [BreakStep] with a suggestion for [ResultBuilder.warning].
+  static void warning({
+    String kind,
+    @required String title,
+    @required String description,
+    SourceSpan location,
+    double penalty = 0,
+  }) =>
+      throw BreakStep._(
+        kind: kind,
+        level: SuggestionLevel.warning,
+        title: title,
+        description: description,
+        location: location,
+        penalty: penalty,
+      );
+
+  /// Throw a [BreakStep] with a suggestion for [ResultBuilder.hint].
+  static void hint({
+    String kind,
+    @required String title,
+    @required String description,
+    SourceSpan location,
+    double penalty = 0,
+  }) =>
+      throw BreakStep._(
+        kind: kind,
+        level: SuggestionLevel.hint,
+        title: title,
+        description: description,
+        location: location,
+        penalty: penalty,
+      );
+
+  /// Add this suggestion to [resultBuilder].
+  void report(ResultBuilder resultBuilder) => resultBuilder._addSuggestion(
+        kind,
+        _level,
+        _title,
+        _description,
+        _loc,
+        _penalty,
+      );
+}

--- a/lib/src/steps/run.dart
+++ b/lib/src/steps/run.dart
@@ -1,0 +1,46 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection' show UnmodifiableListView;
+import 'package:file/chroot.dart' show ChrootFileSystem;
+import 'package:file/local.dart' show LocalFileSystem;
+
+import 'common/changelog.dart' show changelog;
+import 'result.dart' show ResultBuilder, Result, BreakStep;
+import 'step.dart';
+
+/// List of all steps from `common/` and `flutter/`.
+final List<Step> steps = UnmodifiableListView([
+  changelog,
+]);
+
+/// Run [steps] on [packageFolder] and return [Result].
+Future<Result> run(
+  String packageFolder,
+  Iterable<Step> steps,
+) async {
+  ArgumentError.checkNotNull(packageFolder, 'packageFolder');
+  ArgumentError.checkNotNull(steps, 'steps');
+
+  final packageFs = ChrootFileSystem(const LocalFileSystem(), packageFolder);
+
+  try {
+    final rbs = <ResultBuilder>[];
+    for (final step in steps) {
+      final rb = ResultBuilder(step.name);
+      rbs.add(rb);
+      try {
+        await step.run(AnalysisContext(
+          packageFolder: packageFs.directory('/'),
+          add: rb,
+        ));
+      } on BreakStep catch (e) {
+        e.report(rb);
+      }
+    }
+    return ResultBuilder.build(rbs);
+  } finally {
+    // Cleanup stuff
+  }
+}

--- a/lib/src/steps/step.dart
+++ b/lib/src/steps/step.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:meta/meta.dart' show sealed;
+import 'package:file/file.dart';
+import 'result.dart' show ResultBuilder, BreakStep;
+
+export 'result.dart' show ResultBuilder, BreakStep;
+
+@sealed
+class Step {
+  /// Unique name of this analysis step.
+  ///
+  /// This **must** be a unique lowercase identifier matching `^[a-z0-9_-]+$`.
+  final String name;
+
+  /// Run analysis given an [AnalysisContext].
+  ///
+  /// This may throw [BreakStep] to report a final suggestion and stop analysis.
+  final Future<void> Function(AnalysisContext) run;
+
+  Step(this.name, this.run);
+}
+
+/// Context passed to [Step] which allows access to resources during analysis.
+@sealed
+class AnalysisContext {
+  AnalysisContext({this.packageFolder, this.add});
+
+  /// A [ResultBuilder] to which results for the current package can be added.
+  final ResultBuilder add;
+
+  /// [Directory] containing the extracted package.
+  ///
+  /// This is provided through the `package:file` interface.
+  ///
+  /// Note: Future version of this may be read-only, do not write to this
+  /// file-system.
+  final Directory packageFolder;
+}

--- a/lib/src/steps/tags.dart
+++ b/lib/src/steps/tags.dart
@@ -1,0 +1,121 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:collection' show UnmodifiableListView, UnmodifiableMapView;
+import 'package:meta/meta.dart' show sealed, required;
+
+/// Valid field names in [TagPattern].
+final _fieldNamePattern = RegExp(r'^[a-z][a-z0-9-]*$');
+
+/// Characters allowed in tags.
+///
+/// Do **NOT** change this expression without discussion with pub.dev owners.
+/// Changing this will affect UX and could break APIs, it's for a good reason
+/// that tags cannot contain spaces.
+final _tagCharacters = 'a-z:A-Z0-9+.*_-'; // RELAX THIS WITH CARE
+
+/// Pattern that all tags must satisfy.
+final _tagPattern = RegExp('^[a-z][$_tagCharacters]*\$'); // DO NOT RELAX THIS
+
+/// List of all alllowed tagging patterns.
+///
+/// Package analysis can associate tags with a package, these tags are fairly
+/// free-form. But we require that all patterns used are registered here.
+/// Tags will be validated against this list when created.
+final List<TagPattern> tagPatterns = UnmodifiableListView([
+  TagPattern(
+    pattern: 'license:<license>',
+    fields: {
+      'license': 'SPDX license identifier',
+    },
+    description: 'License under which the package is distributed',
+  ),
+]);
+
+/// Find registered [TagPattern] from [tagPatterns] that matches [tag].
+///
+/// Returns a [TagPattern] or `null` if [tag] does match a registered
+/// [TagPattern].
+TagPattern findTagPattern(String tag) => tagPatterns.firstWhere(
+      (p) => p.match(tag),
+      orElse: () => null,
+    );
+
+/// Returns `true` if tag is a valid tag that matches a registered [TagPattern].
+bool isValidTag(String tag) =>
+    _tagPattern.hasMatch(tag) && findTagPattern(tag) != null;
+
+/// Description of a tagging pattern.
+@sealed
+class TagPattern {
+  /// A tag pattern, optionally containing `<fields>`.
+  ///
+  /// Example: `license:<license-identifier>`, all fields must be specified
+  /// in the [fields] property.
+  final String pattern;
+
+  /// Mapping from _field name_ to field description.
+  final Map<String, String> fields;
+
+  /// Description of what this tagging pattern covers.
+  final String description;
+
+  /// Lazily created validator
+  RegExp _validator;
+
+  /// Define a [TagPattern], this should only be used in [tagPatterns].
+  TagPattern({
+    @required this.pattern,
+    Map<String, String> fields = const {},
+    @required this.description,
+  }) : fields = UnmodifiableMapView(fields) {
+    ArgumentError.checkNotNull(pattern, 'pattern');
+    ArgumentError.checkNotNull(fields, 'fields');
+    ArgumentError.checkNotNull(description, 'description');
+
+    // Ensure fields match a reasonable pattern
+    if (!fields.keys.every(_fieldNamePattern.hasMatch)) {
+      throw ArgumentError.value(
+          fields, 'fields', 'Field names must match $_fieldNamePattern');
+    }
+
+    // Check that pattern doesn't start with a field
+    if (pattern.startsWith('<')) {
+      throw ArgumentError.value(
+          pattern, 'pattern', 'Patterns cannot start with a field');
+    }
+
+    // Replace all fields with empty-string and validate the result.
+    // This ensures that all fields used in the string are listed in [fields].
+    final fakeTag = fields.keys.fold<String>(
+      pattern,
+      (p, field) => p.replaceAll('<$field>', ''),
+    );
+    if (!_tagPattern.hasMatch(fakeTag)) {
+      throw ArgumentError.value(pattern, 'pattern',
+          'must match $_tagPattern when fields are removed');
+    }
+
+    // Check that all fields are used.
+    if (!fields.keys.every((field) => pattern.contains('<$field>'))) {
+      throw ArgumentError.value(
+          fields, 'fields', 'All fields must be present in tag pattern');
+    }
+  }
+
+  /// Return `true` if [tag] matches this tagging pattern.
+  bool match(String tag) {
+    // Lazily create and cache validator pattern.
+    _validator ??= RegExp('^' +
+        fields.keys.fold<String>(
+          pattern,
+          (p, field) => p.replaceAll('<$field>', '[$_tagCharacters]*'),
+        ) +
+        '\$');
+
+    ArgumentError.checkNotNull(tag, 'tag');
+
+    return _validator.hasMatch(tag);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,8 @@ dependencies:
   quiver: '>=0.24.0 <3.0.0'
   resource: ^2.1.5
   yaml: ^2.1.15
+  file: ^5.0.10
+  source_span: ^1.5.5
 
 dev_dependencies:
   build: ^1.1.0

--- a/test/steps/common/changelog_test.dart
+++ b/test/steps/common/changelog_test.dart
@@ -1,0 +1,69 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pana/src/steps/common/changelog.dart' show changelog;
+
+import '../descriptor.dart' as d;
+import '../steptest.dart';
+
+void main() {
+  stepTest('Passes with good CHANGELOG.md',
+      steps: [changelog],
+      package: [
+        d.pubspec({
+          'name': 'subject',
+          'version': '1.0.0',
+          'dependencies': {},
+          'environment': {
+            'sdk': '>=2.0.0 <3.0.0',
+          },
+        }),
+        d.file('CHANGELOG.md', '''
+# 1.0.0
+ * Initial release
+'''),
+      ],
+      tags: isEmpty,
+      kinds: isEmpty);
+
+  stepTest('Detect missing entry in CHANGELOG.md',
+      steps: [changelog],
+      package: [
+        d.pubspec({
+          'name': 'subject',
+          'version': '1.0.0',
+          'dependencies': {},
+          'environment': {
+            'sdk': '>=2.0.0 <3.0.0',
+          },
+        }),
+        d.file('CHANGELOG.md', '''
+# 0.9.1
+ * Some old release...
+'''),
+      ],
+      tags: isEmpty,
+      kinds: allOf([
+        contains('changelog-entry-missing'),
+        hasLength(1),
+      ]));
+
+  stepTest('detect missing CHANGELOG',
+      steps: [changelog],
+      package: [
+        d.pubspec({
+          'name': 'subject',
+          'version': '1.0.0',
+          'dependencies': {},
+          'environment': {
+            'sdk': '>=2.0.0 <3.0.0',
+          },
+        }),
+      ],
+      tags: isEmpty,
+      kinds: allOf([
+        contains('changelog-not-found'),
+        hasLength(1),
+      ]));
+}

--- a/test/steps/descriptor.dart
+++ b/test/steps/descriptor.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// A minimalistic library for declarative description of filesystem entities.
+///
+/// This is heavily inspired by `package:test_descriptor` which delivers the
+/// same functionality, but doesn't enable using the abstracted filesystem from
+/// `package:file`.
+library descriptor;
+
+import 'dart:collection' show UnmodifiableListView;
+import 'dart:convert' show json, utf8;
+
+import 'package:file/file.dart';
+
+/// A declarative description of a filesystem entry.
+abstract class Descriptor {
+  /// Name of this filesystem entry.
+  final String name;
+
+  Descriptor(this.name);
+
+  /// Create this entry in [target].
+  Future<void> create(Directory target);
+}
+
+/// Descriptor for a directory named [name] containing [contents].
+Descriptor dir(String name, List<Descriptor> contents) =>
+    _DirectoryDescriptor(name, contents);
+
+/// Descriptor for a file named [name] containing [contents] as [utf8] encoded
+/// string.
+Descriptor file(String name, String contents) =>
+    _FileDescriptor(name, contents);
+
+/// Descriptor for a `pubspec.yaml` file containing [contents] render as
+/// JSON (which is a subset of YAML).
+Descriptor pubspec(Map<String, Object> contents) =>
+    file('pubspec.yaml', json.encode(contents));
+
+class _FileDescriptor extends Descriptor {
+  final String contents;
+  _FileDescriptor(String name, this.contents) : super(name);
+
+  @override
+  Future<void> create(Directory target) => target
+      .childFile(name)
+      .writeAsString(contents, encoding: utf8, mode: FileMode.write);
+}
+
+class _DirectoryDescriptor extends Descriptor {
+  final List<Descriptor> contents;
+  _DirectoryDescriptor(String name, List<Descriptor> contents)
+      : contents = UnmodifiableListView(contents),
+        super(name);
+
+  @override
+  Future<void> create(Directory target) async {
+    final subfolder = target.childDirectory(name);
+    await subfolder.create();
+    await Future.wait(contents.map((d) => d.create(subfolder)));
+  }
+}

--- a/test/steps/steptest.dart
+++ b/test/steps/steptest.dart
@@ -1,0 +1,49 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:file/local.dart' show LocalFileSystem;
+import 'package:matcher/matcher.dart' show Matcher, anything;
+import 'package:pana/src/steps/run.dart';
+import 'package:pana/src/steps/step.dart';
+import 'package:test/test.dart' show test, expect;
+
+import 'descriptor.dart' show Descriptor;
+
+export 'package:matcher/matcher.dart';
+
+/// Test a set of [steps] against [package].
+///
+/// The [tags] matcher will be matched against the set of tags produced.
+/// The [kinds] matchers will be matched against the set of `kind` supplied when
+/// errors, warnings and hints were created.
+void stepTest(
+  String testName, {
+  List<Step> steps,
+  List<Descriptor> package,
+  Matcher tags = anything,
+  Matcher kinds = anything,
+}) {
+  final stepNames = steps.map((s) => s.name).join(',');
+  test('$testName ($stepNames)', () async {
+    final fs = const LocalFileSystem();
+    final tempFolder = await fs.systemTempDirectory.createTemp('pana-test-');
+    try {
+      // Create contents of package in [tempFolder]
+      await Future.wait(package.map((d) => d.create(tempFolder)));
+
+      // Run the analysis
+      final result = await run(tempFolder.path, steps);
+
+      expect(result.tags, tags);
+      expect(
+        result.suggestions
+            .map((s) => s.code.split('.').skip(1).join('.'))
+            .toSet(),
+        kinds,
+      );
+    } finally {
+      await tempFolder.delete(recursive: true);
+    }
+  });
+}

--- a/test/steps/tags_test.dart
+++ b/test/steps/tags_test.dart
@@ -1,0 +1,65 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:pana/src/steps/tags.dart';
+
+void main() {
+  test('No fields', () {
+    TagPattern(
+      pattern: 'nnbd-compatible',
+      description: 'The package is NNBD migration compatible',
+    );
+  });
+
+  test('Single field', () {
+    TagPattern(
+      pattern: 'license:<license>',
+      fields: {
+        'license': 'SPDX license identifier',
+      },
+      description: 'License under which the package is distributed',
+    );
+  });
+
+  test('No overlapping TagPattern prefixes', () {
+    final uniquePrefixes =
+        tagPatterns.map((p) => p.pattern.split('<').first).toSet();
+    expect(uniquePrefixes.length, tagPatterns.length,
+        reason: 'tagPattern prefixes are not unique');
+  });
+
+  test('match', () {
+    expect(findTagPattern('license:gpl'), isNotNull);
+  });
+
+  test('bad TagPattern', () {
+    expect(
+      () => TagPattern(
+        pattern: 'lic',
+        fields: {
+          'license': 'SPDX license identifier',
+        },
+        description: 'License under which the package is distributed',
+      ),
+      throwsArgumentError,
+    );
+
+    expect(
+      () => TagPattern(
+        pattern: 'license:<license>',
+        description: 'License under which the package is distributed',
+      ),
+      throwsArgumentError,
+    );
+
+    expect(
+      () => TagPattern(
+        pattern: '#license',
+        description: 'License under which the package is distributed',
+      ),
+      throwsArgumentError,
+    );
+  });
+}


### PR DESCRIPTION
This isn't quite ready to do... the logic for the `changelog` step is mostly just a quick hack..

Probably we have to fit the `pubspec` from `pubspec_parse` in to the `AnalysisContext`, probably along with the `.packages` and `pubspec.lock` (which shouldn't exist in the `packageFolder`).

I'm tempted to give up using `package:file`, as it would be somewhat attractive to use [package:test_descriptor](https://pub.dev/packages/test_descriptor). In practice we'll probably always want to create actual files anyways.

This is just a WIP, feel free to leave some suggestions... I'm not exactly sure how we can gracefully migrate existing code to use this flow. IMO, it's okay if we just leave a bunch of the old check as is..