### PR TITLE
Use ToolException instead of ArgumentError in analysis output processing.

### DIFF
--- a/lib/src/code_problem.dart
+++ b/lib/src/code_problem.dart
@@ -7,6 +7,7 @@ library pana.code_problem;
 import 'package:path/path.dart' as p;
 
 import 'internal_model.dart';
+import 'sdk_env.dart' show ToolException;
 
 // ignore: prefer_interpolation_to_compose_strings
 final _regexp = RegExp('^' + // beginning of line
@@ -63,8 +64,7 @@ CodeProblem? parseCodeProblem(String content, {String? projectDir}) {
       );
     }
 
-    throw ArgumentError(
-        'Provided content does not align with expectations.\n`$content`');
+    throw ToolException('Analysis failed with unexpected output.\n`$content`');
   }
 
   var match = matches.single;

--- a/test/code_problem_test.dart
+++ b/test/code_problem_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:pana/src/code_problem.dart';
+import 'package:pana/src/sdk_env.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -16,5 +17,10 @@ void main() {
   test('too many lines', () {
     final cp = parseCodeProblem('STDERR exceeded 100000 lines.')!;
     expect(cp.description, 'Analysis returned too many issues.');
+  });
+
+  test('analysis server failure', () {
+    expect(() => parseCodeProblem('Please report this at dartbug.com.'),
+        throwsA(isA<ToolException>()));
   });
 }


### PR DESCRIPTION
- Fixes #1081 (at least the part which we have control over).
- The `ToolException` is better than `ArgumentError`, as it becomes part of the pana report (while it is also being logged), without blocking the rest of analysis too much.