### PR TITLE
Remove deprecated `pub` usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Used by the [Dart Package site](https://pub.dev/).
 ### Installation
 
 ```console
-> pub global activate pana
+dart pub global activate pana
 ```
 
 ### Usage


### PR DESCRIPTION
Also removed the leading `> ` as it only makes copying annoying