### PR TITLE
Deprecate and don't populate LicenseFile.url + getRepositoryUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.21.4
+
+- NOTE: `LicenseFile.url` and `getRepositoryUrl` is deprecated, will be removed in a future release.
+
 ## 0.21.3
 
 - Tag Flutter plugins with `is:plugin`.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,6 +6,9 @@ analyzer:
     unused_import: error
     unused_local_variable: error
     dead_code: error
+  exclude:
+    # TODO: removed after LicenseFile.url gets removed
+    - lib/src/model.g.dart
 
 linter:
   rules:

--- a/lib/src/download_utils.dart
+++ b/lib/src/download_utils.dart
@@ -55,6 +55,7 @@ Future<void> downloadPackage(
 }
 
 /// Returns an URL that is likely the downloadable URL of the given path.
+@Deprecated('The method will be removed in a future release.')
 String? getRepositoryUrl(String? repository, String relativePath) {
   if (repository == null || repository.isEmpty) return null;
   for (var key in _repoReplacePrefixes.keys) {

--- a/lib/src/license.dart
+++ b/lib/src/license.dart
@@ -12,7 +12,6 @@ import 'package:meta/meta.dart';
 import 'package:pana/src/license_detection/license_detector.dart';
 import 'package:path/path.dart' as p;
 
-import 'download_utils.dart';
 import 'maintenance.dart';
 import 'model.dart';
 
@@ -23,22 +22,6 @@ Future<LicenseFile?> detectLicenseInDir(String baseDir) async {
     return detectLicenseInFile(file, relativePath: candidate);
   }
   return null;
-}
-
-Future<String?> getLicenseUrl(
-    UrlChecker urlChecker, String? baseUrl, LicenseFile? license) async {
-  if (baseUrl == null || baseUrl.isEmpty) {
-    return null;
-  }
-  if (license == null || license.path.isEmpty) {
-    return null;
-  }
-  final url = getRepositoryUrl(baseUrl, license.path);
-  if (url == null) {
-    return null;
-  }
-  final status = await urlChecker.checkStatus(url);
-  return status.exists ? url : null;
 }
 
 @visibleForTesting

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -116,6 +116,7 @@ class LicenseFile {
   final String path;
   final String name;
   final String? version;
+  @Deprecated('`url` is deprecated and will be removed in a future release')
   final String? url;
 
   LicenseFile(this.path, this.name, {this.version, this.url});
@@ -125,6 +126,7 @@ class LicenseFile {
 
   Map<String, dynamic> toJson() => _$LicenseFileToJson(this);
 
+  @Deprecated('`url` is deprecated and will be removed in a future release')
   LicenseFile change({String? url}) =>
       LicenseFile(path, name, version: version, url: url ?? this.url);
 
@@ -141,10 +143,12 @@ class LicenseFile {
           path == other.path &&
           name == other.name &&
           version == other.version &&
+          // ignore: deprecated_member_use_from_same_package
           url == other.url;
 
   @override
   int get hashCode =>
+      // ignore: deprecated_member_use_from_same_package
       path.hashCode ^ name.hashCode ^ version.hashCode ^ url.hashCode;
 }
 

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -184,8 +184,6 @@ class PackageAnalyzer {
     }
 
     final licenseFile = await detectLicenseInDir(pkgDir);
-    final licenseUrl = await getLicenseUrl(
-        _urlChecker, pubspec.repository ?? pubspec.homepage, licenseFile);
 
     final errorMessage = context.errors.isEmpty
         ? null
@@ -197,7 +195,7 @@ class PackageAnalyzer {
       pubspec: pubspec,
       allDependencies:
           pkgResolution?.dependencies.map((d) => d.package).toList(),
-      licenseFile: licenseFile?.change(url: licenseUrl),
+      licenseFile: licenseFile,
       tags: tags,
       report: await createReport(context),
       urlProblems: context.urlProblems.entries

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.21.3';
+const packageVersion = '0.21.4-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.21.3
+version: 0.21.4-dev
 homepage: https://github.com/dart-lang/pana
 
 environment:

--- a/test/download_utils_test.dart
+++ b/test/download_utils_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'package:pana/src/download_utils.dart';
 import 'package:test/test.dart';
 

--- a/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
+++ b/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
@@ -17,8 +17,7 @@
   },
   "licenseFile": {
     "path": "LICENSE",
-    "name": "BSD-3-Clause",
-    "url": "https://github.com/dart-lang/pub-dev/blob/master/LICENSE"
+    "name": "BSD-3-Clause"
   },
   "tags": [],
   "report": {

--- a/test/goldens/end2end/async-2.5.0.json
+++ b/test/goldens/end2end/async-2.5.0.json
@@ -26,8 +26,7 @@
   },
   "licenseFile": {
     "path": "LICENSE",
-    "name": "BSD-3-Clause",
-    "url": "https://github.com/dart-lang/async/blob/master/LICENSE"
+    "name": "BSD-3-Clause"
   },
   "allDependencies": [
     "collection",

--- a/test/goldens/end2end/bulma_min-0.7.4.json
+++ b/test/goldens/end2end/bulma_min-0.7.4.json
@@ -18,8 +18,7 @@
   },
   "licenseFile": {
     "path": "LICENSE",
-    "name": "MIT",
-    "url": "https://github.com/agilord/bulma_min/blob/master/LICENSE"
+    "name": "MIT"
   },
   "allDependencies": [],
   "tags": [

--- a/test/goldens/end2end/dnd-2.0.0.json
+++ b/test/goldens/end2end/dnd-2.0.0.json
@@ -23,8 +23,7 @@
   },
   "licenseFile": {
     "path": "LICENSE",
-    "name": "MIT",
-    "url": "https://github.com/marcojakob/dart-dnd/blob/master/LICENSE"
+    "name": "MIT"
   },
   "allDependencies": [
     "build_runner",

--- a/test/goldens/end2end/http-0.13.0.json
+++ b/test/goldens/end2end/http-0.13.0.json
@@ -27,8 +27,7 @@
   },
   "licenseFile": {
     "path": "LICENSE",
-    "name": "BSD-3-Clause",
-    "url": "https://github.com/dart-lang/http/blob/master/LICENSE"
+    "name": "BSD-3-Clause"
   },
   "allDependencies": [
     "charcode",

--- a/test/goldens/end2end/sdp_transform-0.2.0.json
+++ b/test/goldens/end2end/sdp_transform-0.2.0.json
@@ -25,8 +25,7 @@
   },
   "licenseFile": {
     "path": "LICENSE",
-    "name": "MIT",
-    "url": "https://github.com/cloudwebrtc/dart-sdp-transform/blob/master/LICENSE"
+    "name": "MIT"
   },
   "allDependencies": [
     "test"

--- a/test/goldens/end2end/skiplist-0.1.0.json
+++ b/test/goldens/end2end/skiplist-0.1.0.json
@@ -21,8 +21,7 @@
   },
   "licenseFile": {
     "path": "LICENSE",
-    "name": "MIT",
-    "url": "https://github.com/stevenroose/dart-skiplist/blob/master/LICENSE"
+    "name": "MIT"
   },
   "tags": [],
   "report": {

--- a/test/goldens/end2end/url_launcher-6.0.3.json
+++ b/test/goldens/end2end/url_launcher-6.0.3.json
@@ -62,8 +62,7 @@
   },
   "licenseFile": {
     "path": "LICENSE",
-    "name": "BSD-3-Clause",
-    "url": "https://github.com/flutter/plugins/blob/master/packages/url_launcher/url_launcher/LICENSE"
+    "name": "BSD-3-Clause"
   },
   "allDependencies": [
     "characters",

--- a/test/goldens/end2end/webdriver-3.0.0.json
+++ b/test/goldens/end2end/webdriver-3.0.0.json
@@ -28,8 +28,7 @@
   },
   "licenseFile": {
     "path": "LICENSE",
-    "name": "Apache-2.0",
-    "url": "https://github.com/google/webdriver.dart/blob/master/LICENSE"
+    "name": "Apache-2.0"
   },
   "allDependencies": [
     "archive",


### PR DESCRIPTION
- `pub.dev` uses license file from the package archive
- as we no longer need the link, the utility method can be moved off of pana, and be part of pub-dev
- https://github.com/dart-lang/pub-dev/issues/5068
- this would make #981 most likely short-lived here, but the code and test can be moved to pub-dev