### PR TITLE
Fail gracefully on source code parsing bugs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Consistent license evaluation order.
 - Better handling of timeout or output exceeded.
+- Better handling of analyzer/code parsing errors.
 
 ## 0.21.1+1
 


### PR DESCRIPTION
This helps to unblock analysis on bugs like #914: the URI of the source code is exposed in the report, the exception is logged with stacktrace and warning, and we will no longer display a forever-awaiting status on packages like that (e.g. `wialon 1.0.1+1`). 
