### PR TITLE
Unescape double-backslash on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.13.6
 
 * Fix: detect Dart files on Windows
+* Fix: unescape double-backslash from files reported by `dartanalyzer` on Windows. 
 
 ## 0.13.5
 

--- a/lib/src/code_problem.dart
+++ b/lib/src/code_problem.dart
@@ -64,6 +64,9 @@ CodeProblem parseCodeProblem(String content, {String projectDir}) {
   // length = 7
   var description = match[8];
 
+  // dartanalyzer --format=machine returns backslashes escaped with double backslash
+  filePath = filePath.replaceAll(r'\\', r'\');
+
   if (projectDir != null) {
     assert(p.isWithin(projectDir, filePath));
     filePath = p.relative(filePath, from: projectDir);

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -392,6 +392,16 @@ class PackageAnalyzer {
       dartFileSummaries: files.values,
     );
 
+    if (analyzerItems != null) {
+      final reportedFiles = analyzerItems.map((i) => i.file).toSet();
+      final knownFiles = files.values.map((f) => f.path).toSet();
+      final unattributedFiles = <String>{...reportedFiles}
+        ..removeAll(knownFiles);
+      if (unattributedFiles.isNotEmpty) {
+        log.warning('Unattributed files from dartanalyzer: $unattributedFiles');
+      }
+    }
+
     DartPlatform platform;
     if (pkgPlatformConflict != null) {
       platform = DartPlatform.conflict(

--- a/test/code_problem_test.dart
+++ b/test/code_problem_test.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'package:pana/src/code_problem.dart';
+
+void main() {
+  test('windows double escape', () {
+    final cp = parseCodeProblem(
+        r"INFO|HINT|UNUSED_FIELD|D:\\Documents\\youtube_explode_dart\\lib\\src\\extensions\\helpers_extension.dart|16|16|4|The value of the field '_exp' isn't used.");
+    expect(cp.file,
+        r'D:\Documents\youtube_explode_dart\lib\src\extensions\helpers_extension.dart');
+  });
+}


### PR DESCRIPTION
- added fix to parse files (https://github.com/dart-lang/pub-dev/issues/3389)
- added sanity check + log to detect if we are missing out on other patterns