### PR TITLE
Migrate to recommended lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 * Removed package list of 2.10 null-safety experiments.
 * Update dependencies to latest.
 * Migration to null-safety.
-* Deprecate `SCREAMING_CAPS` versions of `LicenseNames` constants.
+* **BREAKING CHANGES**
+  * Deprecate the `SCREAMING_CAPS` versions of the `LicenseNames` constants. 
+    Use the newly introduced `lowerCamelCase` versions instead.
 
 ## 0.17.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Removed package list of 2.10 null-safety experiments.
 * Update dependencies to latest.
 * Migration to null-safety.
+* Deprecate `SCREAMING_CAPS` versions of `LicenseNames` constants.
 
 ## 0.17.1
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 analyzer:
   strong-mode:
     implicit-casts: false
@@ -6,58 +6,24 @@ analyzer:
     unused_import: error
     unused_local_variable: error
     dead_code: error
+
 linter:
   rules:
-    - annotate_overrides
-    #- avoid_function_literals_in_foreach_calls
-    - avoid_init_to_null
-    - avoid_null_checks_in_equality_operators
-    - avoid_relative_lib_imports
-    #- avoid_returning_null
+    - always_declare_return_types
     - avoid_unused_constructor_parameters
-    - await_only_futures
-    - camel_case_types
     - cancel_subscriptions
     - comment_references
-    #- constant_identifier_names
-    - control_flow_in_finally
     - directives_ordering
-    - empty_catches
-    - empty_constructor_bodies
-    - empty_statements
-    - hash_and_equals
-    - implementation_imports
-    - invariant_booleans
-    - iterable_contains_unrelated_type
-    - library_names
-    - library_prefixes
-    - list_remove_unrelated_type
     - no_adjacent_strings_in_list
-    - non_constant_identifier_names
     - omit_local_variable_types
     - only_throw_errors
-    - overridden_fields
     - package_api_docs
-    - package_names
-    - package_prefixed_library_names
-    - prefer_adjacent_string_concatenation
-    - prefer_collection_literals
-    - prefer_conditional_assignment
     - prefer_const_constructors
-    - prefer_final_fields
-    - prefer_initializing_formals
-    #- prefer_interpolation_to_compose_strings
     - prefer_single_quotes
-    - prefer_typing_uninitialized_variables
-    - slash_for_doc_comments
+    - sort_child_properties_last
     - test_types_in_equals
     - throw_in_finally
-    - type_init_formals
-    - unnecessary_brace_in_string_interps
-    - unnecessary_const
-    - unnecessary_getters_setters
+    - unawaited_futures
     - unnecessary_lambdas
-    - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_statements
-    - unnecessary_this

--- a/lib/src/create_report.dart
+++ b/lib/src/create_report.dart
@@ -1233,7 +1233,7 @@ String _makeSummary(List<_Subsection> subsections,
       final statusMarker = reportStatusMarker(subsection.status);
       return [
         '### $statusMarker ${subsection.grantedPoints}/${subsection.maxPoints} points: ${subsection.description}\n',
-        if (subsection.bodyPrefix.isNotEmpty) '${subsection.bodyPrefix}',
+        if (subsection.bodyPrefix.isNotEmpty) subsection.bodyPrefix,
         if (subsection.issues.isNotEmpty &&
             subsection.issues.length <= maxIssues)
           issuesMarkdown.join('\n'),

--- a/lib/src/license.dart
+++ b/lib/src/license.dart
@@ -70,32 +70,32 @@ LicenseFile? detectLicenseInContent(String originalContent,
   }
 
   if (_mpl.hasMatch(stripped)) {
-    return LicenseFile(relativePath, LicenseNames.MPL, version: version);
+    return LicenseFile(relativePath, LicenseNames.mpl, version: version);
   }
   if (_agpl.hasMatch(stripped) && !_useWithAgpl.hasMatch(stripped)) {
-    return LicenseFile(relativePath, LicenseNames.AGPL, version: version);
+    return LicenseFile(relativePath, LicenseNames.agpl, version: version);
   }
   if (_apache.hasMatch(stripped)) {
-    return LicenseFile(relativePath, LicenseNames.Apache, version: version);
+    return LicenseFile(relativePath, LicenseNames.apache, version: version);
   }
   if (_lgpl.hasMatch(stripped) && !_useLgplInstead.hasMatch(stripped)) {
-    return LicenseFile(relativePath, LicenseNames.LGPL, version: version);
+    return LicenseFile(relativePath, LicenseNames.lgpl, version: version);
   }
   if (_gplLong.hasMatch(stripped)) {
-    return LicenseFile(relativePath, LicenseNames.GPL, version: version);
+    return LicenseFile(relativePath, LicenseNames.gpl, version: version);
   }
   if (_gplShort.hasMatch(stripped)) {
-    return LicenseFile(relativePath, LicenseNames.GPL, version: version);
+    return LicenseFile(relativePath, LicenseNames.gpl, version: version);
   }
   if (_mit.hasMatch(stripped) || _mitEmphasis.hasMatch(stripped)) {
-    return LicenseFile(relativePath, LicenseNames.MIT, version: version);
+    return LicenseFile(relativePath, LicenseNames.mit, version: version);
   }
   if (_unlicense.hasMatch(stripped)) {
-    return LicenseFile(relativePath, LicenseNames.Unlicense, version: version);
+    return LicenseFile(relativePath, LicenseNames.unlicense, version: version);
   }
 
   if (_bsdPreamble.hasMatch(stripped) && _bsdEmphasis.hasMatch(stripped)) {
-    return LicenseFile(relativePath, LicenseNames.BSD);
+    return LicenseFile(relativePath, LicenseNames.bsd);
   }
 
   return null;

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -148,15 +148,47 @@ class LicenseFile {
 }
 
 abstract class LicenseNames {
-  static const String AGPL = 'AGPL';
-  static const String Apache = 'Apache';
-  static const String BSD = 'BSD';
-  static const String GPL = 'GPL';
-  static const String LGPL = 'LGPL';
-  static const String MIT = 'MIT';
-  static const String MPL = 'MPL';
-  static const String Unlicense = 'Unlicense';
+  static const String agpl = 'AGPL';
+  static const String apache = 'Apache';
+  static const String bsd = 'BSD';
+  static const String gpl = 'GPL';
+  static const String lgpl = 'LGPL';
+  static const String mit = 'MIT';
+  static const String mpl = 'MPL';
+  static const String unlicense = 'Unlicense';
   static const String unknown = 'unknown';
+
+  @Deprecated('Use LicenseNames.agpl instead.')
+  // ignore: constant_identifier_names
+  static const String AGPL = agpl;
+
+  @Deprecated('Use LicenseNames.apache instead.')
+  // ignore: constant_identifier_names
+  static const String Apache = apache;
+
+  @Deprecated('Use LicenseNames.bsd instead.')
+  // ignore: constant_identifier_names
+  static const String BSD = bsd;
+
+  @Deprecated('Use LicenseNames.gpl instead.')
+  // ignore: constant_identifier_names
+  static const String GPL = gpl;
+
+  @Deprecated('Use LicenseNames.lgpl instead.')
+  // ignore: constant_identifier_names
+  static const String LGPL = lgpl;
+
+  @Deprecated('Use LicenseNames.mit instead.')
+  // ignore: constant_identifier_names
+  static const String MIT = mit;
+
+  @Deprecated('Use LicenseNames.mpl instead.')
+  // ignore: constant_identifier_names
+  static const String MPL = mpl;
+
+  @Deprecated('Use LicenseNames.unlicense instead.')
+  // ignore: constant_identifier_names
+  static const String Unlicense = unlicense;
 }
 
 @JsonSerializable()

--- a/lib/src/pkg_resolution.dart
+++ b/lib/src/pkg_resolution.dart
@@ -274,7 +274,9 @@ List<PkgDependency> _buildDeps(Pubspec pubspec,
           'Package $package has version $resolved but $constraint does not allow it!');
     }
 
-    errors.forEach((error) => log.info('Weird: $error'));
+    for (final error in errors) {
+      log.info('Weird: $error');
+    }
 
     deps.add(PkgDependency(
       package: package,

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -64,16 +64,16 @@ class Pubspec {
   Set<String> get dependentSdks {
     if (_dependentSdks == null) {
       _dependentSdks = SplayTreeSet();
-      dependencies.values.forEach((value) {
+      for (final value in dependencies.values) {
         if (value is SdkDependency) {
           _dependentSdks!.add(value.sdk);
         }
-      });
-      devDependencies.values.forEach((value) {
+      }
+      for (final value in devDependencies.values) {
         if (value is SdkDependency) {
           _dependentSdks!.add(value.sdk);
         }
-      });
+      }
       if (_inner.environment != null) {
         final keys = _inner.environment!.keys.toList();
         keys.remove('sdk');

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -374,7 +374,7 @@ class ToolEnvironment {
     return env;
   }
 
-  @deprecated
+  @Deprecated('Will be removed in a future release.')
   Future activateGlobalDartdoc(String version) async {
     handleProcessErrors(await runProc(
       [..._pubCmd, 'global', 'activate', 'dartdoc', version],

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -374,7 +374,7 @@ class ToolEnvironment {
     return env;
   }
 
-  @Deprecated('Will be removed in a future release.')
+  @Deprecated('Instead specify useGlobalDartdoc as true with ToolEnvironment.create.')
   Future activateGlobalDartdoc(String version) async {
     handleProcessErrors(await runProc(
       [..._pubCmd, 'global', 'activate', 'dartdoc', version],

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -374,7 +374,8 @@ class ToolEnvironment {
     return env;
   }
 
-  @Deprecated('Instead specify useGlobalDartdoc as true with ToolEnvironment.create.')
+  @Deprecated(
+      'Instead specify useGlobalDartdoc as true with ToolEnvironment.create.')
   Future activateGlobalDartdoc(String version) async {
     handleProcessErrors(await runProc(
       [..._pubCmd, 'global', 'activate', 'dartdoc', version],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dev_dependencies:
   build_verify: ^2.0.0
   build_version: ^2.0.0
   json_serializable: ^4.1.2
-  pedantic: ^1.4.0
+  lints: ^1.0.0
   shelf: ^1.0.0
   source_gen: ^1.0.0
   test: ^1.5.2

--- a/test/create_report_test.dart
+++ b/test/create_report_test.dart
@@ -34,7 +34,7 @@ Future<ToolEnvironment> testToolEnvironment() async {
         'frameworkCommitDate': '2021-02-19 10:03:46 +0100',
         'engineRevision': 'b04955656c87de0d80d259792e3a0e4a23b7c260',
         'dartSdkVersion': '2.12.0 (build 2.12.0)',
-        'flutterRoot': '${fakeFlutterRoot.io.path}'
+        'flutterRoot': fakeFlutterRoot.io.path
       },
     ),
   );

--- a/test/end2end_test.dart
+++ b/test/end2end_test.dart
@@ -97,10 +97,10 @@ void main() {
               (map['pkgResolution'] as Map).containsKey('dependencies')) {
             final deps = (map['pkgResolution']['dependencies'] as List)
                 .cast<Map<dynamic, dynamic>>();
-            deps.forEach((Map m) {
+            for (final m in deps) {
               m.remove('resolved');
               m.remove('available');
-            });
+            }
           }
         }
 


### PR DESCRIPTION
Migrates to the `recommended` set of lints from https://pub.dev/packages/lints, removes duplicate linter rules, and fixes the corresponding issues.