### PR TITLE
Check all pubspec.yaml during repository verification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.21.11
 
 - Cache the currently fetched depth in `GitLocalRepository`.
-- List files and detect the presence of `pubspec.yaml` during repository verification.
+- List files and check all `pubspec.yaml` during repository verification.
 - Typed `stdout` and `stderr` in `PanaProcessResult`.
 - Updated SPDX linceses.
 - Emit `license:<license>` tag on all the detected licenses.

--- a/lib/src/repository/check_repository.dart
+++ b/lib/src/repository/check_repository.dart
@@ -61,7 +61,7 @@ Future<Repository?> checkRepository(PackageContext context) async {
       final pubspecFiles =
           files.where((path) => p.basename(path) == 'pubspec.yaml').toList();
       if (pubspecFiles.isEmpty) {
-        failVerification('Repository has no `pubspec.yaml`.');
+        failVerification('Could not find any `pubspec.yaml` in the repository.');
         return result();
       }
 
@@ -95,9 +95,9 @@ Future<Repository?> checkRepository(PackageContext context) async {
           return _PubspecMatch(
               path, true, 'Repository `$path` has no version.');
         }
-        if (gitPubspec.toJson().containsKey('publish_to ')) {
+        if (gitPubspec.toJson().containsKey('publish_to')) {
           return _PubspecMatch(
-              path, true, 'Repository `$path` has `publish_to`.');
+              path, true, '`$path/pubspec.yaml` from the repository defines `publish_to`, thus, we are unable to verify the package is published from here.');
         }
 
         // found no issue

--- a/lib/src/repository/check_repository.dart
+++ b/lib/src/repository/check_repository.dart
@@ -27,14 +27,20 @@ Future<Repository?> checkRepository(PackageContext context) async {
   var branch = url.branch;
   bool? isVerified;
   String? verificationFailure;
+  var packagePath = url.path.isEmpty ? null : url.path;
 
-  Repository result() => Repository(
-        baseUrl: url.baseUrl,
-        branch: branch,
-        packagePath: url.path.isEmpty ? null : url.path,
-        isVerified: isVerified,
-        verificationFailure: verificationFailure,
-      );
+  Repository result() {
+    if (packagePath == '.') {
+      packagePath = null;
+    }
+    return Repository(
+      baseUrl: url.baseUrl,
+      branch: branch,
+      packagePath: packagePath,
+      isVerified: isVerified,
+      verificationFailure: verificationFailure,
+    );
+  }
 
   void failVerification(String message, [error, StackTrace? st]) {
     verificationFailure = message;
@@ -43,7 +49,7 @@ Future<Repository?> checkRepository(PackageContext context) async {
 
   if (context.options.checkRemoteRepository) {
     isVerified = false;
-    GitLocalRepository? repo;
+    late GitLocalRepository repo;
     try {
       repo = await GitLocalRepository.createLocalRepository(url.baseUrl);
       branch ??= await repo.detectDefaultBranch();
@@ -58,47 +64,81 @@ Future<Repository?> checkRepository(PackageContext context) async {
         failVerification('Repository has no `pubspec.yaml`.');
         return result();
       }
-      final pubspecPath = p.join(url.path, 'pubspec.yaml');
-      if (!pubspecFiles.contains(pubspecPath)) {
-        // TODO: detect if any of them is matching
-        failVerification(
-            'Repository has no `pubspec.yaml` in location: `${url.path}/`.');
-        return result();
+
+      Future<_PubspecMatch> matchRepoPubspecYaml(String path) async {
+        // checkout the pubspec.yaml at the assumed location
+        final content = await repo.showStringContent(
+          branch!,
+          path,
+          maxOutputBytes: _maxPubspecBytes,
+        );
+        final gitPubspec = Pubspec.parseYaml(content);
+        // verification steps
+        if (gitPubspec.name != context.pubspec.name) {
+          return _PubspecMatch(
+              path,
+              false,
+              'Repository `$path` name missmatch: '
+              '`${gitPubspec.name}` != `${context.pubspec.name}`.');
+        } else if (gitPubspec.repositoryOrHomepage !=
+            context.pubspec.repositoryOrHomepage) {
+          return _PubspecMatch(
+              path,
+              true,
+              'Repository `$path` URL missmatch: '
+              '`${gitPubspec.repositoryOrHomepage}` != `${context.pubspec.repositoryOrHomepage}`.');
+        } else if (gitPubspec.version == null) {
+          return _PubspecMatch(
+              path, true, 'Repository `$path` has no version.');
+        } else if (gitPubspec.toJson().containsKey('publish_to ')) {
+          return _PubspecMatch(
+              path, true, 'Repository `$path` has `publish_to`.');
+        }
+
+        // found no issue
+        return _PubspecMatch(path, true);
       }
 
-      // checkout the pubspec.yaml at the assumed location
-      final content = await repo.showStringContent(
-        branch,
-        p.join(url.path, 'pubspec.yaml'),
-        maxOutputBytes: _maxPubspecBytes,
-      );
-      final gitPubspec = Pubspec.parseYaml(content);
+      final results = <_PubspecMatch>[];
+      for (final path in pubspecFiles) {
+        results.add(await matchRepoPubspecYaml(path));
+      }
 
-      // verification steps
-      if (gitPubspec.name != context.pubspec.name) {
-        failVerification('Repository `pubspec.yaml` name missmatch: '
-            '`${gitPubspec.name}` != `${context.pubspec.name}`.');
-      } else if (gitPubspec.repositoryOrHomepage !=
-          context.pubspec.repositoryOrHomepage) {
-        failVerification('Repository `pubspec.yaml` URL missmatch: '
-            '`${gitPubspec.repositoryOrHomepage}` != `${context.pubspec.repositoryOrHomepage}`.');
-      } else if (gitPubspec.version == null) {
-        failVerification('Repository `pubspec.yaml` has no version.');
-      } else if (gitPubspec.toJson().containsKey('publish_to ')) {
-        failVerification('Repository `pubspec.yaml` has `publish_to`.');
+      final nameMatches = results.where((e) => e.hasMatchingName).toList();
+      if (nameMatches.isEmpty) {
+        failVerification(
+            'Repository has no matching `pubspec.yaml` with `name: ${context.pubspec.name}`.');
+      } else if (nameMatches.length > 1) {
+        failVerification(
+            'Repository has multiple matching `pubspec.yaml` with `name: ${context.pubspec.name}`.');
+      } else {
+        // confirmed name match, storing path
+        packagePath = p.dirname(nameMatches.single.path);
+
+        if (nameMatches.single.verificationIssue != null) {
+          failVerification(nameMatches.single.verificationIssue!);
+        }
       }
     } on FormatException catch (e, st) {
       failVerification(
-          'Unable to parse `pubspec.yaml` from git repository.', e, st);
+          'Unable to parse `pubspec.yaml` from git repository. $e', e, st);
     } on ArgumentError catch (e, st) {
       failVerification(
-          'Unable to parse `pubspec.yaml` from git repository.', e, st);
+          'Unable to parse `pubspec.yaml` from git repository. $e', e, st);
     } on GitToolException catch (e, st) {
       failVerification('Unable to access git repository: ${e.message}', e, st);
     } finally {
-      await repo?.delete();
+      await repo.delete();
     }
     isVerified = verificationFailure == null;
   }
   return result();
+}
+
+class _PubspecMatch {
+  final String path;
+  final bool hasMatchingName;
+  final String? verificationIssue;
+
+  _PubspecMatch(this.path, this.hasMatchingName, [this.verificationIssue]);
 }

--- a/lib/src/repository/check_repository.dart
+++ b/lib/src/repository/check_repository.dart
@@ -80,17 +80,22 @@ Future<Repository?> checkRepository(PackageContext context) async {
               false,
               'Repository `$path` name missmatch: '
               '`${gitPubspec.name}` != `${context.pubspec.name}`.');
-        } else if (gitPubspec.repositoryOrHomepage !=
-            context.pubspec.repositoryOrHomepage) {
-          return _PubspecMatch(
-              path,
-              true,
-              'Repository `$path` URL missmatch: '
-              '`${gitPubspec.repositoryOrHomepage}` != `${context.pubspec.repositoryOrHomepage}`.');
-        } else if (gitPubspec.version == null) {
+        }
+        final gitRepoOrHomepage = gitPubspec.repositoryOrHomepage;
+        if (gitRepoOrHomepage == null) {
+          return _PubspecMatch(path, true,
+              'Repository `$path` has no `repository` or `homepage` URL.');
+        }
+        final gitRepoUrl = RepositoryUrl.tryParse(gitRepoOrHomepage);
+        if (gitRepoUrl?.baseUrl != url.baseUrl) {
+          return _PubspecMatch(path, true,
+              'Repository `$path` URL missmatch: expected `${url.baseUrl}` but got `${gitRepoUrl?.baseUrl}`.');
+        }
+        if (gitPubspec.version == null) {
           return _PubspecMatch(
               path, true, 'Repository `$path` has no version.');
-        } else if (gitPubspec.toJson().containsKey('publish_to ')) {
+        }
+        if (gitPubspec.toJson().containsKey('publish_to ')) {
           return _PubspecMatch(
               path, true, 'Repository `$path` has `publish_to`.');
         }

--- a/lib/src/repository/git_local_repository.dart
+++ b/lib/src/repository/git_local_repository.dart
@@ -10,7 +10,7 @@ import 'package:retry/retry.dart';
 import '../utils.dart' show runProc, PanaProcessResult;
 
 final _acceptedBranchNameRegExp = RegExp(r'^[a-z0-9]+$');
-final _acceptedPathSegmentsRegExp = RegExp(r'^[a-z0-9\-\.]+$');
+final _acceptedPathSegmentsRegExp = RegExp(r'^[a-z0-9_\-\.]+$');
 
 /// The value to indicate we are fetching the branch without depth restriction.
 const unlimitedFetchDepth = 0;

--- a/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
+++ b/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
@@ -86,8 +86,9 @@
   "repository": {
     "baseUrl": "https://github.com/dart-lang/pub-dev",
     "branch": "master",
+    "packagePath": "pkg/pub_integration/test_data/_dummy_pkg",
     "isVerified": false,
-    "verificationFailure": "Repository has no `pubspec.yaml` in location: `/`."
+    "verificationFailure": "Repository `pkg/pub_integration/test_data/_dummy_pkg/pubspec.yaml` has no version."
   },
   "urlProblems": [],
   "errorMessage": "Running `dart pub upgrade` failed with the following output:\n\n```\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.\n```"

--- a/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
+++ b/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
@@ -88,7 +88,7 @@
     "branch": "master",
     "packagePath": "pkg/pub_integration/test_data/_dummy_pkg",
     "isVerified": false,
-    "verificationFailure": "Repository `pkg/pub_integration/test_data/_dummy_pkg/pubspec.yaml` has no version."
+    "verificationFailure": "`pkg/pub_integration/test_data/_dummy_pkg/pubspec.yaml` from the repository has no `version`."
   },
   "urlProblems": [],
   "errorMessage": "Running `dart pub upgrade` failed with the following output:\n\n```\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.\nERR: The current Dart SDK version is {{sdk-version}}.\n \n Because _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.\n```"

--- a/test/goldens/end2end/async-2.5.0.json
+++ b/test/goldens/end2end/async-2.5.0.json
@@ -114,8 +114,7 @@
   "repository": {
     "baseUrl": "https://github.com/dart-lang/async",
     "branch": "master",
-    "isVerified": false,
-    "verificationFailure": "Repository `pubspec.yaml` URL missmatch: `https://github.com/dart-lang/async` != `https://www.github.com/dart-lang/async`."
+    "isVerified": true
   },
   "urlProblems": []
 }

--- a/test/goldens/end2end/audio_service-0.17.0.json
+++ b/test/goldens/end2end/audio_service-0.17.0.json
@@ -173,8 +173,9 @@
   "repository": {
     "baseUrl": "https://github.com/ryanheise/audio_service",
     "branch": "minor",
+    "packagePath": "audio_service",
     "isVerified": false,
-    "verificationFailure": "Repository has no `pubspec.yaml` in location: `/`."
+    "verificationFailure": "Repository `audio_service/pubspec.yaml` URL missmatch: `https://github.com/ryanheise/audio_service/tree/master/audio_service` != `https://github.com/ryanheise/audio_service`."
   },
   "urlProblems": []
 }

--- a/test/goldens/end2end/audio_service-0.17.0.json
+++ b/test/goldens/end2end/audio_service-0.17.0.json
@@ -174,8 +174,7 @@
     "baseUrl": "https://github.com/ryanheise/audio_service",
     "branch": "minor",
     "packagePath": "audio_service",
-    "isVerified": false,
-    "verificationFailure": "Repository `audio_service/pubspec.yaml` URL missmatch: `https://github.com/ryanheise/audio_service/tree/master/audio_service` != `https://github.com/ryanheise/audio_service`."
+    "isVerified": true
   },
   "urlProblems": []
 }

--- a/test/goldens/end2end/nsd_android-1.0.2.json
+++ b/test/goldens/end2end/nsd_android-1.0.2.json
@@ -118,8 +118,7 @@
     "baseUrl": "https://github.com/sebastianhaberey/nsd",
     "branch": "main",
     "packagePath": "nsd_android",
-    "isVerified": false,
-    "verificationFailure": "Unable to parse `pubspec.yaml` from git repository."
+    "isVerified": true
   },
   "urlProblems": []
 }

--- a/test/goldens/end2end/url_launcher-6.0.3.json
+++ b/test/goldens/end2end/url_launcher-6.0.3.json
@@ -164,7 +164,7 @@
     "branch": "master",
     "packagePath": "packages/url_launcher/url_launcher",
     "isVerified": false,
-    "verificationFailure": "Unable to parse `pubspec.yaml` from git repository."
+    "verificationFailure": "Repository `packages/url_launcher/url_launcher/pubspec.yaml` URL missmatch: `https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher` != `https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher`."
   },
   "urlProblems": []
 }

--- a/test/goldens/end2end/url_launcher-6.0.3.json
+++ b/test/goldens/end2end/url_launcher-6.0.3.json
@@ -161,7 +161,7 @@
   "screenshots": [],
   "repository": {
     "baseUrl": "https://github.com/flutter/plugins",
-    "branch": "master",
+    "branch": "main",
     "packagePath": "packages/url_launcher/url_launcher",
     "isVerified": true
   },

--- a/test/goldens/end2end/url_launcher-6.0.3.json
+++ b/test/goldens/end2end/url_launcher-6.0.3.json
@@ -163,8 +163,7 @@
     "baseUrl": "https://github.com/flutter/plugins",
     "branch": "master",
     "packagePath": "packages/url_launcher/url_launcher",
-    "isVerified": false,
-    "verificationFailure": "Repository `packages/url_launcher/url_launcher/pubspec.yaml` URL missmatch: `https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher` != `https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher`."
+    "isVerified": true
   },
   "urlProblems": []
 }


### PR DESCRIPTION
- detects if multiple `pubspec.yaml` has the same package name, which may be a copy-paste error or a fraud attempt
- exposes the matched package path in the result data
