### PR TITLE
Better handling of `runProc` timeout or output exceeded errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.21.2
 
 - Consistent license evaluation order.
+- Better handling of timeout or output exceeded.
 
 ## 0.21.1+1
 

--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -16,7 +16,7 @@ import 'pkg_resolution.dart';
 import 'pubspec.dart';
 import 'pubspec_io.dart';
 import 'sdk_env.dart';
-import 'utils.dart' show listFocusDirs, ProcessResultExt;
+import 'utils.dart' show listFocusDirs;
 
 /// Calculates and stores the intermediate analysis and processing results that
 /// are required for the final report.

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -186,6 +186,11 @@ class ToolEnvironment {
         workingDirectory: packageDir,
         timeout: const Duration(minutes: 5),
       );
+      final error = proc.stderr.toString().trim();
+      if (error.startsWith('Output exceeded ')) {
+        throw ToolException(
+            'Running `dart analyze` produced too large output.');
+      }
       final output = proc.asJoinedOutput;
       if (output.startsWith('Exceeded timeout of ')) {
         throw ToolException('Running `dart analyze` timed out.');

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -86,14 +86,14 @@ Future<ProcessResult> runProc(
       exitCode,
       stdoutLines
           .map(systemEncoding.decode)
-          .map(const LineSplitter().convert)
+          .expand(const LineSplitter().convert)
           .take(_maxOutputLinesWhenKilled)
           .join('\n'),
       [
         if (killMessage != null) killMessage,
         ...stderrLines
             .map(systemEncoding.decode)
-            .map(const LineSplitter().convert)
+            .expand(const LineSplitter().convert)
             .take(_maxOutputLinesWhenKilled),
       ].join('\n'),
     );

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -25,7 +25,7 @@ const _maxOutputLinesWhenKilled = 1000;
 /// Kills the process if its output is more than [maxOutputBytes] (10 MiB if not specified).
 ///
 /// If the process is killed, it returns only the first 1000 lines of both `stdout` and `stderr`.
-Future<ProcessResult> runProc(
+Future<PanaProcessResult> runProc(
   List<String> arguments, {
   String? workingDirectory,
   Map<String, String>? environment,
@@ -44,6 +44,8 @@ Future<ProcessResult> runProc(
   var remainingBytes = maxOutputBytes;
 
   var killed = false;
+  var wasTimeout = false;
+  var wasOutputExceeded = false;
   String? killMessage;
 
   void killProc(String message) {
@@ -56,6 +58,7 @@ Future<ProcessResult> runProc(
   }
 
   var timer = Timer(timeout, () {
+    wasTimeout = true;
     killProc('Exceeded timeout of $timeout');
   });
 
@@ -65,6 +68,7 @@ Future<ProcessResult> runProc(
       stdoutLines.add(outLine);
       remainingBytes -= outLine.length;
       if (remainingBytes < 0) {
+        wasOutputExceeded = true;
         killProc('Output exceeded $maxOutputBytes bytes.');
       }
     }),
@@ -72,6 +76,7 @@ Future<ProcessResult> runProc(
       stderrLines.add(errLine);
       remainingBytes -= errLine.length;
       if (remainingBytes < 0) {
+        wasOutputExceeded = true;
         killProc('Output exceeded $maxOutputBytes bytes.');
       }
     })
@@ -81,7 +86,7 @@ Future<ProcessResult> runProc(
 
   final exitCode = items[0] as int;
   if (killed) {
-    return ProcessResult(
+    return PanaProcessResult(
       process.pid,
       exitCode,
       stdoutLines
@@ -96,14 +101,18 @@ Future<ProcessResult> runProc(
             .expand(const LineSplitter().convert)
             .take(_maxOutputLinesWhenKilled),
       ].join('\n'),
+      wasTimeout: wasTimeout,
+      wasOutputExceeded: wasOutputExceeded,
     );
   }
 
-  return ProcessResult(
+  return PanaProcessResult(
     process.pid,
     exitCode,
     stdoutLines.map(systemEncoding.decode).join(),
     stderrLines.map(systemEncoding.decode).join(),
+    wasTimeout: wasTimeout,
+    wasOutputExceeded: wasOutputExceeded,
   );
 }
 
@@ -235,7 +244,19 @@ Future<String> getVersionListing(String package, {Uri? pubHostedUrl}) async {
       retryIf: (e) => e is SocketException || e is TimeoutException);
 }
 
-extension ProcessResultExt on ProcessResult {
+class PanaProcessResult extends ProcessResult {
+  final bool wasTimeout;
+  final bool wasOutputExceeded;
+
+  PanaProcessResult(
+    int pid,
+    int exitCode,
+    String stdout,
+    String stderr, {
+    this.wasTimeout = false,
+    this.wasOutputExceeded = false,
+  }) : super(pid, exitCode, stdout, stderr);
+
   /// Returns the line-concatened output of `stdout` and `stderr`
   /// (both converted to [String]), and the final output trimmed.
   String get asJoinedOutput {

--- a/test/self_run_test.dart
+++ b/test/self_run_test.dart
@@ -9,7 +9,7 @@ void main() {
   test('running pana locally with relative path', () async {
     final pr = await runProc(
       ['dart', 'bin/pana.dart', '--no-warning', '.'],
-      timeout: const Duration(minutes: 1),
+      timeout: const Duration(minutes: 2),
     );
     expect(pr.exitCode, 0, reason: pr.asJoinedOutput);
 

--- a/test/self_run_test.dart
+++ b/test/self_run_test.dart
@@ -7,8 +7,11 @@ import 'package:test/test.dart';
 
 void main() {
   test('running pana locally with relative path', () async {
-    final pr = await runProc(['dart', 'bin/pana.dart', '.']);
-    expect(pr.exitCode, 0);
+    final pr = await runProc(
+      ['dart', 'bin/pana.dart', '.'],
+      timeout: const Duration(minutes: 1),
+    );
+    expect(pr.exitCode, 0, reason: pr.asJoinedOutput);
 
     final output = pr.stdout.toString();
     final snippets = [

--- a/test/self_run_test.dart
+++ b/test/self_run_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 void main() {
   test('running pana locally with relative path', () async {
     final pr = await runProc(
-      ['dart', 'bin/pana.dart', '.'],
+      ['dart', 'bin/pana.dart', '--no-warning', '.'],
       timeout: const Duration(minutes: 1),
     );
     expect(pr.exitCode, 0, reason: pr.asJoinedOutput);


### PR DESCRIPTION
- Fixes #966.
- Creates an extended `ProcessResult` class for the additional information of timeout or output exceeded. 