### PR TITLE
Added meta dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   yaml: ^3.0.0
   safe_url_check: ^1.0.0
   retry: ^3.0.1
+  meta: ^1.4.0
 
 dev_dependencies:
   build: ^2.0.1


### PR DESCRIPTION
Error when publishing:

```
Package validation found the following errors:
* line 82, column 1 of lib/src/tag_detection.dart: This package does not have meta in the `dependencies` section of `pubspec.yaml`.
     ╷
  82 │ import 'package:meta/meta.dart';
     │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ╵
* line 10, column 1 of lib/src/create_report.dart: This package does not have meta in the `dependencies` section of `pubspec.yaml`.
     ╷
  10 │ import 'package:meta/meta.dart';
     │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ╵
```