### PR TITLE
Control the linter rule set via InspectOptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.4
+
+* `InspectOptions.analysisOptionsUri` to optionally control which `pedantic`
+  version (or other package's) ruleset is used for analysis lints.
+
 ## 0.13.3
 
 * Updated tag detection for packages without a primary library.

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -40,6 +40,7 @@ class InspectOptions {
   final Duration dartdocTimeout;
   final bool isInternal;
   final int lineLength;
+  final String analysisOptionsUri;
 
   InspectOptions({
     this.verbosity = Verbosity.normal,
@@ -50,6 +51,7 @@ class InspectOptions {
     this.dartdocTimeout,
     this.isInternal = false,
     this.lineLength,
+    this.analysisOptionsUri,
   });
 }
 
@@ -309,7 +311,7 @@ class PackageAnalyzer {
       if (dartFiles.isNotEmpty) {
         analyzeProcessStopwatch.start();
         try {
-          analyzerItems = await _pkgAnalyze(pkgDir, usesFlutter);
+          analyzerItems = await _pkgAnalyze(pkgDir, usesFlutter, options);
         } on ArgumentError catch (e) {
           if (e.toString().contains('No dart files found at: .')) {
             log.warning('`dartanalyzer` found no files to analyze.');
@@ -438,13 +440,14 @@ class PackageAnalyzer {
   }
 
   Future<List<CodeProblem>> _pkgAnalyze(
-      String pkgPath, bool usesFlutter) async {
+      String pkgPath, bool usesFlutter, InspectOptions inspectOptions) async {
     log.info('Analyzing package...');
     final dirs = await listFocusDirs(pkgPath);
     if (dirs.isEmpty) {
       return null;
     }
-    final output = await _toolEnv.runAnalyzer(pkgPath, dirs, usesFlutter);
+    final output = await _toolEnv.runAnalyzer(pkgPath, dirs, usesFlutter,
+        inspectOptions: inspectOptions);
     final list = LineSplitter.split(output)
         .map((s) => parseCodeProblem(s, projectDir: pkgPath))
         .where((e) => e != null)

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -8,12 +8,14 @@ import 'dart:io';
 
 import 'package:cli_util/cli_util.dart' as cli;
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 
 import 'analysis_options.dart';
 import 'logging.dart';
 import 'model.dart' show PanaRuntimeInfo;
+import 'package_analyzer.dart' show InspectOptions;
 import 'pubspec.dart';
 import 'utils.dart';
 import 'version.dart';
@@ -135,14 +137,19 @@ class ToolEnvironment {
   }
 
   Future<String> runAnalyzer(
-      String packageDir, List<String> dirs, bool usesFlutter) async {
+    String packageDir,
+    List<String> dirs,
+    bool usesFlutter, {
+    @required InspectOptions inspectOptions,
+  }) async {
     final originalOptionsFile =
         File(p.join(packageDir, 'analysis_options.yaml'));
     String originalOptions;
     if (await originalOptionsFile.exists()) {
       originalOptions = await originalOptionsFile.readAsString();
     }
-    final pedanticContent = await getPedanticContent();
+    final pedanticContent =
+        await getPedanticContent(inspectOptions: inspectOptions);
     final pedanticFileName =
         'pedantic_analyis_options_${DateTime.now().microsecondsSinceEpoch}.g.yaml';
     final pedanticOptionsFile = File(p.join(packageDir, pedanticFileName));

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.13.3';
+const packageVersion = '0.13.4-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.13.3
+version: 0.13.4-dev
 homepage: https://github.com/dart-lang/pana
 
 environment:

--- a/test/analysis_options_test.dart
+++ b/test/analysis_options_test.dart
@@ -7,14 +7,28 @@ import 'dart:convert';
 import 'package:test/test.dart';
 
 import 'package:pana/src/analysis_options.dart';
+import 'package:pana/src/package_analyzer.dart' show InspectOptions;
 
 void main() {
-  test('pedantic options', () async {
-    final content = await getPedanticContent();
+  test('default pedantic options', () async {
+    final content = await getPedanticContent(inspectOptions: InspectOptions());
     expect(content, contains('linter:'));
     expect(content, contains('rules:'));
     expect(content, contains('avoid_empty_else'));
     expect(content, contains('prefer_is_empty'));
+    expect(content, contains('prefer_single_quotes')); // in 1.9.0
+  });
+
+  test('specific pedantic options', () async {
+    final content = await getPedanticContent(
+        inspectOptions: InspectOptions(
+            analysisOptionsUri:
+                'package:pedantic/analysis_options.1.8.0.yaml'));
+    expect(content, contains('linter:'));
+    expect(content, contains('rules:'));
+    expect(content, contains('avoid_empty_else'));
+    expect(content, contains('prefer_is_empty'));
+    expect(content, isNot(contains('prefer_single_quotes'))); // only from 1.9.0
   });
 
   test('default options', () {


### PR DESCRIPTION
The default behaviour remains the current one, but we can control it for pub.dev without modifying it in `pana` for each new ruleset.