### PR TITLE
Updated tag detection for packages without a primary library.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.3
+
+* Updated tag detection for packages without a primary library.
+
 ## 0.13.2
 
 * Don't penalize packages on legacy platform detection results.

--- a/lib/src/tag_detection.dart
+++ b/lib/src/tag_detection.dart
@@ -548,7 +548,7 @@ class Tagger {
     final topLibraries = primaryLibrary != null
         ? <Uri>[primaryLibrary]
         : topLibraryFiles
-            .map((name) => Uri.parse('package:${pubspec.name}/$name.dart'))
+            .map((name) => Uri.parse('package:${pubspec.name}/$name'))
             .toList();
 
     return Tagger._(packageDir, session, pubspecCache, topLibraries);

--- a/lib/src/tag_detection.dart
+++ b/lib/src/tag_detection.dart
@@ -519,9 +519,8 @@ class Tagger {
         .listSync(recursive: false)
         .where((e) => e is File && e.path.endsWith('.dart'))
         .map((f) => path.basename(f.path))
-        .toList()
-          // Sort to make the arbitrary use of first file deterministic.
-          ..sort();
+        .toList();
+
     final libSrcDir = Directory(path.join(packageDir, 'lib', 'src'));
     final libSrcDartFiles = !libSrcDir.existsSync()
         ? <String>[]
@@ -530,7 +529,8 @@ class Tagger {
             .where((e) => e is File && e.path.endsWith('.dart'))
             .map((f) => path.relative(f.path, from: libDir.path))
             .toList();
-    // Sort to make the arbitrary use of first file deterministic.
+    // Sort to make the order of files and the reported events deterministic.
+    libDartFiles.sort();
     libSrcDartFiles.sort();
 
     // Use `lib/*.dart` otherwise `lib/src/*.dart`.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.13.2';
+const packageVersion = '0.13.3';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.13.3';
+const packageVersion = '0.13.3-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.13.2
+version: 0.13.3
 homepage: https://github.com/dart-lang/pana
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.13.3
+version: 0.13.3-dev
 homepage: https://github.com/dart-lang/pana
 
 environment:

--- a/test/end2end/angular_components-0.10.0.json
+++ b/test/end2end/angular_components-0.10.0.json
@@ -445,7 +445,7 @@
         "package": "sass",
         "dependencyType": "transitive",
         "constraintType": "inherited",
-        "resolved": "1.23.7"
+        "resolved": "1.24.0"
       },
       {
         "package": "sass_builder",
@@ -2856,6 +2856,7 @@
         "package:sass/src/ast/sass/argument_invocation.dart",
         "package:sass/src/ast/sass/at_root_query.dart",
         "package:sass/src/ast/sass/callable_invocation.dart",
+        "package:sass/src/ast/sass/configured_variable.dart",
         "package:sass/src/ast/sass/expression.dart",
         "package:sass/src/ast/sass/expression/binary_operation.dart",
         "package:sass/src/ast/sass/expression/boolean.dart",
@@ -2937,6 +2938,8 @@
         "package:sass/src/callable/user_defined.dart",
         "package:sass/src/color_names.dart",
         "package:sass/src/compile.dart",
+        "package:sass/src/configuration.dart",
+        "package:sass/src/configured_value.dart",
         "package:sass/src/environment.dart",
         "package:sass/src/exception.dart",
         "package:sass/src/extend/empty_extender.dart",
@@ -2971,6 +2974,7 @@
         "package:sass/src/module.dart",
         "package:sass/src/module/built_in.dart",
         "package:sass/src/module/forwarded_view.dart",
+        "package:sass/src/module/shadowed_view.dart",
         "package:sass/src/parse/at_root_query.dart",
         "package:sass/src/parse/css.dart",
         "package:sass/src/parse/keyframe_selector.dart",


### PR DESCRIPTION
- Fixes #591.
- Top-level libraries are the files in `lib/*.dart`. However, if there is a primary library in the package (`/lib/[package_name].dart`), it will be used as a single value in top-level libraries.
- Tags are added when all of the top-level libraries agree on supporting the given SDK or platform.
- Binary-only packages are handled via a temporary heuristic.