### PR TITLE
Formalized repository URL parsing and resolving.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `package:analyzer` dependency upgraded to `^3.1.0`.
 - Fix dart analysis. Code problems are now propagatet to the pana report.
 - Fix retry on version listing HTTP requests during `getVersionListing`.
+- `RepositoryUrl` (private API) to detect repository patterns and resolve paths.
 
 ## 0.21.5
 

--- a/lib/src/repository_url.dart
+++ b/lib/src/repository_url.dart
@@ -126,17 +126,16 @@ RepositoryUrl? _tryParseRepositoryUrl(String input) {
   if (repoSegmentIndex < 0) return null;
 
   String? separator;
-  final extraSegments = segments.skip(repoSegmentIndex + 1).toList();
-  if (extraSegments.isNotEmpty &&
-      _githubSegmentSeparators.contains(extraSegments.first)) {
-    separator = extraSegments.removeAt(0);
-  }
-
   String? branch;
-  if (RepositoryProvider.isGitHubCompatible(provider) &&
-      separator != null &&
-      extraSegments.isNotEmpty) {
-    branch = extraSegments.removeAt(0);
+  final extraSegments = segments.skip(repoSegmentIndex + 1).toList();
+  if (RepositoryProvider.isGitHubCompatible(provider)) {
+    if (extraSegments.isNotEmpty &&
+        _githubSegmentSeparators.contains(extraSegments.first)) {
+      separator = extraSegments.removeAt(0);
+    }
+    if (separator != null && extraSegments.isNotEmpty) {
+      branch = extraSegments.removeAt(0);
+    }
   }
 
   return RepositoryUrl(

--- a/lib/src/repository_url.dart
+++ b/lib/src/repository_url.dart
@@ -1,0 +1,180 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:path/path.dart' as p;
+
+/// Describes the url + folder or file path of a repository URL.
+class RepositoryUrl {
+  /// One of the values from [RepositoryProvider].
+  final String provider;
+
+  /// The base URL up to the repository itself.
+  final String baseUrl;
+
+  /// The separator between the repository and the relative folder or file path.
+  final String? separator;
+
+  /// The branch to use.
+  final String? branch;
+
+  /// The relative folder or path of the repository.
+  final String path;
+
+  RepositoryUrl({
+    this.provider = RepositoryProvider.unknown,
+    required this.baseUrl,
+    this.separator,
+    this.branch,
+    required this.path,
+  });
+
+  /// Parses [input] and return the parsed [RepositoryUrl] if successful,
+  /// or returns null if it was unable to recognize the pattern.
+  static RepositoryUrl? tryParse(String input) => _tryParseRepositoryUrl(input);
+
+  /// Parses [input] and return the parsed [RepositoryUrl] if successful,
+  /// or throws [FormatException] if it was unable to recognize the pattern.
+  static RepositoryUrl parse(String input) {
+    final v = tryParse(input);
+    if (v == null) {
+      throw FormatException('Unable to parse repository url: `$input`.');
+    } else {
+      return v;
+    }
+  }
+
+  /// Resolves a relative path and returns a new instance of the [RepositoryUrl].
+  RepositoryUrl resolve(
+    String relativePath, {
+    String? separator,
+    String? branch,
+  }) {
+    final newPath = p.joinAll([
+      if (path.isNotEmpty) path,
+      if (relativePath.isNotEmpty) relativePath,
+    ]);
+    final normalizedNewPath = p.normalize(newPath);
+
+    if (RepositoryProvider.isGitHubCompatible(provider)) {
+      final extension = p.extension(normalizedNewPath).toLowerCase();
+      final needsRaw = _imageExtensions.contains(extension);
+      final newBaseUrl = baseUrl.endsWith('.git')
+          ? baseUrl.substring(0, baseUrl.length - 4)
+          : baseUrl;
+      return RepositoryUrl(
+        provider: provider,
+        baseUrl: newBaseUrl,
+        separator: separator ?? (needsRaw ? 'raw' : null) ?? 'blob',
+        branch: branch ?? this.branch ?? 'master',
+        path: normalizedNewPath,
+      );
+    } else {
+      return RepositoryUrl(
+        provider: provider,
+        baseUrl: baseUrl,
+        separator: separator,
+        branch: branch,
+        path: normalizedNewPath,
+      );
+    }
+  }
+
+  /// Creates a String representation of the URL.
+  String toUrl() =>
+      p.joinAll([baseUrl, separator, branch, path].whereType<String>());
+}
+
+abstract class RepositoryProvider {
+  static const github = 'github';
+  static const gitlab = 'gitlab';
+  static const unknown = 'unknown';
+
+  static bool isGitHubCompatible(String provider) =>
+      provider == github || provider == gitlab;
+}
+
+const _repoReplacePrefixes = {
+  'http://github.com': 'https://github.com',
+  'https://www.github.com': 'https://github.com',
+  'https://www.gitlab.com': 'https://gitlab.com',
+};
+
+const _githubSegmentSeparators = ['tree', 'blob', 'raw'];
+
+final _imageExtensions = <String>{'.gif', '.jpg', '.jpeg', '.png'};
+
+RepositoryUrl? _tryParseRepositoryUrl(String input) {
+  var url = input;
+
+  // apply known prefix replace patterns
+  for (final key in _repoReplacePrefixes.keys) {
+    if (url.startsWith(key)) {
+      url = url.replaceFirst(key, _repoReplacePrefixes[key]!);
+    }
+  }
+
+  final uri = Uri.parse(url);
+  final provider = _detectProvider(uri);
+
+  // detect repo vs path segments
+  final segments = Uri.parse(p.normalize(uri.path))
+      .pathSegments
+      .where((s) => s.isNotEmpty)
+      .toList();
+  final repoSegmentIndex = _repoSegmentIndex(provider, segments);
+  if (repoSegmentIndex < 0) return null;
+
+  String? separator;
+  final extraSegments = segments.skip(repoSegmentIndex + 1).toList();
+  if (extraSegments.isNotEmpty &&
+      _githubSegmentSeparators.contains(extraSegments.first)) {
+    separator = extraSegments.removeAt(0);
+  }
+
+  String? branch;
+  if (RepositoryProvider.isGitHubCompatible(provider) &&
+      separator != null &&
+      extraSegments.isNotEmpty) {
+    branch = extraSegments.removeAt(0);
+  }
+
+  return RepositoryUrl(
+    provider: provider,
+    baseUrl: Uri(
+      scheme: uri.scheme,
+      host: uri.host,
+      port: uri.hasPort ? uri.port : null,
+      pathSegments: segments.sublist(0, repoSegmentIndex + 1),
+    ).toString(),
+    separator: separator,
+    branch: branch,
+    path: extraSegments.join('/'),
+  );
+}
+
+String _detectProvider(Uri uri) {
+  if (uri.host == 'github.com') return RepositoryProvider.github;
+  if (uri.host == 'gitlab.com') return RepositoryProvider.gitlab;
+  return RepositoryProvider.unknown;
+}
+
+int _repoSegmentIndex(String provider, List<String> segments) {
+  // first segment with .git postfix
+  final gitPostfixIndex = segments.indexWhere((s) => s.endsWith('.git'));
+  if (gitPostfixIndex >= 0) return gitPostfixIndex;
+
+  if (RepositoryProvider.isGitHubCompatible(provider)) {
+    // detect segment separators, starting from the 3rd position
+    for (final separator in _githubSegmentSeparators) {
+      final index = segments.length <= 2 ? -1 : segments.indexOf(separator, 2);
+      if (index >= 2) return index - 1;
+    }
+
+    // fallback
+    if (segments.length == 2) return 1;
+  }
+
+  // couldn't find anything
+  return -1;
+}

--- a/lib/src/repository_url.dart
+++ b/lib/src/repository_url.dart
@@ -94,10 +94,13 @@ abstract class RepositoryProvider {
       provider == github || provider == gitlab;
 }
 
-const _repoReplacePrefixes = {
-  'http://github.com': 'https://github.com',
-  'https://www.github.com': 'https://github.com',
-  'https://www.gitlab.com': 'https://gitlab.com',
+const _replaceSchemes = {
+  'http': 'https',
+};
+
+const _replaceHosts = {
+  'www.github.com': 'github.com',
+  'www.gitlab.com': 'gitlab.com',
 };
 
 const _githubSegmentSeparators = ['tree', 'blob', 'raw'];
@@ -105,16 +108,17 @@ const _githubSegmentSeparators = ['tree', 'blob', 'raw'];
 final _imageExtensions = <String>{'.gif', '.jpg', '.jpeg', '.png'};
 
 RepositoryUrl? _tryParseRepositoryUrl(String input) {
-  var url = input;
+  var uri = Uri.tryParse(input);
+  if (uri == null) return null;
 
   // apply known prefix replace patterns
-  for (final key in _repoReplacePrefixes.keys) {
-    if (url.startsWith(key)) {
-      url = url.replaceFirst(key, _repoReplacePrefixes[key]!);
-    }
+  if (_replaceSchemes.containsKey(uri.scheme)) {
+    uri = uri.replace(scheme: _replaceSchemes[uri.scheme]!);
+  }
+  if (_replaceHosts.containsKey(uri.host)) {
+    uri = uri.replace(host: _replaceHosts[uri.host]!);
   }
 
-  final uri = Uri.parse(url);
   final provider = _detectProvider(uri);
 
   // detect repo vs path segments

--- a/test/repository_url_test.dart
+++ b/test/repository_url_test.dart
@@ -1,0 +1,118 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pana/src/repository_url.dart';
+import 'package:test/test.dart';
+
+void main() {
+  void testGitHubUrls(String prefix) {
+    test('user root fails', () {
+      expect(RepositoryUrl.tryParse('$prefix/dart-lang'), isNull);
+      expect(RepositoryUrl.tryParse('$prefix/dart-lang/'), isNull);
+    });
+
+    test('project root', () {
+      expect(
+          RepositoryUrl.parse('$prefix/dart-lang/angular')
+              .resolve('README.md')
+              .toUrl(),
+          '$prefix/dart-lang/angular/blob/master/README.md');
+      expect(
+          RepositoryUrl.parse('$prefix/dart-lang/angular/')
+              .resolve('README.md')
+              .toUrl(),
+          '$prefix/dart-lang/angular/blob/master/README.md');
+    });
+
+    test('project subdir', () {
+      expect(
+          RepositoryUrl.parse('$prefix/dart-lang/angular/tree/master/angular')
+              .resolve('README.md')
+              .toUrl(),
+          '$prefix/dart-lang/angular/blob/master/angular/README.md');
+      expect(
+          RepositoryUrl.parse('$prefix/dart-lang/angular/tree/master/angular/')
+              .resolve('README.md')
+              .toUrl(),
+          '$prefix/dart-lang/angular/blob/master/angular/README.md');
+    });
+
+    test('image links in root', () {
+      expect(
+          RepositoryUrl.parse('$prefix/dart-lang/angular')
+              .resolve('logo.png')
+              .toUrl(),
+          '$prefix/dart-lang/angular/raw/master/logo.png');
+      expect(
+          RepositoryUrl.parse('$prefix/dart-lang/angular/')
+              .resolve('logo.png')
+              .toUrl(),
+          '$prefix/dart-lang/angular/raw/master/logo.png');
+    });
+
+    test('image links in specific branch', () {
+      expect(
+        RepositoryUrl.parse('$prefix/dart-lang/angular')
+            .resolve(
+              'logo.png',
+              branch: 'main',
+            )
+            .toUrl(),
+        '$prefix/dart-lang/angular/raw/main/logo.png',
+      );
+    });
+
+    test('image links in project subdir', () {
+      expect(
+          RepositoryUrl.parse('$prefix/dart-lang/angular/tree/master/angular')
+              .resolve('logo.png')
+              .toUrl(),
+          '$prefix/dart-lang/angular/raw/master/angular/logo.png');
+      expect(
+          RepositoryUrl.parse('$prefix/dart-lang/angular/tree/master/angular/')
+              .resolve('logo.png')
+              .toUrl(),
+          '$prefix/dart-lang/angular/raw/master/angular/logo.png');
+    });
+  }
+
+  group('GitHub URLs', () {
+    testGitHubUrls('https://github.com');
+  });
+
+  group('GitLab URLs', () {
+    testGitHubUrls('https://gitlab.com');
+  });
+
+  group('URL replacements', () {
+    test('GitHub replacements', () {
+      expect(
+          RepositoryUrl.parse('http://github.com/user/project/')
+              .resolve('README.md')
+              .toUrl(),
+          'https://github.com/user/project/blob/master/README.md');
+      expect(
+          RepositoryUrl.parse('https://www.github.com/user/project/')
+              .resolve('README.md')
+              .toUrl(),
+          'https://github.com/user/project/blob/master/README.md');
+    });
+
+    test('.git URL', () {
+      expect(
+          RepositoryUrl.parse(
+                  'https://github.com/daniel-maxhari/dynamic_text_highlighting.git')
+              .resolve('LICENSE')
+              .toUrl(),
+          'https://github.com/daniel-maxhari/dynamic_text_highlighting/blob/master/LICENSE');
+
+      expect(
+          RepositoryUrl.parse(
+                  'https://github.com/daniel-maxhari/dynamic_text_highlighting.git/blob/master/subdir')
+              .resolve('LICENSE')
+              .toUrl(),
+          'https://github.com/daniel-maxhari/dynamic_text_highlighting/blob/master/subdir/LICENSE');
+    });
+  });
+}


### PR DESCRIPTION
- reusing and repurposing the tests for the now-defunct `getRepositoryUrl`
