### PR TITLE
Handle new output from --version in latest Dart SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.7
+
+* Fix: handle new `--version` output from latest Dart SDK.
+
 ## 0.13.6
 
 * Fix: detect Dart files on Windows

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -493,7 +493,7 @@ class DartdocResult {
 
 class DartSdkInfo {
   static final _sdkRegexp = RegExp(
-    r'Dart VM version:\s([^\s]+)\s\(([^\)]+)\)(\s\(([^\)]+)\))? on "(\w+)"',
+    r'Dart VM version:\s([^\s]+)(?:\s\((?:[^\)]+)\))?\s\(([^\)]+)\) on "(\w+)"',
   );
 
   // TODO: parse an actual `DateTime` here. Likely requires using pkg/intl

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -492,8 +492,9 @@ class DartdocResult {
 }
 
 class DartSdkInfo {
-  static final _sdkRegexp =
-      RegExp('Dart VM version:\\s([^\\s]+)\\s\\(([^\\)]+)\\) on "(\\w+)"');
+  static final _sdkRegexp = RegExp(
+    r'Dart VM version:\s([^\s]+)\s\(([^\)]+)\)(\s\(([^\)]+)\))? on "(\w+)"',
+  );
 
   // TODO: parse an actual `DateTime` here. Likely requires using pkg/intl
   final String dateString;

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.13.6';
+const packageVersion = '0.13.7';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.13.6
+version: 0.13.7
 homepage: https://github.com/dart-lang/pana
 
 environment:

--- a/test/sdk_env_test.dart
+++ b/test/sdk_env_test.dart
@@ -13,5 +13,17 @@ void main() {
         'Dart VM version: 2.0.0-dev.49.0 (Wed Apr 18 20:41:36 2018 +0200) on "macos_x64"';
     final sdkInfo = DartSdkInfo.parse(version);
     expect(sdkInfo.version, Version.parse('2.0.0-dev.49.0'));
+    expect(sdkInfo.dateString, 'Wed Apr 18 20:41:36 2018 +0200');
+    expect(sdkInfo.platform, 'macos_x64');
+  });
+
+  test('parsing SDK version  new style', () {
+    final version =
+        'Dart VM version: 2.8.0-edge.b8b4a16179653c18f49bc31abab016595a1245b2 (be) (Fri Mar 27 10:16:29 2020 +0000) on "linux_x64"';
+    final sdkInfo = DartSdkInfo.parse(version);
+    expect(sdkInfo.version,
+        Version.parse('2.8.0-edge.b8b4a16179653c18f49bc31abab016595a1245b2'));
+    expect(sdkInfo.dateString, 'Fri Mar 27 10:16:29 2020 +0000');
+    expect(sdkInfo.platform, 'linux_x64');
   });
 }


### PR DESCRIPTION
It may contain a date, which needs to be considered in the parser

Fixes https://github.com/dart-lang/pana/issues/628
Prepare for v0.13.7