### PR TITLE
Allow zero tolerance

### DIFF
--- a/bin/pana.dart
+++ b/bin/pana.dart
@@ -188,7 +188,7 @@ Future main(List<String> args) async {
         print('\nPoints: ${report.grantedPoints}/${report.maxPoints}.');
       }
       if (exitCodeThreshold != null &&
-          exitCodeThreshold > 0 &&
+          exitCodeThreshold >= 0 &&
           exitCodeThreshold + summary.report!.grantedPoints <
               summary.report!.maxPoints) {
         exitCode = -1;


### PR DESCRIPTION
Hi,

I finally got around to trying the fix for [this issue I reported a while back](https://github.com/dart-lang/pana/issues/843) and found a small problem with it. I want to be able to specify zero tolerance for any lost points, but the code requires I set the exit threshold to at least 1 (0 is ignored). This PR fixes that.