### PR TITLE
Fix null-safety classification issue with dart-ext: imports.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.19.0
 
+* Fix null-safety classification issue with `dart-ext:` imports.
 * **BREAKING CHANGES**
   * Removed methods from public API: 
     `detectLicenseInContent`, `detectLicenseInDir`, `detectLicenseInFile`,

--- a/lib/src/tag/_common.dart
+++ b/lib/src/tag/_common.dart
@@ -4,7 +4,6 @@
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/session.dart';
-import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 
 /// Creates a [Explanation] indicating an issue, using [path] to give the location
@@ -53,16 +52,8 @@ class TagException implements Exception {
 /// Returns `null` in case of any errors.
 ///
 /// Returns `null` if [uri] points to a part file.
-CompilationUnit? parsedUnitFromUri(
-  AnalysisSession analysisSession,
-  Uri uri, {
-  bool ignoreDartExt = false,
-}) {
+CompilationUnit? parsedUnitFromUri(AnalysisSession analysisSession, Uri uri) {
   final path = analysisSession.uriConverter.uriToPath(uri);
-  if (ignoreDartExt && uri.scheme == 'dart-ext') {
-    // return an empty dart file as a result of the parse
-    return parseString(content: '').unit;
-  }
   if (path == null) {
     // Could not resolve uri.
     // Probably a missing/broken dependency.

--- a/lib/src/tag/_common.dart
+++ b/lib/src/tag/_common.dart
@@ -4,6 +4,7 @@
 
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/analysis/session.dart';
+import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 
 /// Creates a [Explanation] indicating an issue, using [path] to give the location
@@ -52,8 +53,16 @@ class TagException implements Exception {
 /// Returns `null` in case of any errors.
 ///
 /// Returns `null` if [uri] points to a part file.
-CompilationUnit? parsedUnitFromUri(AnalysisSession analysisSession, Uri uri) {
+CompilationUnit? parsedUnitFromUri(
+  AnalysisSession analysisSession,
+  Uri uri, {
+  bool ignoreDartExt = false,
+}) {
   final path = analysisSession.uriConverter.uriToPath(uri);
+  if (ignoreDartExt && uri.scheme == 'dart-ext') {
+    // return an empty dart file as a result of the parse
+    return parseString(content: '').unit;
+  }
   if (path == null) {
     // Could not resolve uri.
     // Probably a missing/broken dependency.

--- a/lib/src/tag/tagger.dart
+++ b/lib/src/tag/tagger.dart
@@ -380,8 +380,8 @@ class Tagger {
           final optOutViolationFinder = PathFinder<Uri>(
             LibraryGraph(_session, runtime.declaredVariables),
             (library) {
-              final unit =
-                  parsedUnitFromUri(_session, library, ignoreDartExt: true);
+              if (library.scheme == 'dart-ext') return null;
+              final unit = parsedUnitFromUri(_session, library);
               if (unit == null) return null;
               final languageVersionToken = unit.languageVersionToken;
               if (languageVersionToken == null) return null;

--- a/lib/src/tag/tagger.dart
+++ b/lib/src/tag/tagger.dart
@@ -380,7 +380,8 @@ class Tagger {
           final optOutViolationFinder = PathFinder<Uri>(
             LibraryGraph(_session, runtime.declaredVariables),
             (library) {
-              final unit = parsedUnitFromUri(_session, library);
+              final unit =
+                  parsedUnitFromUri(_session, library, ignoreDartExt: true);
               if (unit == null) return null;
               final languageVersionToken = unit.languageVersionToken;
               if (languageVersionToken == null) return null;

--- a/lib/src/tag/tagger.dart
+++ b/lib/src/tag/tagger.dart
@@ -381,6 +381,14 @@ class Tagger {
             LibraryGraph(_session, runtime.declaredVariables),
             (library) {
               if (library.scheme == 'dart-ext') return null;
+              final resolvedPath = _session.uriConverter.uriToPath(library);
+              if (resolvedPath == null) {
+                return (path) => Explanation(
+                      'Unable to access import.',
+                      'Because:\n${LibraryGraph.formatPath(path)} where $library is inaccessible.',
+                      tag: _nullSafeTag,
+                    );
+              }
               final unit = parsedUnitFromUri(_session, library);
               if (unit == null) return null;
               final languageVersionToken = unit.languageVersionToken;

--- a/test/tag/tag_null_safe_test.dart
+++ b/test/tag/tag_null_safe_test.dart
@@ -245,6 +245,25 @@ void main() {
         explanations: tagDetectionFailed,
       );
     });
+
+    test('dart-ext: import gets ignored', () async {
+      final descriptor = d.dir('cache', [
+        packageWithPathDeps(
+          'my_package',
+          sdkConstraint: '>=2.12.0 <3.0.0',
+          lib: [
+            d.file('my_package.dart', 'import "dart-ext:rpi_gpio_ext";'),
+          ],
+        ),
+      ]);
+      await descriptor.create();
+      final tagger = Tagger(p.join(descriptor.io.path, 'my_package'));
+      expectTagging(
+        tagger.nullSafetyTags,
+        tags: ['is:null-safe'],
+        explanations: isEmpty,
+      );
+    });
   });
 }
 


### PR DESCRIPTION
- Fixes  #918.
- Adds more details for #891 into the report section.
