### PR TITLE
New command-line args.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Use `dart pub` instead of `pub`.
 * Flutter SDK on CI + Flutter package in end2end test.
 * Fix: use `line-length` option in report.
+* New options for CI: `dart-sdk`, `exit-code-threshold`.
 * **BREAKING CHANGES**
   * Internal to `pub.dev`: `dartdocFailedSection` signature changed to match recent update.
   * Removed `InspectOptions.analysisOptionsUri`. Use `analysisOptionsYaml` instead.

--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ Usage: pana [<options>] --hosted <published package name> [<version>]
        pana [<options>] <local directory>
 
 Options:
-      --flutter-sdk     The directory of the Flutter SDK.
-  -j, --json            Output log records and full report as JSON.
-      --hosted-url      The server that hosts <package>.
-                        (defaults to "https://pub.dev")
-  -l, --line-length     The line length to use with dartfmt.
-      --hosted          Download and analyze a hosted package (from https://pub.dev).
-      --[no-]warning    Shows the warning message before potentially destructive operation.
-                        (defaults to on)
+      --dart-sdk               The directory of the Dart SDK.
+      --flutter-sdk            The directory of the Flutter SDK.
+      --exit-code-threshold    The exit code will indicate if (max - granted points) <= threshold.
+  -j, --json                   Output log records and full report as JSON.
+      --hosted-url             The server that hosts <package>.
+                               (defaults to "https://pub.dev")
+  -l, --line-length            The line length to use with dartfmt.
+      --hosted                 Download and analyze a hosted package (from https://pub.dev).
+      --[no-]warning           Shows the warning message before potentially destructive operation.
+                               (defaults to on)
 ```

--- a/test/goldens/help.txt
+++ b/test/goldens/help.txt
@@ -2,11 +2,13 @@ Usage: pana [<options>] --hosted <published package name> [<version>]
        pana [<options>] <local directory>
 
 Options:
-      --flutter-sdk     The directory of the Flutter SDK.
-  -j, --json            Output log records and full report as JSON.
-      --hosted-url      The server that hosts <package>.
-                        (defaults to "https://pub.dev")
-  -l, --line-length     The line length to use with dartfmt.
-      --hosted          Download and analyze a hosted package (from https://pub.dev).
-      --[no-]warning    Shows the warning message before potentially destructive operation.
-                        (defaults to on)
+      --dart-sdk               The directory of the Dart SDK.
+      --flutter-sdk            The directory of the Flutter SDK.
+      --exit-code-threshold    The exit code will indicate if (max - granted points) <= threshold.
+  -j, --json                   Output log records and full report as JSON.
+      --hosted-url             The server that hosts <package>.
+                               (defaults to "https://pub.dev")
+  -l, --line-length            The line length to use with dartfmt.
+      --hosted                 Download and analyze a hosted package (from https://pub.dev).
+      --[no-]warning           Shows the warning message before potentially destructive operation.
+                               (defaults to on)


### PR DESCRIPTION
- `dart-sdk` is useful to run a test with a different SDK and is a pair for `flutter-sdk`
- `exit-code-threshold` fixes #843.