### PR TITLE
Fix platform classification for Flutter plugins without Dart or asset files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - `getRepositoryUrl` with custom `branch` parameter (defaults to `master`).
 - NOTE: `LicenseFile.url` and `getRepositoryUrl` is deprecated, will be removed in a future release.
+- Fix platform classification for Flutter plugins without Dart or asset files.
 
 ## 0.21.3
 

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -101,7 +101,6 @@ class PackageAnalyzer {
     );
 
     final dartFiles = <String>[];
-    final libAssets = <String>[];
     final fileList = listFiles(pkgDir, deleteBadExtracted: true);
     await for (final file in fileList) {
       final isInBin = path.isWithin('bin', file);
@@ -109,9 +108,6 @@ class PackageAnalyzer {
       final isDart = file.endsWith('.dart');
       if (isDart && (isInLib || isInBin)) {
         dartFiles.add(file);
-      }
-      if (!isDart && isInLib) {
-        libAssets.add(file);
       }
     }
 
@@ -169,7 +165,7 @@ class PackageAnalyzer {
           context.errors
               .add(runningDartanalyzerFailed(context.usesFlutter, e.message));
         }
-      } else if (libAssets.isNotEmpty) {
+      } else {
         analyzerItems = <CodeProblem>[];
       }
       if (analyzerItems != null && !analyzerItems.any((item) => item.isError)) {

--- a/lib/src/tag/tagger.dart
+++ b/lib/src/tag/tagger.dart
@@ -271,19 +271,16 @@ class Tagger {
                       'Because:\n${LibraryGraph.formatPath(path)}',
                       tag: flutterPlatform.tag)));
           // Report only the first non-pruned violation as Explanation
-          final firstNonPrunedViolation = _topLibraries
-              .map(violationFinder.findPlatformViolation)
-              .firstWhere((e) => e != null, orElse: () => null);
+          final firstNonPrunedViolation =
+              violationFinder.firstViolation(packageName, _topLibraries);
           if (firstNonPrunedViolation != null) {
             explanations.add(firstNonPrunedViolation);
           }
 
           // Tag is supported, if there is no pruned violations
-          final supports = _topLibraries
-              .map(prunedViolationFinder.findPlatformViolation)
-              .every((e) => e == null);
-
-          if (supports) {
+          final firstPrunedViolation =
+              prunedViolationFinder.firstViolation(packageName, _topLibraries);
+          if (firstPrunedViolation == null) {
             tags.add(flutterPlatform.tag);
           }
         }

--- a/test/end2end_test.dart
+++ b/test/end2end_test.dart
@@ -155,6 +155,9 @@ void main() {
   // flutter-only package
   _verifyPackage('url_launcher', '6.0.3');
 
+  // single-platform Flutter plugin without Dart files or assets
+  _verifyPackage('nsd_android', '1.0.2');
+
   // multi-level symlink
   _verifyPackage('audio_service', '0.17.0');
 

--- a/test/goldens/end2end/nsd_android-1.0.2.json
+++ b/test/goldens/end2end/nsd_android-1.0.2.json
@@ -1,0 +1,107 @@
+{
+  "runtimeInfo": {
+    "panaVersion": "{{pana-version}}",
+    "sdkVersion": "{{sdk-version}}",
+    "flutterVersions": {}
+  },
+  "packageName": "nsd_android",
+  "packageVersion": "1.0.2",
+  "pubspec": {
+    "name": "nsd_android",
+    "description": "Flutter network service discovery plugin (Android submodule - will be installed with the parent plugin).",
+    "version": "1.0.2",
+    "repository": "https://github.com/sebastianhaberey/nsd/tree/main/nsd_android",
+    "issue_tracker": "https://github.com/sebastianhaberey/nsd/issues",
+    "environment": {
+      "sdk": ">=2.12.0 <3.0.0",
+      "flutter": ">=1.20.0"
+    },
+    "dependencies": {
+      "flutter": {
+        "sdk": "flutter"
+      }
+    },
+    "flutter": {
+      "plugin": {
+        "platforms": {
+          "android": {
+            "package": "com.haberey.flutter.nsd_android",
+            "pluginClass": "NsdAndroidPlugin"
+          }
+        }
+      }
+    }
+  },
+  "licenseFile": {
+    "path": "LICENSE",
+    "name": "MIT"
+  },
+  "allDependencies": [
+    "characters",
+    "collection",
+    "flutter",
+    "meta",
+    "sky_engine",
+    "typed_data",
+    "vector_math"
+  ],
+  "tags": [
+    "sdk:flutter",
+    "platform:android",
+    "is:plugin",
+    "is:null-safe"
+  ],
+  "report": {
+    "sections": [
+      {
+        "id": "convention",
+        "title": "Follow Dart file conventions",
+        "grantedPoints": 20,
+        "maxPoints": 20,
+        "status": "passed",
+        "summary": "### [*] 10/10 points: Provide a valid `pubspec.yaml`\n\n\n### [*] 5/5 points: Provide a valid `README.md`\n\n\n### [*] 5/5 points: Provide a valid `CHANGELOG.md`\n"
+      },
+      {
+        "id": "documentation",
+        "title": "Provide documentation",
+        "grantedPoints": 10,
+        "maxPoints": 10,
+        "status": "passed",
+        "summary": "### [*] 10/10 points: Package has an example\n\n* Found example at: `example/EXAMPLE.md`"
+      },
+      {
+        "id": "platform",
+        "title": "Support multiple platforms",
+        "grantedPoints": 0,
+        "maxPoints": 20,
+        "status": "failed",
+        "summary": "### [x] 0/20 points: Supports 1 of 3 possible platforms (iOS, **Android**, Web)\n\nFound 7 issues. Showing the first 2:\n\n\nConsider supporting multiple platforms:\n\n<details>\n<summary>\nPackage does not support Flutter platform `iOS`.\n</summary>\n\nBecause:\n* `nsd_android` that declares support for platforms: `Android`.\n</details>"
+      },
+      {
+        "id": "analysis",
+        "title": "Pass static analysis",
+        "grantedPoints": 30,
+        "maxPoints": 30,
+        "status": "passed",
+        "summary": "### [*] 30/30 points: code has no errors, warnings, lints, or formatting issues\n"
+      },
+      {
+        "id": "dependency",
+        "title": "Support up-to-date dependencies",
+        "grantedPoints": 20,
+        "maxPoints": 20,
+        "status": "passed",
+        "summary": "### [*] 10/10 points: All of the package dependencies are supported in the latest version\n\n|Package|Constraint|Compatible|Latest|\n|:-|:-|:-|:-|\n|[`flutter`]|`flutter`|0.0.0|0.0.0|\n\n<details><summary>Transitive dependencies</summary>\n\n|Package|Constraint|Compatible|Latest|\n|:-|:-|:-|:-|\n|[`characters`]|-|1.1.0|1.1.0|\n|[`collection`]|-|1.15.0|1.15.0|\n|[`meta`]|-|1.7.0|1.7.0|\n|[`sky_engine`]|-|0.0.99|0.0.99|\n|[`typed_data`]|-|1.3.0|1.3.0|\n|[`vector_math`]|-|2.1.0|2.1.0|\n</details>\n\nTo reproduce run `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`.\n\n[`flutter`]: https://pub.dev/packages/flutter\n[`characters`]: https://pub.dev/packages/characters\n[`collection`]: https://pub.dev/packages/collection\n[`meta`]: https://pub.dev/packages/meta\n[`sky_engine`]: https://pub.dev/packages/sky_engine\n[`typed_data`]: https://pub.dev/packages/typed_data\n[`vector_math`]: https://pub.dev/packages/vector_math\n\n\n### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs\n"
+      },
+      {
+        "id": "null-safety",
+        "title": "Support sound null safety",
+        "grantedPoints": 20,
+        "maxPoints": 20,
+        "status": "passed",
+        "summary": "### [*] 20/20 points: Package and dependencies are fully migrated to null safety!\n"
+      }
+    ]
+  },
+  "urlProblems": []
+}

--- a/test/goldens/end2end/nsd_android-1.0.2.json_report.md
+++ b/test/goldens/end2end/nsd_android-1.0.2.json_report.md
@@ -1,0 +1,77 @@
+## 20/20 Follow Dart file conventions
+
+### [*] 10/10 points: Provide a valid `pubspec.yaml`
+
+
+### [*] 5/5 points: Provide a valid `README.md`
+
+
+### [*] 5/5 points: Provide a valid `CHANGELOG.md`
+
+
+## 10/10 Provide documentation
+
+### [*] 10/10 points: Package has an example
+
+* Found example at: `example/EXAMPLE.md`
+
+## 0/20 Support multiple platforms
+
+### [x] 0/20 points: Supports 1 of 3 possible platforms (iOS, **Android**, Web)
+
+Found 7 issues. Showing the first 2:
+
+
+Consider supporting multiple platforms:
+
+<details>
+<summary>
+Package does not support Flutter platform `iOS`.
+</summary>
+
+Because:
+* `nsd_android` that declares support for platforms: `Android`.
+</details>
+
+## 30/30 Pass static analysis
+
+### [*] 30/30 points: code has no errors, warnings, lints, or formatting issues
+
+
+## 20/20 Support up-to-date dependencies
+
+### [*] 10/10 points: All of the package dependencies are supported in the latest version
+
+|Package|Constraint|Compatible|Latest|
+|:-|:-|:-|:-|
+|[`flutter`]|`flutter`|0.0.0|0.0.0|
+
+<details><summary>Transitive dependencies</summary>
+
+|Package|Constraint|Compatible|Latest|
+|:-|:-|:-|:-|
+|[`characters`]|-|1.1.0|1.1.0|
+|[`collection`]|-|1.15.0|1.15.0|
+|[`meta`]|-|1.7.0|1.7.0|
+|[`sky_engine`]|-|0.0.99|0.0.99|
+|[`typed_data`]|-|1.3.0|1.3.0|
+|[`vector_math`]|-|2.1.0|2.1.0|
+</details>
+
+To reproduce run `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`.
+
+[`flutter`]: https://pub.dev/packages/flutter
+[`characters`]: https://pub.dev/packages/characters
+[`collection`]: https://pub.dev/packages/collection
+[`meta`]: https://pub.dev/packages/meta
+[`sky_engine`]: https://pub.dev/packages/sky_engine
+[`typed_data`]: https://pub.dev/packages/typed_data
+[`vector_math`]: https://pub.dev/packages/vector_math
+
+
+### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs
+
+
+## 20/20 Support sound null safety
+
+### [*] 20/20 points: Package and dependencies are fully migrated to null safety!

--- a/test/tag/tag_end2end_test.dart
+++ b/test/tag/tag_end2end_test.dart
@@ -469,11 +469,7 @@ name: my_package
       _expectTagging(tagger.sdkTags, tags: {'sdk:flutter'});
       _expectTagging(tagger.flutterPlatformTags, tags: {
         'platform:ios',
-        'platform:android',
         'platform:web',
-        'platform:linux',
-        'platform:windows',
-        'platform:macos',
       });
       _expectTagging(tagger.runtimeTags, tags: isEmpty);
       _expectTagging(tagger.flutterPluginTags, tags: {'is:plugin'});


### PR DESCRIPTION
- Fixes #985.
- Treats asset-only packages (no .dart files, but some content in lib/) the same way as packages that have no content in lib/.
- When there are no top libraries, it uses the pubspec dependencies to find platform violations.