### PR TITLE
Track and store URL problems in the Summary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.20.0
 
 * Fix SDK version parsing issue (also reading `stdout` for newer SDKs).
+* `Summary.urlProblems` lists the URLs that should be displayed differently on `pub.dev`.
 * **BREAKING CHANGES**
   * `UrlStatus` is converted to a class with fields.
   * `UrlChecker` internal cache is removed (incl. `maxCacheSize`, `existsInCache`, `markExistsInCache`).

--- a/lib/src/download_utils.dart
+++ b/lib/src/download_utils.dart
@@ -133,6 +133,18 @@ class UrlStatus {
         isInternal = false,
         isSecure = false,
         exists = false;
+
+  /// Returns a brief problem code that can be displayed when linking to it.
+  /// Returns `null` when URL has no problem.
+  String? getProblemCode({
+    required bool packageIsKnownInternal,
+  }) {
+    if (isInvalid) return 'invalid';
+    if (isInternal && !packageIsKnownInternal) return 'internal';
+    if (!isSecure) return 'insecure';
+    if (!exists) return 'missing';
+    return null;
+  }
 }
 
 /// Checks if an URL is valid and accessible.

--- a/lib/src/download_utils.dart
+++ b/lib/src/download_utils.dart
@@ -13,6 +13,7 @@ import 'package:safe_url_check/safe_url_check.dart';
 import 'package:tar/tar.dart';
 
 import 'logging.dart';
+import 'model.dart';
 
 final _imageExtensions = <String>{'.gif', '.jpg', '.jpeg', '.png'};
 
@@ -139,10 +140,12 @@ class UrlStatus {
   String? getProblemCode({
     required bool packageIsKnownInternal,
   }) {
-    if (isInvalid) return 'invalid';
-    if (isInternal && !packageIsKnownInternal) return 'internal';
-    if (!isSecure) return 'insecure';
-    if (!exists) return 'missing';
+    if (isInvalid) return UrlProblemCodes.invalid;
+    if (isInternal && !packageIsKnownInternal) {
+      return UrlProblemCodes.internal;
+    }
+    if (!isSecure) return UrlProblemCodes.insecure;
+    if (!exists) return UrlProblemCodes.missing;
     return null;
   }
 }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -286,6 +286,8 @@ class ReportSection {
 @JsonSerializable()
 class UrlProblem {
   final String url;
+
+  /// One of [UrlProblemCodes].
   final String problem;
 
   UrlProblem({
@@ -297,4 +299,12 @@ class UrlProblem {
       _$UrlProblemFromJson(json);
 
   Map<String, dynamic> toJson() => _$UrlProblemToJson(this);
+}
+
+/// Possible values for [UrlProblem.problem].
+abstract class UrlProblemCodes {
+  static const invalid = 'invalid';
+  static const internal = 'internal';
+  static const insecure = 'insecure';
+  static const missing = 'missing';
 }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -27,6 +27,9 @@ class Summary {
   final List<String>? tags;
   final Report? report;
 
+  /// URLs that are invalid, unsafe or missing.
+  final List<UrlProblem>? urlProblems;
+
   /// Markdown-formatted text with errors encountered by `pana`.
   final String? errorMessage;
 
@@ -39,6 +42,7 @@ class Summary {
     this.licenseFile,
     this.tags,
     this.report,
+    this.urlProblems,
     this.errorMessage,
   });
 
@@ -60,6 +64,7 @@ class Summary {
       licenseFile: licenseFile,
       tags: tags ?? this.tags,
       report: report,
+      urlProblems: urlProblems,
       errorMessage: errorMessage,
     );
   }
@@ -276,4 +281,20 @@ class ReportSection {
       _$ReportSectionFromJson(json);
 
   Map<String, dynamic> toJson() => _$ReportSectionToJson(this);
+}
+
+@JsonSerializable()
+class UrlProblem {
+  final String url;
+  final String problem;
+
+  UrlProblem({
+    required this.url,
+    required this.problem,
+  });
+
+  factory UrlProblem.fromJson(Map<String, dynamic> json) =>
+      _$UrlProblemFromJson(json);
+
+  Map<String, dynamic> toJson() => _$UrlProblemToJson(this);
 }

--- a/lib/src/model.g.dart
+++ b/lib/src/model.g.dart
@@ -25,6 +25,9 @@ Summary _$SummaryFromJson(Map<String, dynamic> json) => Summary(
       report: json['report'] == null
           ? null
           : Report.fromJson(json['report'] as Map<String, dynamic>),
+      urlProblems: (json['urlProblems'] as List<dynamic>?)
+          ?.map((e) => UrlProblem.fromJson(e as Map<String, dynamic>))
+          .toList(),
       errorMessage: json['errorMessage'] as String?,
     );
 
@@ -47,6 +50,7 @@ Map<String, dynamic> _$SummaryToJson(Summary instance) {
   writeNotNull('allDependencies', instance.allDependencies);
   writeNotNull('tags', instance.tags);
   writeNotNull('report', instance.report);
+  writeNotNull('urlProblems', instance.urlProblems);
   writeNotNull('errorMessage', instance.errorMessage);
   return val;
 }
@@ -159,3 +163,14 @@ const _$ReportStatusEnumMap = {
   ReportStatus.partial: 'partial',
   ReportStatus.passed: 'passed',
 };
+
+UrlProblem _$UrlProblemFromJson(Map<String, dynamic> json) => UrlProblem(
+      url: json['url'] as String,
+      problem: json['problem'] as String,
+    );
+
+Map<String, dynamic> _$UrlProblemToJson(UrlProblem instance) =>
+    <String, dynamic>{
+      'url': instance.url,
+      'problem': instance.problem,
+    };

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -199,6 +199,10 @@ class PackageAnalyzer {
       licenseFile: licenseFile?.change(url: licenseUrl),
       tags: tags,
       report: await createReport(context),
+      urlProblems: context.urlProblems.entries
+          .map((e) => UrlProblem(url: e.key, problem: e.value))
+          .toList()
+            ..sort((a, b) => a.url.compareTo(b.url)),
       errorMessage: errorMessage,
     );
   }

--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -26,6 +26,7 @@ class PackageContext {
   final InspectOptions options;
   final UrlChecker urlChecker;
   final errors = <String>[];
+  final urlProblems = <String, String>{};
 
   Version? _currentSdkVersion;
   Pubspec? _pubspec;

--- a/lib/src/report/template.dart
+++ b/lib/src/report/template.dart
@@ -79,6 +79,11 @@ Future<ReportSection> followsTemplate(PackageContext context) async {
         ),
       );
     }
+    final problemCode =
+        status.getProblemCode(packageIsKnownInternal: options.isInternal);
+    if (problemCode != null) {
+      context.urlProblems[url] = problemCode;
+    }
     return issues;
   }
 

--- a/test/download_utils_test.dart
+++ b/test/download_utils_test.dart
@@ -80,4 +80,47 @@ void main() {
           'https://github.com/daniel-maxhari/dynamic_text_highlighting/blob/master/subdir/LICENSE');
     });
   });
+
+  group('UrlChecker', () {
+    test('problem: invalid', () async {
+      final status = await UrlChecker().checkStatus('htp://pub.dev/');
+      expect(status.isInvalid, true);
+      expect(status.isInternal, false);
+      expect(status.isSecure, false);
+      expect(status.exists, false);
+      expect(status.getProblemCode(packageIsKnownInternal: false), 'invalid');
+      expect(status.getProblemCode(packageIsKnownInternal: true), 'invalid');
+    });
+
+    test('problem: internal', () async {
+      final status = await UrlChecker().checkStatus('https://pub.dev/');
+      expect(status.isInvalid, false);
+      expect(status.isInternal, true);
+      expect(status.isSecure, true);
+      expect(status.exists, true);
+      expect(status.getProblemCode(packageIsKnownInternal: false), 'internal');
+      expect(status.getProblemCode(packageIsKnownInternal: true), isNull);
+    });
+
+    test('problem: insecure', () async {
+      final status = await UrlChecker().checkStatus('http://pub.dev/');
+      expect(status.isInvalid, false);
+      expect(status.isInternal, true);
+      expect(status.isSecure, false);
+      expect(status.exists, true);
+      expect(status.getProblemCode(packageIsKnownInternal: false), 'internal');
+      expect(status.getProblemCode(packageIsKnownInternal: true), 'insecure');
+    });
+
+    test('problem: missing', () async {
+      final status = await UrlChecker()
+          .checkStatus('https://github.com/dart-lang/pub-dev/missing-url');
+      expect(status.isInvalid, false);
+      expect(status.isInternal, false);
+      expect(status.isSecure, true);
+      expect(status.exists, false);
+      expect(status.getProblemCode(packageIsKnownInternal: false), 'missing');
+      expect(status.getProblemCode(packageIsKnownInternal: true), 'missing');
+    });
+  });
 }

--- a/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
+++ b/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
@@ -73,5 +73,6 @@
       }
     ]
   },
+  "urlProblems": [],
   "errorMessage": "Running `dart pub upgrade` failed with the following output:\n\n```\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.\n```"
 }

--- a/test/goldens/end2end/async-2.5.0.json
+++ b/test/goldens/end2end/async-2.5.0.json
@@ -101,5 +101,6 @@
         "summary": "### [*] 20/20 points: Package and dependencies are fully migrated to null safety!\n"
       }
     ]
-  }
+  },
+  "urlProblems": []
 }

--- a/test/goldens/end2end/audio_service-0.17.0.json
+++ b/test/goldens/end2end/audio_service-0.17.0.json
@@ -167,5 +167,6 @@
         "summary": "### [*] 20/20 points: Package and dependencies are fully migrated to null safety!\n"
       }
     ]
-  }
+  },
+  "urlProblems": []
 }

--- a/test/goldens/end2end/bulma_min-0.7.4.json
+++ b/test/goldens/end2end/bulma_min-0.7.4.json
@@ -86,5 +86,6 @@
         "summary": "### [~] 0/20 points: Package does not opt in to null safety.\n\n<details>\n<summary>\nPackage language version (indicated by the sdk constraint `>=1.0.0 <3.0.0`) is less than 2.12.\n</summary>\n\nConsider [migrating](https://dart.dev/null-safety/migration-guide).\n</details>"
       }
     ]
-  }
+  },
+  "urlProblems": []
 }

--- a/test/goldens/end2end/dnd-2.0.0.json
+++ b/test/goldens/end2end/dnd-2.0.0.json
@@ -88,5 +88,6 @@
         "summary": "### [*] 20/20 points: Package and dependencies are fully migrated to null safety!\n"
       }
     ]
-  }
+  },
+  "urlProblems": []
 }

--- a/test/goldens/end2end/http-0.13.0.json
+++ b/test/goldens/end2end/http-0.13.0.json
@@ -109,5 +109,6 @@
         "summary": "### [*] 20/20 points: Package and dependencies are fully migrated to null safety!\n"
       }
     ]
-  }
+  },
+  "urlProblems": []
 }

--- a/test/goldens/end2end/lints-1.0.0.json
+++ b/test/goldens/end2end/lints-1.0.0.json
@@ -84,5 +84,6 @@
         "summary": "### [*] 20/20 points: Package and dependencies are fully migrated to null safety!\n"
       }
     ]
-  }
+  },
+  "urlProblems": []
 }

--- a/test/goldens/end2end/mime_type-0.3.2.json
+++ b/test/goldens/end2end/mime_type-0.3.2.json
@@ -85,5 +85,6 @@
         "summary": "### [~] 0/20 points: Package does not opt in to null safety.\n\n<details>\n<summary>\nPackage language version (indicated by the sdk constraint `>=0.8.10 <3.0.0`) is less than 2.12.\n</summary>\n\nConsider [migrating](https://dart.dev/null-safety/migration-guide).\n</details>"
       }
     ]
-  }
+  },
+  "urlProblems": []
 }

--- a/test/goldens/end2end/sdp_transform-0.2.0.json
+++ b/test/goldens/end2end/sdp_transform-0.2.0.json
@@ -95,5 +95,6 @@
         "summary": "### [~] 0/20 points: Package does not opt in to null safety.\n\n<details>\n<summary>\nPackage language version (indicated by the sdk constraint `<3.0.0`) is less than 2.12.\n</summary>\n\nConsider [migrating](https://dart.dev/null-safety/migration-guide).\n</details>"
       }
     ]
-  }
+  },
+  "urlProblems": []
 }

--- a/test/goldens/end2end/skiplist-0.1.0.json
+++ b/test/goldens/end2end/skiplist-0.1.0.json
@@ -77,5 +77,6 @@
       }
     ]
   },
+  "urlProblems": [],
   "errorMessage": "Running `dart pub upgrade` failed with the following output:\n\n```\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because skiplist depends on quiver_iterables >=1.0.0 which requires SDK version >=1.9.0 <2.0.0, version solving failed.\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because skiplist depends on quiver_iterables >=1.0.0 which requires SDK version >=1.9.0 <2.0.0, version solving failed.\n```"
 }

--- a/test/goldens/end2end/url_launcher-6.0.3.json
+++ b/test/goldens/end2end/url_launcher-6.0.3.json
@@ -147,5 +147,6 @@
         "summary": "### [*] 20/20 points: Package and dependencies are fully migrated to null safety!\n"
       }
     ]
-  }
+  },
+  "urlProblems": []
 }

--- a/test/goldens/end2end/webdriver-3.0.0.json
+++ b/test/goldens/end2end/webdriver-3.0.0.json
@@ -98,5 +98,6 @@
         "summary": "### [*] 20/20 points: Package and dependencies are fully migrated to null safety!\n"
       }
     ]
-  }
+  },
+  "urlProblems": []
 }


### PR DESCRIPTION
- https://github.com/dart-lang/pub-dev/issues/4902
- Only URLs with problems are stored (assuming it will be the rare case).
- URLs in `README.md` and `CHANGELOG.md` could also go into this list (in a future change).
- Tested with `random_names`, I wouldn't put it to the end2end list for now, I'd rather look for a package that has a problem in their readme.