### PR TITLE
List files and detect the presence of pubspec.yaml during repository verification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.21.11
 
 - Cache the currently fetched depth in `GitLocalRepository`.
+- List files and detect the presence of `pubspec.yaml` during repository verification.
 - Typed `stdout` and `stderr` in `PanaProcessResult`.
 
 ## 0.21.10

--- a/lib/src/repository/git_local_repository.dart
+++ b/lib/src/repository/git_local_repository.dart
@@ -139,6 +139,31 @@ class GitLocalRepository {
     return pr.stdout.asString;
   }
 
+  /// List file names of [branch].
+  ///
+  /// Throws [GitToolException] if the git command fails.
+  Future<List<String>> listFiles(String branch) async {
+    _assertBranchFormat(branch);
+    await _fetch(branch, 1);
+    final pr = await _runGitWithRetry(
+      [
+        'ls-tree',
+        '-r',
+        '--name-only',
+        '--full-tree',
+        'origin/$branch',
+      ],
+      createException: (pr) =>
+          GitToolException('Could not list `$branch`.', pr.asTrimmedOutput),
+    );
+    return pr.stdout
+        .toString()
+        .split('\n')
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty)
+        .toList();
+  }
+
   /// Deletes the local directory.
   Future<void> delete() async {
     await Directory(localPath).delete(recursive: true);

--- a/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
+++ b/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
@@ -85,7 +85,7 @@
     "baseUrl": "https://github.com/dart-lang/pub-dev",
     "branch": "master",
     "isVerified": false,
-    "verificationFailure": "Unable to access git repository: Could not read `pubspec.yaml`."
+    "verificationFailure": "Repository has no `pubspec.yaml` in location: `/`."
   },
   "urlProblems": [],
   "errorMessage": "Running `dart pub upgrade` failed with the following output:\n\n```\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.\n```"

--- a/test/goldens/end2end/audio_service-0.17.0.json
+++ b/test/goldens/end2end/audio_service-0.17.0.json
@@ -172,7 +172,7 @@
     "baseUrl": "https://github.com/ryanheise/audio_service",
     "branch": "minor",
     "isVerified": false,
-    "verificationFailure": "Unable to access git repository: Could not read `pubspec.yaml`."
+    "verificationFailure": "Repository has no `pubspec.yaml` in location: `/`."
   },
   "urlProblems": []
 }


### PR DESCRIPTION
- Better error message if the path does not have `pubspec.yaml`.
- TBD later: checking file names, and also checking other `pubspec.yaml` files under the specified path.
