### PR TITLE
Fix SDK version parsing issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.20.0
 
+* Fix SDK version parsing issue (also reading `stdout` for newer SDKs).
 * **BREAKING CHANGES**
   * `UrlStatus` is converted to a class with fields.
   * `UrlChecker` internal cache is removed (incl. `maxCacheSize`, `existsInCache`, `markExistsInCache`).

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -16,7 +16,6 @@ import 'model.dart' show PanaRuntimeInfo;
 import 'package_analyzer.dart' show InspectOptions;
 import 'pubspec_io.dart';
 import 'utils.dart';
-// ignore: import_of_legacy_library_into_null_safe
 import 'version.dart';
 
 const _dartfmtTimeout = Duration(minutes: 5);
@@ -83,8 +82,7 @@ class ToolEnvironment {
   Future _init() async {
     final dartVersionResult = _handleProcessErrors(
         await runProc([..._dartCmd, '--version'], environment: _environment));
-    final dartVersionString = dartVersionResult.stderr.toString().trim();
-    final dartSdkInfo = DartSdkInfo.parse(dartVersionString);
+    final dartSdkInfo = DartSdkInfo.parse(dartVersionResult.asJoinedOutput);
     Map<String, dynamic>? flutterVersions;
     try {
       flutterVersions = await getFlutterVersion();

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -501,10 +501,13 @@ class DartSdkInfo {
   DartSdkInfo._(this.version, this.dateString, this.platform);
 
   factory DartSdkInfo.parse(String versionOutput) {
-    var match = _sdkRegexp.firstMatch(versionOutput);
-    var version = Version.parse(match![1]!);
-    var dateString = match[2];
-    var platform = match[3];
+    final match = _sdkRegexp.firstMatch(versionOutput);
+    if (match == null) {
+      throw FormatException('Couldn\'t parse Dart SDK version: $versionOutput');
+    }
+    final version = Version.parse(match[1]!);
+    final dateString = match[2];
+    final platform = match[3];
 
     return DartSdkInfo._(version, dateString, platform);
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -222,3 +222,14 @@ Future<String> getVersionListing(String package, {Uri? pubHostedUrl}) async {
   return await retry(() => http.read(url),
       retryIf: (e) => e is SocketException || e is TimeoutException);
 }
+
+extension ProcessResultExt on ProcessResult {
+  /// Returns the line-concatened output of [stdout] and [stderr]
+  /// (both converted to [String]), and the final output trimmed.
+  String get asJoinedOutput {
+    return [
+      stdout.toString().trim(),
+      stderr.toString().trim(),
+    ].join('\n').trim();
+  }
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -224,12 +224,12 @@ Future<String> getVersionListing(String package, {Uri? pubHostedUrl}) async {
 }
 
 extension ProcessResultExt on ProcessResult {
-  /// Returns the line-concatened output of [stdout] and [stderr]
+  /// Returns the line-concatened output of `stdout` and `stderr`
   /// (both converted to [String]), and the final output trimmed.
   String get asJoinedOutput {
     return [
-      stdout.toString().trim(),
-      stderr.toString().trim(),
+      this.stdout.toString().trim(),
+      this.stderr.toString().trim(),
     ].join('\n').trim();
   }
 }

--- a/test/sdk_env_test.dart
+++ b/test/sdk_env_test.dart
@@ -25,4 +25,22 @@ void main() {
     expect(sdkInfo.dateString, 'Fri Mar 27 10:16:29 2020 +0000');
     expect(sdkInfo.platform, 'linux_x64');
   });
+
+  test('parsing SDK version newest style', () {
+    final version =
+        'Dart SDK version: 2.15.0-edge.e8ddc0219f1e8f1ad784143fec693890e2b81954 (be) (Fri Aug 13 13:27:41 2021 +0000) on "macos_x64"';
+    final sdkInfo = DartSdkInfo.parse(version);
+    expect(sdkInfo.version,
+        Version.parse('2.15.0-edge.e8ddc0219f1e8f1ad784143fec693890e2b81954'));
+    expect(sdkInfo.dateString, 'Fri Aug 13 13:27:41 2021 +0000');
+    expect(sdkInfo.platform, 'macos_x64');
+  });
+
+  test('fail to parse', () {
+    expect(() => DartSdkInfo.parse('-'), throwsA(isA<FormatException>()));
+    expect(
+        () => DartSdkInfo.parse(
+            'Dart VM version: 2.0.0.0 (Wed Apr 18 20:41:36 2018 +0200) on "macos_x64"'),
+        throwsA(isA<FormatException>()));
+  });
 }


### PR DESCRIPTION
- #941
- Throw `FormatException` when SDK version parsing fails.
- Read both `stdout` and `stderr`, as newer SDKs switched to `stdout`.