### PR TITLE
Expose repository info in Summary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.21.8
 
 - Start emitting `license:<license>` tags.
+- Start populating `Summary.repository`, optionally with `git` remote branch check.
 
 ## 0.21.7
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -49,6 +49,7 @@ class Summary {
   final List<String>? tags;
   final Report? report;
   final List<ProcessedScreenshot>? screenshots;
+  final Repository? repository;
 
   /// URLs that are invalid, unsafe or missing.
   final List<UrlProblem>? urlProblems;
@@ -65,6 +66,7 @@ class Summary {
     this.licenseFile,
     this.tags,
     this.report,
+    this.repository,
     this.urlProblems,
     this.errorMessage,
     this.screenshots,
@@ -88,6 +90,7 @@ class Summary {
       licenseFile: licenseFile,
       tags: tags ?? this.tags,
       report: report,
+      repository: repository,
       urlProblems: urlProblems,
       errorMessage: errorMessage,
       screenshots: screenshots,
@@ -310,6 +313,25 @@ class ReportSection {
       _$ReportSectionFromJson(json);
 
   Map<String, dynamic> toJson() => _$ReportSectionToJson(this);
+}
+
+/// NOTE: the content of the class is experimental, clients should not rely on it yet.
+@JsonSerializable(includeIfNull: false)
+class Repository {
+  final String baseUrl;
+  final String? branch;
+  final String? packagePath;
+
+  Repository({
+    required this.baseUrl,
+    this.branch,
+    this.packagePath,
+  });
+
+  factory Repository.fromJson(Map<String, dynamic> json) =>
+      _$RepositoryFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RepositoryToJson(this);
 }
 
 @JsonSerializable()

--- a/lib/src/model.g.dart
+++ b/lib/src/model.g.dart
@@ -44,6 +44,9 @@ Summary _$SummaryFromJson(Map<String, dynamic> json) => Summary(
       report: json['report'] == null
           ? null
           : Report.fromJson(json['report'] as Map<String, dynamic>),
+      repository: json['repository'] == null
+          ? null
+          : Repository.fromJson(json['repository'] as Map<String, dynamic>),
       urlProblems: (json['urlProblems'] as List<dynamic>?)
           ?.map((e) => UrlProblem.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -73,6 +76,7 @@ Map<String, dynamic> _$SummaryToJson(Summary instance) {
   writeNotNull('tags', instance.tags);
   writeNotNull('report', instance.report);
   writeNotNull('screenshots', instance.screenshots);
+  writeNotNull('repository', instance.repository);
   writeNotNull('urlProblems', instance.urlProblems);
   writeNotNull('errorMessage', instance.errorMessage);
   return val;
@@ -160,6 +164,28 @@ const _$ReportStatusEnumMap = {
   ReportStatus.partial: 'partial',
   ReportStatus.passed: 'passed',
 };
+
+Repository _$RepositoryFromJson(Map<String, dynamic> json) => Repository(
+      baseUrl: json['baseUrl'] as String,
+      branch: json['branch'] as String?,
+      packagePath: json['packagePath'] as String?,
+    );
+
+Map<String, dynamic> _$RepositoryToJson(Repository instance) {
+  final val = <String, dynamic>{
+    'baseUrl': instance.baseUrl,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('branch', instance.branch);
+  writeNotNull('packagePath', instance.packagePath);
+  return val;
+}
 
 UrlProblem _$UrlProblemFromJson(Map<String, dynamic> json) => UrlProblem(
       url: json['url'] as String,

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -19,6 +19,7 @@ import 'model.dart';
 import 'package_context.dart';
 import 'pubspec.dart';
 import 'report/create_report.dart';
+import 'repository/check_repository.dart';
 import 'sdk_env.dart';
 import 'tag/tagger.dart';
 import 'utils.dart';
@@ -34,6 +35,9 @@ class InspectOptions {
   /// The analysis options (in yaml format) to use for the analysis.
   final String? analysisOptionsYaml;
 
+  /// Whether pana should also access the remote repository specified in pubspec.yaml.
+  final bool checkRemoteRepository;
+
   InspectOptions({
     this.pubHostedUrl,
     this.dartdocOutputDir,
@@ -42,6 +46,7 @@ class InspectOptions {
     this.isInternal = false,
     this.lineLength,
     this.analysisOptionsYaml,
+    this.checkRemoteRepository = false,
   });
 }
 
@@ -222,6 +227,7 @@ class PackageAnalyzer {
       licenseFile: licenseFile,
       tags: tags,
       report: await createReport(context),
+      repository: await checkRepository(context),
       urlProblems: context.urlProblems.entries
           .map((e) => UrlProblem(url: e.key, problem: e.value))
           .toList()

--- a/lib/src/repository/check_repository.dart
+++ b/lib/src/repository/check_repository.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../model.dart';
+import '../package_context.dart';
+
+import 'default_git_branch.dart';
+import 'repository_url.dart';
+
+/// Returns the repository information for the current package.
+Future<Repository?> checkRepository(PackageContext context) async {
+  final sourceUrl = context.pubspec.repository ?? context.pubspec.homepage;
+  if (sourceUrl == null) {
+    return null;
+  }
+  final url = RepositoryUrl.tryParse(sourceUrl);
+  if (url == null) {
+    return null;
+  }
+  final detectedGitBranch = context.options.checkRemoteRepository
+      ? await tryDetectDefaultGitBranch(url.baseUrl)
+      : null;
+  final branch = detectedGitBranch ?? url.branch;
+  return Repository(
+    baseUrl: url.baseUrl,
+    branch: branch,
+    packagePath: url.path.isEmpty ? null : url.path,
+  );
+}

--- a/test/end2end_test.dart
+++ b/test/end2end_test.dart
@@ -57,6 +57,7 @@ void main() {
           version: version,
           options: InspectOptions(
             pubHostedUrl: 'http://127.0.0.1:${httpServer.port}',
+            checkRemoteRepository: true,
           ),
         );
 

--- a/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
+++ b/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
@@ -75,6 +75,10 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/dart-lang/pub-dev",
+    "branch": "master"
+  },
   "urlProblems": [],
   "errorMessage": "Running `dart pub upgrade` failed with the following output:\n\n```\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.\n```"
 }

--- a/test/goldens/end2end/async-2.5.0.json
+++ b/test/goldens/end2end/async-2.5.0.json
@@ -103,5 +103,9 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/dart-lang/async",
+    "branch": "master"
+  },
   "urlProblems": []
 }

--- a/test/goldens/end2end/audio_service-0.17.0.json
+++ b/test/goldens/end2end/audio_service-0.17.0.json
@@ -162,5 +162,9 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/ryanheise/audio_service",
+    "branch": "minor"
+  },
   "urlProblems": []
 }

--- a/test/goldens/end2end/bulma_min-0.7.4.json
+++ b/test/goldens/end2end/bulma_min-0.7.4.json
@@ -88,5 +88,9 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/agilord/bulma_min",
+    "branch": "master"
+  },
   "urlProblems": []
 }

--- a/test/goldens/end2end/dnd-2.0.0.json
+++ b/test/goldens/end2end/dnd-2.0.0.json
@@ -90,5 +90,9 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/marcojakob/dart-dnd",
+    "branch": "master"
+  },
   "urlProblems": []
 }

--- a/test/goldens/end2end/http-0.13.0.json
+++ b/test/goldens/end2end/http-0.13.0.json
@@ -111,5 +111,9 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/dart-lang/http",
+    "branch": "master"
+  },
   "urlProblems": []
 }

--- a/test/goldens/end2end/mime_type-0.3.2.json
+++ b/test/goldens/end2end/mime_type-0.3.2.json
@@ -88,5 +88,9 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/mitsuoka/mime_type",
+    "branch": "master"
+  },
   "urlProblems": []
 }

--- a/test/goldens/end2end/nsd_android-1.0.2.json
+++ b/test/goldens/end2end/nsd_android-1.0.2.json
@@ -106,5 +106,10 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/sebastianhaberey/nsd",
+    "branch": "main",
+    "packagePath": "nsd_android"
+  },
   "urlProblems": []
 }

--- a/test/goldens/end2end/sdp_transform-0.2.0.json
+++ b/test/goldens/end2end/sdp_transform-0.2.0.json
@@ -97,5 +97,9 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/cloudwebrtc/dart-sdp-transform",
+    "branch": "master"
+  },
   "urlProblems": []
 }

--- a/test/goldens/end2end/skiplist-0.1.0.json
+++ b/test/goldens/end2end/skiplist-0.1.0.json
@@ -79,6 +79,10 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/stevenroose/dart-skiplist",
+    "branch": "master"
+  },
   "urlProblems": [],
   "errorMessage": "Running `dart pub upgrade` failed with the following output:\n\n```\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because skiplist depends on quiver_iterables >=1.0.0 which requires SDK version >=1.9.0 <2.0.0, version solving failed.\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because skiplist depends on quiver_iterables >=1.0.0 which requires SDK version >=1.9.0 <2.0.0, version solving failed.\n```"
 }

--- a/test/goldens/end2end/url_launcher-6.0.3.json
+++ b/test/goldens/end2end/url_launcher-6.0.3.json
@@ -151,5 +151,10 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/flutter/plugins",
+    "branch": "main",
+    "packagePath": "packages/url_launcher/url_launcher"
+  },
   "urlProblems": []
 }

--- a/test/goldens/end2end/webdriver-3.0.0.json
+++ b/test/goldens/end2end/webdriver-3.0.0.json
@@ -101,5 +101,9 @@
     ]
   },
   "screenshots": [],
+  "repository": {
+    "baseUrl": "https://github.com/google/webdriver.dart",
+    "branch": "master"
+  },
   "urlProblems": []
 }


### PR DESCRIPTION
- next step: extend this data with the verification that the link to the repository is indeed the package itself
- optional items to store here: repo type (e.g. git), provider (e.g. github), git tags info... (TBD)
- end2end tests are enabled to check the git remote
- pub.dev may need to have a cache for the default git branch (TBD)
