### PR TITLE
Normalize line endings in test

### DIFF
--- a/test/bin_pana_test.dart
+++ b/test/bin_pana_test.dart
@@ -34,6 +34,6 @@ void main() {
 
     var readme = File('README.md');
     expect(readme.readAsStringSync().replaceAll('\r\n', '\n'),
-        contains('```\n${File(helpGoldenPath).readAsStringSync()}\n```'));
+        contains('```\n${File(helpGoldenPath).readAsStringSync().replaceAll('\r\n', '\n')}\n```'));
   });
 }

--- a/test/bin_pana_test.dart
+++ b/test/bin_pana_test.dart
@@ -33,7 +33,9 @@ void main() {
     await process.shouldExit(ExitCode.usage.code);
 
     var readme = File('README.md');
-    expect(readme.readAsStringSync().replaceAll('\r\n', '\n'),
-        contains('```\n${File(helpGoldenPath).readAsStringSync().replaceAll('\r\n', '\n')}\n```'));
+    expect(
+        readme.readAsStringSync().replaceAll('\r\n', '\n'),
+        contains(
+            '```\n${File(helpGoldenPath).readAsStringSync().replaceAll('\r\n', '\n')}\n```'));
   });
 }


### PR DESCRIPTION
Fixes a test that is failing on Windows due to line endings not being normalized correctly.