### PR TITLE
Upgrade package:analyzer dependency constraint.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.21.6
+
+- `package:analyzer` dependency upgraded to `^3.1.0`.
+
 ## 0.21.5
 
 - Support for top-level platform tags in `pubspec.yaml`.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.21.5';
+const packageVersion = '0.21.6-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.21.5
+version: 0.21.6-dev
 homepage: https://github.com/dart-lang/pana
 
 environment:
   sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
-  analyzer: '^2.1.0'
+  analyzer: '^3.1.0'
   args: ^2.0.0
   async: ^2.0.0
   cli_util: ^0.3.0
@@ -15,7 +15,7 @@ dependencies:
   html: ^0.15.0
   http: ^0.13.0
   io: ^1.0.0
-  json_annotation: ^4.3.0
+  json_annotation: ^4.4.0
   logging: ^1.0.0
   markdown: ^4.0.0
   path: ^1.6.2


### PR DESCRIPTION
Also upgrading `json_annotation`, as the build message seemed to insist on a new range.