### PR TITLE
Terminate the timeouted processes with sigkill.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Upgraded dependencies: `analyzer` and `json_serializable`.
 * Report a reason when no platform is detected - still lacking more details.
+* Terminate the timeouted processes with `sigkill`.
 
 ## 0.19.0
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -42,7 +42,7 @@ Future<ProcessResult> runProc(
     if (!killed) {
       killMessage = message;
       log.severe('Killing `${arguments.join(' ')}` $killMessage');
-      killed = process.kill();
+      killed = process.kill(ProcessSignal.sigkill);
       log.info('killed `${arguments.join(' ')}` - $killed');
     }
   }


### PR DESCRIPTION
- I think one of the core reasons we have incomplete dartdoc reports may be the lack of kill signal.
- https://github.com/dart-lang/pub-dev/issues/4750