### PR TITLE
Detect git monorepo root and copy everything from that root for local analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Limit the length of the source spans in the report.
 * Removed package list of 2.10 null-safety experiments.
+* Detect `git` monorepo root and copy everything from that root for local analysis.
 * Update dependencies to latest.
 * Migration to null-safety.
 


### PR DESCRIPTION
- #895
- I think this is a better solution than `path` rewrites, as it doesn't need to change the `pubspec.yaml` at all.