### PR TITLE
Use lib/**/*.dart as top-level libraries when there is no lib/*.dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.5
+
+* Fix: when there are no libraries matching `lib/*.dart`, other libraries
+  outside of `lib/src/` will be recognized as top-level libraries.
+
 ## 0.13.4
 
 * `InspectOptions.analysisOptionsUri` to optionally control which `pedantic`

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.13.4';
+const packageVersion = '0.13.5-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.13.4
+version: 0.13.5-dev
 homepage: https://github.com/dart-lang/pana
 
 environment:


### PR DESCRIPTION
#605