### PR TITLE
Use the analyzer-provided UrlChecker in the createReport() checks.

### DIFF
--- a/lib/src/create_report.dart
+++ b/lib/src/create_report.dart
@@ -48,7 +48,7 @@ Future<Report> createReport(PackageContext context) async {
   }
 
   return Report(sections: [
-    await _followsTemplate(context.options, context.packageDir, pubspec),
+    await _followsTemplate(context),
     await _hasDocumentation(context.packageDir, pubspec),
     await _multiPlatform(context.packageDir, pubspec),
     await _staticAnalysis(context),
@@ -237,9 +237,10 @@ Future<List<_Issue>> _formatPackage(
   }
 }
 
-Future<ReportSection> _followsTemplate(
-    InspectOptions options, String packageDir, Pubspec pubspec) async {
-  final urlChecker = UrlChecker();
+Future<ReportSection> _followsTemplate(PackageContext context) async {
+  final options = context.options;
+  final packageDir = context.packageDir;
+  final pubspec = context.pubspec;
 
   Future<List<_Issue>> findUrlIssues(
     String key,
@@ -266,7 +267,7 @@ Future<ReportSection> _followsTemplate(
       return issues;
     }
 
-    final status = await urlChecker.checkStatus(
+    final status = await context.urlChecker.checkStatus(
       url,
       isInternalPackage: options.isInternal,
     );
@@ -940,8 +941,10 @@ class _Issue implements _Paragraph {
       description,
       '</summary>',
       '', // This empty line will make the span render its markdown.
-      if (span != null) span.markdown(basePath: basePath),
-      if (suggestion != null) suggestion,
+      if (span != null)
+        span.markdown(basePath: basePath),
+      if (suggestion != null)
+        suggestion,
       '</details>',
     ].join('\n');
   }

--- a/lib/src/create_report.dart
+++ b/lib/src/create_report.dart
@@ -941,10 +941,8 @@ class _Issue implements _Paragraph {
       description,
       '</summary>',
       '', // This empty line will make the span render its markdown.
-      if (span != null)
-        span.markdown(basePath: basePath),
-      if (suggestion != null)
-        suggestion,
+      if (span != null) span.markdown(basePath: basePath),
+      if (suggestion != null) suggestion,
       '</details>',
     ].join('\n');
   }

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -83,6 +83,7 @@ class PackageAnalyzer {
       toolEnvironment: _toolEnv,
       packageDir: pkgDir,
       options: options,
+      urlChecker: _urlChecker,
     );
 
     var dartFiles = await listFiles(

--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 
 import 'code_problem.dart';
+import 'download_utils.dart';
 import 'logging.dart';
 import 'messages.dart' as messages;
 import 'model.dart';
@@ -23,6 +24,7 @@ class PackageContext {
   final ToolEnvironment toolEnvironment;
   final String packageDir;
   final InspectOptions options;
+  final UrlChecker urlChecker;
   final errors = <String>[];
 
   Pubspec _pubspec;
@@ -34,7 +36,8 @@ class PackageContext {
     @required this.toolEnvironment,
     @required this.packageDir,
     @required this.options,
-  });
+    UrlChecker urlChecker,
+  }) : urlChecker = urlChecker ?? UrlChecker();
 
   Pubspec get pubspec {
     if (_pubspec != null) return _pubspec;


### PR DESCRIPTION
- On pub.dev we provide an instance with caching.
- Moved to the `PackageContext` as it will also hold the license file (and could use it for the licenseUrl calculation)