### PR TITLE
Use the stripped/augmented pubspec.yaml for 'pub outdated'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.21.13-dev
 
 - Populate the pubspec's `repository` field.
+- Fix: Use the stripped/augmented `pubspec.yaml` for `pub outdated`.
 
 ## 0.21.12
 

--- a/test/goldens/end2end/audio_service-0.18.4.json
+++ b/test/goldens/end2end/audio_service-0.18.4.json
@@ -113,7 +113,7 @@
         "grantedPoints": 10,
         "maxPoints": 20,
         "status": "failed",
-        "summary": "### [x] 0/10 points: All of the package dependencies are supported in the latest version\n\n* Could not run `flutter pub outdated`: `dart pub get` failed:\n\n```\nOUT:\nResolving dependencies...\nERR:\nBecause every version of flutter_test from sdk depends on fake_async 1.3.0 which doesn't match any versions, flutter_test from sdk is forbidden.\nSo, because audio_service depends on flutter_test from sdk, version solving failed.\n```\n\n### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs\n"
+        "summary": "### [x] 0/10 points: All of the package dependencies are supported in the latest version\n\n* Could not run `flutter pub outdated`: `dart pub get` failed:\n\n```\nOUT:\nResolving dependencies...\nERR:\nBecause every version of flutter_web_plugins from sdk depends on vector_math 2.1.2 which doesn't match any versions, flutter_web_plugins from sdk is forbidden.\nSo, because audio_service depends on flutter_web_plugins from sdk, version solving failed.\n```\n\n### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs\n"
       },
       {
         "id": "null-safety",

--- a/test/goldens/end2end/audio_service-0.18.4.json_report.md
+++ b/test/goldens/end2end/audio_service-0.18.4.json_report.md
@@ -75,8 +75,8 @@ To reproduce make sure you are using the [lints_core](https://pub.dev/packages/l
 OUT:
 Resolving dependencies...
 ERR:
-Because every version of flutter_test from sdk depends on fake_async 1.3.0 which doesn't match any versions, flutter_test from sdk is forbidden.
-So, because audio_service depends on flutter_test from sdk, version solving failed.
+Because every version of flutter_web_plugins from sdk depends on vector_math 2.1.2 which doesn't match any versions, flutter_web_plugins from sdk is forbidden.
+So, because audio_service depends on flutter_web_plugins from sdk, version solving failed.
 ```
 
 ### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs

--- a/test/goldens/end2end/sdp_transform-0.2.0.json
+++ b/test/goldens/end2end/sdp_transform-0.2.0.json
@@ -89,10 +89,10 @@
       {
         "id": "dependency",
         "title": "Support up-to-date dependencies",
-        "grantedPoints": 10,
+        "grantedPoints": 20,
         "maxPoints": 20,
-        "status": "failed",
-        "summary": "### [x] 0/10 points: All of the package dependencies are supported in the latest version\n\n* Could not run `dart pub outdated`: `dart pub get` failed:\n\n```\nOUT:\nResolving dependencies...\nERR:\npubspec.yaml has no lower-bound SDK constraint.\nYou should edit pubspec.yaml to contain an SDK constraint:\n\nenvironment:\n  sdk: '>=2.10.0 <3.0.0'\n\nSee https://dart.dev/go/sdk-constraint\n```\n\n### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs\n"
+        "status": "passed",
+        "summary": "### [*] 10/10 points: All of the package dependencies are supported in the latest version\n\nNo dependencies.\n\nTo reproduce run `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`.\n\n\n### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs\n"
       },
       {
         "id": "null-safety",

--- a/test/goldens/end2end/sdp_transform-0.2.0.json_report.md
+++ b/test/goldens/end2end/sdp_transform-0.2.0.json_report.md
@@ -78,24 +78,14 @@ INFO: 'List.List' is deprecated and shouldn't be used. Use a list literal, [], o
 To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/src/parser.dart`
 </details>
 
-## 10/20 Support up-to-date dependencies
+## 20/20 Support up-to-date dependencies
 
-### [x] 0/10 points: All of the package dependencies are supported in the latest version
+### [*] 10/10 points: All of the package dependencies are supported in the latest version
 
-* Could not run `dart pub outdated`: `dart pub get` failed:
+No dependencies.
 
-```
-OUT:
-Resolving dependencies...
-ERR:
-pubspec.yaml has no lower-bound SDK constraint.
-You should edit pubspec.yaml to contain an SDK constraint:
+To reproduce run `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides`.
 
-environment:
-  sdk: '>=2.10.0 <3.0.0'
-
-See https://dart.dev/go/sdk-constraint
-```
 
 ### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs
 

--- a/test/goldens/end2end/url_launcher-6.1.2.json
+++ b/test/goldens/end2end/url_launcher-6.1.2.json
@@ -116,7 +116,7 @@
         "grantedPoints": 10,
         "maxPoints": 20,
         "status": "failed",
-        "summary": "### [x] 0/10 points: All of the package dependencies are supported in the latest version\n\n* Could not run `flutter pub outdated`: `dart pub get` failed:\n\n```\nOUT:\nResolving dependencies...\nERR:\nBecause every version of flutter_test from sdk depends on vector_math 2.1.2 which doesn't match any versions, flutter_test from sdk is forbidden.\nSo, because url_launcher depends on flutter_test from sdk, version solving failed.\n```\n\n### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs\n"
+        "summary": "### [x] 0/10 points: All of the package dependencies are supported in the latest version\n\n* Could not run `flutter pub outdated`: `dart pub get` failed:\n\n```\nOUT:\nResolving dependencies...\nERR:\nBecause every version of flutter from sdk depends on vector_math 2.1.2 which doesn't match any versions, flutter from sdk is forbidden.\nSo, because url_launcher depends on flutter from sdk, version solving failed.\n```\n\n### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs\n"
       },
       {
         "id": "null-safety",

--- a/test/goldens/end2end/url_launcher-6.1.2.json_report.md
+++ b/test/goldens/end2end/url_launcher-6.1.2.json_report.md
@@ -75,8 +75,8 @@ To reproduce make sure you are using the [lints_core](https://pub.dev/packages/l
 OUT:
 Resolving dependencies...
 ERR:
-Because every version of flutter_test from sdk depends on vector_math 2.1.2 which doesn't match any versions, flutter_test from sdk is forbidden.
-So, because url_launcher depends on flutter_test from sdk, version solving failed.
+Because every version of flutter from sdk depends on vector_math 2.1.2 which doesn't match any versions, flutter from sdk is forbidden.
+So, because url_launcher depends on flutter from sdk, version solving failed.
 ```
 
 ### [*] 10/10 points: Package supports latest stable Dart and Flutter SDKs


### PR DESCRIPTION
- Fixes #1069.
- Re-implements part of #1052, without the actual reuse (which should be a separate PR).