### PR TITLE
Changing signature of dartdocFailedSection to match pub.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Use `dart pub` instead of `pub`.
 * Flutter SDK on CI + Flutter package in end2end test.
 * **BREAKING CHANGES**
+  * Internal to `pub.dev`: `dartdocFailedSection` signature changed to match recent update.
   * Removed `InspectOptions.analysisOptionsUri`. Use `analysisOptionsYaml` instead.
     When `analysisOptionsYaml` is not specified, `pana` will load defaults from GitHub.
 

--- a/lib/src/dartdoc_analyzer.dart
+++ b/lib/src/dartdoc_analyzer.dart
@@ -6,7 +6,6 @@ import 'package:meta/meta.dart';
 
 import 'create_report.dart' show renderSimpleSectionSummary;
 import 'model.dart';
-import 'sdk_env.dart';
 
 const documentationSectionTitle = 'Provide documentation';
 
@@ -49,10 +48,7 @@ ReportSection documentationCoverageSection({
 }
 
 /// Creates a report section when running dartdoc failed to produce content.
-ReportSection dartdocFailedSection([DartdocResult result]) {
-  final errorMessage = result?.processResult?.stderr?.toString() ?? '';
-  final failure = (result?.wasTimeout ?? false) ? 'timed out' : 'failed';
-
+ReportSection dartdocFailedSection(String abortMessage) {
   return ReportSection(
     id: ReportSectionId.documentation,
     title: documentationSectionTitle,
@@ -60,8 +56,7 @@ ReportSection dartdocFailedSection([DartdocResult result]) {
     maxPoints: 10,
     summary: renderSimpleSectionSummary(
       title: 'Failed to run dartdoc',
-      description:
-          'Running `dartdoc` $failure with the following output:\n\n```\n$errorMessage\n```\n',
+      description: abortMessage,
       grantedPoints: 0,
       maxPoints: 10,
     ),


### PR DESCRIPTION
This will replace https://github.com/dart-lang/pub-dev/blob/master/app/lib/dartdoc/dartdoc_runner.dart#L670-L684 in pub-dev.