### PR TITLE
Utility for analyzing configurable imports/exports

### DIFF
--- a/lib/src/dependency_analysis.dart
+++ b/lib/src/dependency_analysis.dart
@@ -1,0 +1,96 @@
+import 'package:analyzer/dart/analysis/session.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+
+/// Dependencies for library at `package:` [uri] under some configuration of
+/// declared variables.
+class LibraryDependencies {
+  final Uri uri;
+  final Set<Uri> dependencies;
+
+  LibraryDependencies(this.uri, Iterable<Uri> dependencies)
+      : dependencies = Set.from(dependencies);
+
+  @override
+  String toString() => '[library at \'$uri\' depends on '
+      '${dependencies.map((u) => "'$u'").join(", ")}]';
+}
+
+/// Parse dependencies (import/export directives) of library at `package:`
+/// [uri], returns `null` if the file is a part or parsing fails.
+///
+/// This returns dependencies as `package:` [Uri]'s using the declared-variables
+/// given to the analysis context. Hence, the [LibraryDependencies] object
+/// returned is specific the the declared-variables.
+LibraryDependencies parseDependencies(AnalysisSession session, Uri uri) {
+  final unitResult = session.getParsedUnit(
+    session.uriConverter.uriToPath(uri),
+  );
+  if (unitResult.isPart || unitResult.unit == null) {
+    // TODO: Verify that part files cannot contain import/export directives.
+    //       And see if we can ensure this code is updated if that changes.
+    return null;
+  }
+  final dependencies = <Uri>{};
+  for (final node in unitResult.unit.sortedDirectivesAndDeclarations) {
+    if (node is! ImportDirective && node is! ExportDirective) {
+      continue;
+    }
+    // We have:
+    //
+    //    directive ::=
+    //        'import' stringLiteral (configuration)*
+    //      | 'export' stringLiteral (configuration)*
+    //
+    // Hence, we have dependency upon `directive.uri` resolved relative to this
+    // library `uri`. Unless there is a `configuration` for which the `test`
+    // evaluates to true.
+    final directive = node as NamespaceDirective;
+    var dependency = uri.resolve(directive.uri.stringValue);
+
+    for (final configuration in directive.configurations) {
+      // We have:
+      //
+      //    configuration ::=
+      //        'if' '(' test ')' uri
+      //
+      //    test ::=
+      //        dottedName ('==' stringLiteral)?
+
+      // Get the dottedName
+      final dottedName = configuration.name.toString();
+
+      // Get the value that `dottedName` is declared as:
+      final value = session.declaredVariables.get(dottedName);
+
+      if (configuration.equalToken != null) {
+        // If `configuration` has an `equalToken`, we must compare value against
+        // the `stringLiteral` in the test.
+        if (configuration.value != null &&
+            configuration.value.stringValue == value) {
+          dependency = uri.resolve(configuration.uri.stringValue);
+          break; // always pick the first satisfied configuration
+        }
+      } else {
+        // If `configuration` doesn't have an `equalToken` then the `value` that
+        // `dottedName` was declared as must be 'true' or 'false', or we have
+        // an error.
+        if (value == 'true') {
+          dependency = uri.resolve(configuration.uri.stringValue);
+          break; // always pick the first satisfied configuration
+        } else if (value == 'false') {
+          continue; // skip configuration that is false.
+        } else {
+          // Error, the dottedName variable is unknown. For the purpose of
+          // dependency analysis we can simply ignore this configuration.
+          // The configuration is probably not active.
+          continue;
+        }
+      }
+    }
+
+    //TODO: Determine if there is any need to normalize the `dependency` Uri
+    // Add the dependency that was decided above.
+    dependencies.add(dependency);
+  }
+  return LibraryDependencies(uri, dependencies);
+}


### PR DESCRIPTION
@sigurdm, I think we can resolve the configurable imports/exports by simply analyzing the AST.
Looking at the grammar it seems very simple.

I'm not entirely sure what we should do when:
 * Parsing fails,
 * Declared variables are undefineds,

I suspect  we can ignore parsing errors (these will be analyzer errors, anyways), and as long as declared variables are always `true` or `false`, then I suspect the cases where they are unrecognized can be reported as warning for the package. This way, we are sure to get a bug report, when users start using a new variable and we haven't updated pana to reflect that.

The only problem I see is that part files might one day be allowed to do configurable imports, but this might not break the AST to a level that we'll remember to update this. But maybe the best long-term solution is to have the analyzer do this for us.

Upsides to this approach is that it's a bit faster than a full analysis, and if the code has analysis errors we can still do the dependency analysis.

Note. this only resolved immediate imports/exports, so we need propagate these until we reach a fixed-point. But I think this is the tool we need to get configurable imports working :)