### PR TITLE
Fix computation of 'pubHostedUrl' in 'computeOutdatedVersions'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.21.10
+
+- Fix issue in the computation of `pubHostedUrl` in `computeOutdatedVersions`.
 ## 0.21.9
 
 - New defaults for JSON: do not include `null` values, explicit `toJson()`.

--- a/lib/src/report/dependencies.dart
+++ b/lib/src/report/dependencies.dart
@@ -292,9 +292,9 @@ Future<List<OutdatedVersionDescription>> computeOutdatedVersions(
   }
   final result = <OutdatedVersionDescription>[];
 
-  final hostUrlString =
-      context.toolEnvironment.environment['PUB_HOSTED_URL'] ?? '';
-  final environmentUri = Uri.tryParse(hostUrlString);
+  final hostUrlString = context.toolEnvironment.environment['PUB_HOSTED_URL'];
+  final environmentUri =
+      hostUrlString != null ? Uri.tryParse(hostUrlString) : null;
   final versionListing = jsonDecode(await getVersionListing(name,
       pubHostedUrl: hostedDependency.hosted?.url ?? environmentUri));
 

--- a/lib/src/report/dependencies.dart
+++ b/lib/src/report/dependencies.dart
@@ -293,8 +293,9 @@ Future<List<OutdatedVersionDescription>> computeOutdatedVersions(
   final result = <OutdatedVersionDescription>[];
 
   final hostUrlString = context.toolEnvironment.environment['PUB_HOSTED_URL'];
-  final environmentUri =
-      hostUrlString != null ? Uri.tryParse(hostUrlString) : null;
+  final environmentUri = (hostUrlString != null && hostUrlString.isNotEmpty)
+      ? Uri.tryParse(hostUrlString)
+      : null;
   final versionListing = jsonDecode(await getVersionListing(name,
       pubHostedUrl: hostedDependency.hosted?.url ?? environmentUri));
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.21.9';
+const packageVersion = '0.21.10';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.21.9
+version: 0.21.10
 homepage: https://github.com/dart-lang/pana
 
 environment:


### PR DESCRIPTION
Passing the empty string to `Uri.tryParse` results in an empty string. Hence we ended up calling getVersionListing with a wrong value for `pubHostedUrl`.