### PR TITLE
UrlChecker.exists to enable a caching hook for pub.dev

### DIFF
--- a/lib/src/download_utils.dart
+++ b/lib/src/download_utils.dart
@@ -132,7 +132,7 @@ class UrlChecker {
 
   UrlChecker({
     int maxCacheSize,
-  }) : _maxCacheSize = maxCacheSize ?? 100 {
+  }) : _maxCacheSize = maxCacheSize ?? 10000 {
     addInternalHosts([
       'dart.dev',
       RegExp(r'.*\.dart\.dev'),

--- a/lib/src/download_utils.dart
+++ b/lib/src/download_utils.dart
@@ -153,6 +153,10 @@ class UrlChecker {
     return _internalHosts.every((p) => p.allMatches(uri.host).isEmpty);
   }
 
+  Future<bool> exists(Uri uri) async {
+    return await safeUrlCheck(uri);
+  }
+
   Future<UrlStatus> checkStatus(String url,
       {bool isInternalPackage = false}) async {
     if (url == null) {
@@ -169,8 +173,7 @@ class UrlChecker {
     if (!isExternal && !isInternalPackage) {
       return UrlStatus.internal;
     }
-    final exists = await safeUrlCheck(uri);
-    return exists ? UrlStatus.exists : UrlStatus.missing;
+    return await exists(uri) ? UrlStatus.exists : UrlStatus.missing;
   }
 }
 


### PR DESCRIPTION
- #879
- pub.dev should have a cache that stores the URLs that can be accessed successfully.
- The cache could have a longer timeout (e.g. 7 days).
- If a URL is not accessible, it doesn't become a negative cached entry, it would be tried via `super.exists()` and on success the status could be stored in cache.