### PR TITLE
Fix: pre-release versions are not considered when detecting outdated dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.13.0
 
 * `UrlChecker` follows redirects (max. 10 redirects).
+* Fix: pre-release versions are not considered when detecting outdated dependencies.  
 
 * Detect and report sdk tags ('sdk:flutter', 'sdk:dart').
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -628,6 +628,7 @@ class PkgDependency implements Comparable<PkgDependency> {
 
   bool get isLatest => available == null;
 
+  // TODO: investigate if `pub upgrade` reports the latest stable or the latest uploaded
   bool get isOutdated => available != null && !available.isPreRelease;
 
   bool get isHosted =>

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -628,7 +628,7 @@ class PkgDependency implements Comparable<PkgDependency> {
 
   bool get isLatest => available == null;
 
-  bool get isOutdated => !isLatest;
+  bool get isOutdated => available != null && !available.isPreRelease;
 
   bool get isHosted =>
       constraintType != ConstraintTypes.sdk &&

--- a/test/end2end/angular_components-0.10.0.json
+++ b/test/end2end/angular_components-0.10.0.json
@@ -113,8 +113,8 @@
         "code": "pubspec.dependencies.outdated",
         "level": "warning",
         "title": "Support latest dependencies.",
-        "description": "The version constraint in `pubspec.yaml` does not support the latest published versions for 5 dependencies (`angular`, `build_config`, `intl`, `protobuf`, `quiver`).",
-        "score": 50.0
+        "description": "The version constraint in `pubspec.yaml` does not support the latest published versions for 4 dependencies (`build_config`, `intl`, `protobuf`, `quiver`).",
+        "score": 40.0
       },
       {
         "code": "pubspec.documentation.isNotHelpful",

--- a/test/pub_summary_test.dart
+++ b/test/pub_summary_test.dart
@@ -27,10 +27,17 @@ void main() {
           summary.dependencies.firstWhere((pd) => pd.package == 'analyzer');
       expect(analyzer.resolved, Version.parse('0.29.8'));
       expect(analyzer.available, Version.parse('0.30.0-alpha.1'));
-      expect(analyzer.isOutdated, isTrue);
+      expect(analyzer.isOutdated, isFalse);
 
-      expect(summary.outdated, hasLength(7));
-      expect(summary.outdated, contains(analyzer));
+      final buildTest =
+          summary.dependencies.firstWhere((pd) => pd.package == 'build_test');
+      expect(buildTest.resolved, Version.parse('0.2.0+1'));
+      expect(buildTest.available, Version.parse('0.4.1'));
+      expect(buildTest.isOutdated, isTrue);
+
+      expect(summary.outdated, hasLength(5));
+      expect(summary.outdated, isNot(contains(analyzer)));
+      expect(summary.outdated, contains(buildTest));
     });
 
     test('upgrade', () {


### PR DESCRIPTION
- fixes #572 
- end2end test confirmed fix on [angular_components 0.10.0](https://pub.dev/packages/angular_components/versions/0.10.0#-analysis-tab-)