### PR TITLE
Consistent message for SDK constraint issue.

### DIFF
--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:meta/meta.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 import 'code_problem.dart';
 import 'download_utils.dart';
@@ -27,6 +28,7 @@ class PackageContext {
   final UrlChecker urlChecker;
   final errors = <String>[];
 
+  Version _currentSdkVersion;
   Pubspec _pubspec;
   bool _usesFlutter;
   PkgResolution _pkgResolution;
@@ -38,6 +40,9 @@ class PackageContext {
     @required this.options,
     UrlChecker urlChecker,
   }) : urlChecker = urlChecker ?? UrlChecker();
+
+  Version get currentSdkVersion => _currentSdkVersion ??=
+      Version.parse(toolEnvironment.runtimeInfo.sdkVersion);
 
   Pubspec get pubspec {
     if (_pubspec != null) return _pubspec;
@@ -124,4 +129,8 @@ class PackageContext {
     }
     return _codeProblems;
   }
+
+  bool get pubspecAllowsCurrentSdk =>
+      pubspec.dartSdkConstraint != null &&
+      pubspec.dartSdkConstraint.allows(currentSdkVersion);
 }

--- a/test/goldens/end2end/fs_shim-0.7.1.json
+++ b/test/goldens/end2end/fs_shim-0.7.1.json
@@ -82,7 +82,7 @@
         "title": "Support up-to-date dependencies",
         "grantedPoints": 0,
         "maxPoints": 20,
-        "summary": "### [x] 0/10 points: All of the package dependencies are supported in the latest version\n\n<details>\n<summary>\nSdk constraint doesn't support current Dart version 2.9.0. Cannot run `pub outdated`.\n</summary>\n\n`pubspec.yaml:8:8`\n\n```\n  ╷\n8 │   sdk: '>=1.24.0 <2.0.0'\n  │        ^^^^^^^^^^^^^^^^^\n  ╵\n```\n\n</details>\n\n### [x] 0/10 points: Package supports latest stable Dart and Flutter SDKs\n\n<details>\n<summary>\nThe current sdk constraint does not allow the latest stable Dart (2.9.0)\n</summary>\n\n`pubspec.yaml:8:8`\n\n```\n  ╷\n8 │   sdk: '>=1.24.0 <2.0.0'\n  │        ^^^^^^^^^^^^^^^^^\n  ╵\n```\n\nTry widening the upper boundary of the constraint.\n</details>\n* Found no Flutter in your PATH. Could not determine the current Flutter version."
+        "summary": "### [x] 0/10 points: All of the package dependencies are supported in the latest version\n\n<details>\n<summary>\nSdk constraint doesn't support current Dart version 2.9.0. Cannot run `pub outdated`.\n</summary>\n\n`pubspec.yaml:8:8`\n\n```\n  ╷\n8 │   sdk: '>=1.24.0 <2.0.0'\n  │        ^^^^^^^^^^^^^^^^^\n  ╵\n```\n\n</details>\n\n### [x] 0/10 points: Package supports latest stable Dart and Flutter SDKs\n\n<details>\n<summary>\nSdk constraint doesn't support current Dart version 2.9.0.\n</summary>\n\n`pubspec.yaml:8:8`\n\n```\n  ╷\n8 │   sdk: '>=1.24.0 <2.0.0'\n  │        ^^^^^^^^^^^^^^^^^\n  ╵\n```\n\nTry widening the upper boundary of the constraint.\n</details>\n* Found no Flutter in your PATH. Could not determine the current Flutter version."
       }
     ]
   },

--- a/test/goldens/end2end/fs_shim-0.7.1.json_report.md
+++ b/test/goldens/end2end/fs_shim-0.7.1.json_report.md
@@ -111,7 +111,7 @@ Sdk constraint doesn't support current Dart version 2.9.0. Cannot run `pub outda
 
 <details>
 <summary>
-The current sdk constraint does not allow the latest stable Dart (2.9.0)
+Sdk constraint doesn't support current Dart version 2.9.0.
 </summary>
 
 `pubspec.yaml:8:8`

--- a/test/goldens/end2end/skiplist-0.1.0.json
+++ b/test/goldens/end2end/skiplist-0.1.0.json
@@ -55,7 +55,7 @@
         "title": "Support up-to-date dependencies",
         "grantedPoints": 0,
         "maxPoints": 20,
-        "summary": "### [x] 0/10 points: All of the package dependencies are supported in the latest version\n\n* Sdk constraint doesn't support current Dart version 2.9.0. Cannot run `pub outdated`.\n\n### [x] 0/10 points: Package supports latest stable Dart and Flutter SDKs\n\n<details>\n<summary>\nPubspec.yaml does not have an sdk version constraint.\n</summary>\n\nTry adding an sdk constraint to your pubspec.yaml\n</details>\n* Found no Flutter in your PATH. Could not determine the current Flutter version."
+        "summary": "### [x] 0/10 points: All of the package dependencies are supported in the latest version\n\n* Sdk constraint doesn't support current Dart version 2.9.0. Cannot run `pub outdated`.\n\n### [x] 0/10 points: Package supports latest stable Dart and Flutter SDKs\n\n<details>\n<summary>\nPubspec.yaml does not have an sdk version constraint.\n</summary>\n\nTry adding an sdk constraint to your `pubspec.yaml`\n</details>\n* Found no Flutter in your PATH. Could not determine the current Flutter version."
       }
     ]
   },

--- a/test/goldens/end2end/skiplist-0.1.0.json_report.md
+++ b/test/goldens/end2end/skiplist-0.1.0.json_report.md
@@ -93,6 +93,6 @@ To reproduce make sure you are using [pedantic](https://pub.dev/packages/pedanti
 Pubspec.yaml does not have an sdk version constraint.
 </summary>
 
-Try adding an sdk constraint to your pubspec.yaml
+Try adding an sdk constraint to your `pubspec.yaml`
 </details>
 * Found no Flutter in your PATH. Could not determine the current Flutter version.


### PR DESCRIPTION
- This is a refactor preparing for implementing https://github.com/dart-lang/pub-dev/issues/3854
- It also removes the phrase "latest stable" Dart SDK, instead using the "current".