### PR TITLE
More dart:* libraries in tag detection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Updated tag detection for packages without a primary library.
 * Upgraded analyzer to `^0.39.0`.
+* More `dart:*` libraries in tag detection: `cli`, `nativewrappers`, `html_common`.
 
 ## 0.13.2
 

--- a/lib/src/tag_detection.dart
+++ b/lib/src/tag_detection.dart
@@ -303,28 +303,34 @@ class Runtime {
   static final _onAllWeb = {
     'html',
     'indexed_db',
-    'web_audio',
-    'web_gl',
     'js',
     'js_util',
+    'svg',
+    'web_audio',
+    'web_gl',
     'web_sql',
   };
 
   static final nativeJit = Runtime('native-jit', {
     ..._onAllPlatforms,
     ..._onAllNative,
-    'mirrors',
+    'cli',
     'developer',
+    'mirrors',
+    'nativewrappers',
   });
 
   static final nativeAot = Runtime('native-aot', {
     ..._onAllPlatforms,
     ..._onAllNative,
+    'cli',
+    'nativewrappers',
   });
 
   static final web = Runtime('web', {
     ..._onAllPlatforms,
     ..._onAllWeb,
+    'html_common',
   });
 
   static final flutterNative = Runtime('flutter-native', {

--- a/test/tag_detection_external_test.dart
+++ b/test/tag_detection_external_test.dart
@@ -1,0 +1,56 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:http/http.dart';
+import 'package:pana/src/tag_detection.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Dart SDK library definitions', () {
+    Map<String, dynamic> libraries;
+    Set<String> allVmLibs;
+    Set<String> publicVmLibs;
+    Set<String> allDart2jsLibs;
+    Set<String> publicDart2jsLibs;
+
+    Set<String> extractLibraries(Map<String, dynamic> map) {
+      return map.entries
+          .where(
+              (e) => e.value is Map && (e.value as Map)['supported'] != false)
+          .map((e) => e.key)
+          .toSet();
+    }
+
+    setUpAll(() async {
+      // Download and parse https://github.com/dart-lang/sdk/blob/master/sdk/lib/libraries.json
+      final librariesContent = await get(
+          'https://raw.githubusercontent.com/dart-lang/sdk/master/sdk/lib/libraries.json');
+      libraries = json.decode(librariesContent.body) as Map<String, dynamic>;
+      allVmLibs = extractLibraries(
+          libraries['vm']['libraries'] as Map<String, dynamic>);
+      publicVmLibs = allVmLibs.where((s) => !s.startsWith('_')).toSet();
+      allDart2jsLibs = extractLibraries(
+          libraries['dart2js']['libraries'] as Map<String, dynamic>);
+      publicDart2jsLibs =
+          allDart2jsLibs.where((s) => !s.startsWith('_')).toSet();
+    });
+
+    test('VM libraries', () {
+      for (final lib in publicVmLibs) {
+        if (lib == 'wasm' || lib == 'vmservice_io') {
+          continue; // ignore for now
+        }
+        expect(Runtime.nativeJit.enabledLibs, contains(lib));
+      }
+    });
+
+    test('dart2js libraries', () {
+      for (final lib in publicDart2jsLibs) {
+        expect(Runtime.web.enabledLibs, contains(lib));
+      }
+    });
+  });
+}


### PR DESCRIPTION
- fixes #594
- `cli` and `nativewrappers` in `dart/native-jit` (not sure if aot is the same, is it?).
- `html_commons` in `dart/web`.
- added a test that downloads the SDK-provided definitions and checks them against our definitions