### PR TITLE
Rewrite of UrlChecker and UrlStatus.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
+## 0.20.0
+
+* **BREAKING CHANGES**
+  * `UrlStatus` is converted to a class with fields.
+  * `UrlChecker` internal cache is removed (incl. `maxCacheSize`, `existsInCache`, `markExistsInCache`).
+    Caching implementation should wrap the `UrlChecker.checkUrlExists` method.
+
 ## 0.19.1
 
 * Upgraded dependencies: `analyzer` and `json_serializable`.
 * Report a reason when no platform is detected - still lacking more details.
 * Terminate the timeouted processes with `sigkill`.
 * The `deduplicate` parameter in `runProc` is no longer used and will be ignored.
+* Updated cache handlers for `UrlChecker`.
 
 ## 0.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * **BREAKING CHANGES**
   * `UrlStatus` is converted to a class with fields.
   * `UrlChecker` internal cache is removed (incl. `maxCacheSize`, `existsInCache`, `markExistsInCache`).
-    Caching implementation should wrap the `UrlChecker.checkUrlExists` method.
+    Caching implementations should wrap the `UrlChecker.checkUrlExists` method.
 
 ## 0.19.1
 

--- a/lib/src/license.dart
+++ b/lib/src/license.dart
@@ -37,11 +37,7 @@ Future<String?> getLicenseUrl(
     return null;
   }
   final status = await urlChecker.checkStatus(url);
-  if (status == UrlStatus.exists) {
-    return url;
-  } else {
-    return null;
-  }
+  return status.exists ? url : null;
 }
 
 @visibleForTesting

--- a/lib/src/report/template.dart
+++ b/lib/src/report/template.dart
@@ -70,7 +70,7 @@ Future<ReportSection> followsTemplate(PackageContext context) async {
           suggestion: 'At the time of the analysis `$url` was unreachable.',
         ),
       );
-    } else if (status.exists && !status.isSecure) {
+    } else if (!status.isSecure) {
       issues.add(
         Issue(
           '$name is insecure.',


### PR DESCRIPTION
I'd like to have redis-based URL status caching on pub.dev, and the current methods do not provide a way to cache the missing status, instead it will be retried every time. 

Also: added `flutter.dev` in the default list of internal urls.