### PR TITLE
Expose 'RepositoryProvider' in the analysis result ('Repository.provider')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Predefined platform assignments for binary-only packages.
 - Fix: internal hostname check uses full-length match.
+- Expose `RepositoryProvider` in the analysis result (`Repository.provider`).
 
 ## 0.21.13
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -377,20 +377,38 @@ class AnalysisResult {
 ///   - must not have a `publish_to` key.
 @JsonSerializable()
 class Repository {
+  final String provider;
   final String baseUrl;
   final String? branch;
   final String? packagePath;
 
   Repository({
+    String? provider,
     required this.baseUrl,
     this.branch,
     this.packagePath,
-  });
+  }) : provider = provider ?? RepositoryProvider.unknown;
 
   factory Repository.fromJson(Map<String, dynamic> json) =>
       _$RepositoryFromJson(json);
 
   Map<String, dynamic> toJson() => _$RepositoryToJson(this);
+}
+
+/// The identifier of repository provider, which could influence how relative URLs are resolved.
+abstract class RepositoryProvider {
+  /// GitHub
+  static const github = 'github';
+
+  /// GitLab (cloud or self-hosted)
+  static const gitlab = 'gitlab';
+
+  /// Unable to identify.
+  static const unknown = 'unknown';
+
+  /// Whether the provider follows the GitHub URL conventions.
+  static bool isGitHubCompatible(String? provider) =>
+      provider == github || provider == gitlab;
 }
 
 @JsonSerializable()

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -377,13 +377,13 @@ class AnalysisResult {
 ///   - must not have a `publish_to` key.
 @JsonSerializable()
 class Repository {
-  final String provider;
+  final RepositoryProvider provider;
   final String baseUrl;
   final String? branch;
   final String? packagePath;
 
   Repository({
-    String? provider,
+    RepositoryProvider? provider,
     required this.baseUrl,
     this.branch,
     this.packagePath,
@@ -396,18 +396,18 @@ class Repository {
 }
 
 /// The identifier of repository provider, which could influence how relative URLs are resolved.
-abstract class RepositoryProvider {
+enum RepositoryProvider {
   /// GitHub
-  static const github = 'github';
+  github,
 
   /// GitLab (cloud or self-hosted)
-  static const gitlab = 'gitlab';
+  gitlab,
 
   /// Unable to identify.
-  static const unknown = 'unknown';
+  unknown;
 
   /// Whether the provider follows the GitHub URL conventions.
-  static bool isGitHubCompatible(String? provider) =>
+  static bool isGitHubCompatible(RepositoryProvider? provider) =>
       provider == github || provider == gitlab;
 }
 

--- a/lib/src/model.g.dart
+++ b/lib/src/model.g.dart
@@ -210,7 +210,8 @@ Map<String, dynamic> _$AnalysisResultToJson(AnalysisResult instance) {
 }
 
 Repository _$RepositoryFromJson(Map<String, dynamic> json) => Repository(
-      provider: json['provider'] as String?,
+      provider:
+          $enumDecodeNullable(_$RepositoryProviderEnumMap, json['provider']),
       baseUrl: json['baseUrl'] as String,
       branch: json['branch'] as String?,
       packagePath: json['packagePath'] as String?,
@@ -218,7 +219,7 @@ Repository _$RepositoryFromJson(Map<String, dynamic> json) => Repository(
 
 Map<String, dynamic> _$RepositoryToJson(Repository instance) {
   final val = <String, dynamic>{
-    'provider': instance.provider,
+    'provider': _$RepositoryProviderEnumMap[instance.provider],
     'baseUrl': instance.baseUrl,
   };
 
@@ -232,6 +233,12 @@ Map<String, dynamic> _$RepositoryToJson(Repository instance) {
   writeNotNull('packagePath', instance.packagePath);
   return val;
 }
+
+const _$RepositoryProviderEnumMap = {
+  RepositoryProvider.github: 'github',
+  RepositoryProvider.gitlab: 'gitlab',
+  RepositoryProvider.unknown: 'unknown',
+};
 
 UrlProblem _$UrlProblemFromJson(Map<String, dynamic> json) => UrlProblem(
       url: json['url'] as String,

--- a/lib/src/model.g.dart
+++ b/lib/src/model.g.dart
@@ -210,6 +210,7 @@ Map<String, dynamic> _$AnalysisResultToJson(AnalysisResult instance) {
 }
 
 Repository _$RepositoryFromJson(Map<String, dynamic> json) => Repository(
+      provider: json['provider'] as String?,
       baseUrl: json['baseUrl'] as String,
       branch: json['branch'] as String?,
       packagePath: json['packagePath'] as String?,
@@ -217,6 +218,7 @@ Repository _$RepositoryFromJson(Map<String, dynamic> json) => Repository(
 
 Map<String, dynamic> _$RepositoryToJson(Repository instance) {
   final val = <String, dynamic>{
+    'provider': instance.provider,
     'baseUrl': instance.baseUrl,
   };
 

--- a/lib/src/repository/check_repository.dart
+++ b/lib/src/repository/check_repository.dart
@@ -47,6 +47,7 @@ Future<VerifiedRepository?> checkRepository(PackageContext context) async {
     if (isVerified && verificationFailure == null) {
       return VerifiedRepository(
         repository: Repository(
+          provider: url.provider,
           baseUrl: url.baseUrl,
           branch: branch,
           packagePath: packagePath,

--- a/lib/src/repository/repository_url.dart
+++ b/lib/src/repository/repository_url.dart
@@ -4,10 +4,12 @@
 
 import 'package:path/path.dart' as p;
 
+import '../model.dart' show RepositoryProvider;
+
 /// Describes the url + folder or file path of a repository URL.
 class RepositoryUrl {
   /// One of the values from [RepositoryProvider].
-  final String provider;
+  final String? provider;
 
   /// The base URL up to the repository itself.
   final String baseUrl;
@@ -83,15 +85,6 @@ class RepositoryUrl {
   /// Creates a String representation of the URL.
   String toUrl() =>
       p.joinAll([baseUrl, separator, branch, path].whereType<String>());
-}
-
-abstract class RepositoryProvider {
-  static const github = 'github';
-  static const gitlab = 'gitlab';
-  static const unknown = 'unknown';
-
-  static bool isGitHubCompatible(String provider) =>
-      provider == github || provider == gitlab;
 }
 
 const _replaceSchemes = {

--- a/lib/src/repository/repository_url.dart
+++ b/lib/src/repository/repository_url.dart
@@ -9,7 +9,7 @@ import '../model.dart' show RepositoryProvider;
 /// Describes the url + folder or file path of a repository URL.
 class RepositoryUrl {
   /// One of the values from [RepositoryProvider].
-  final String? provider;
+  final RepositoryProvider? provider;
 
   /// The base URL up to the repository itself.
   final String baseUrl;
@@ -156,13 +156,13 @@ RepositoryUrl? _tryParseRepositoryUrl(String input) {
   );
 }
 
-String _detectProvider(Uri uri) {
+RepositoryProvider _detectProvider(Uri uri) {
   if (uri.host == 'github.com') return RepositoryProvider.github;
   if (uri.host == 'gitlab.com') return RepositoryProvider.gitlab;
   return RepositoryProvider.unknown;
 }
 
-int _repoSegmentIndex(String provider, List<String> segments) {
+int _repoSegmentIndex(RepositoryProvider provider, List<String> segments) {
   // first segment with .git postfix
   final gitPostfixIndex = segments.indexWhere((s) => s.endsWith('.git'));
   if (gitPostfixIndex >= 0) return gitPostfixIndex;

--- a/test/goldens/end2end/async-2.5.0.json
+++ b/test/goldens/end2end/async-2.5.0.json
@@ -115,6 +115,7 @@
     "repositoryUrl": "https://www.github.com/dart-lang/async",
     "issueTrackerUrl": "https://github.com/dart-lang/async/issues",
     "repository": {
+      "provider": "github",
       "baseUrl": "https://github.com/dart-lang/async",
       "branch": "master"
     }

--- a/test/goldens/end2end/audio_service-0.18.4.json
+++ b/test/goldens/end2end/audio_service-0.18.4.json
@@ -145,6 +145,7 @@
     "repositoryUrl": "https://github.com/ryanheise/audio_service/tree/master/audio_service",
     "issueTrackerUrl": "https://github.com/ryanheise/audio_service/issues",
     "repository": {
+      "provider": "github",
       "baseUrl": "https://github.com/ryanheise/audio_service",
       "branch": "minor",
       "packagePath": "audio_service"

--- a/test/goldens/end2end/bulma_min-0.7.4.json
+++ b/test/goldens/end2end/bulma_min-0.7.4.json
@@ -100,6 +100,7 @@
     "repositoryUrl": "https://github.com/agilord/bulma_min",
     "issueTrackerUrl": "https://github.com/agilord/bulma_min/issues",
     "repository": {
+      "provider": "github",
       "baseUrl": "https://github.com/agilord/bulma_min",
       "branch": "master"
     }

--- a/test/goldens/end2end/dnd-2.0.0.json
+++ b/test/goldens/end2end/dnd-2.0.0.json
@@ -103,6 +103,7 @@
     "repositoryUrl": "https://github.com/marcojakob/dart-dnd",
     "issueTrackerUrl": "https://github.com/marcojakob/dart-dnd/issues",
     "repository": {
+      "provider": "github",
       "baseUrl": "https://github.com/marcojakob/dart-dnd",
       "branch": "master"
     }

--- a/test/goldens/end2end/http-0.13.0.json
+++ b/test/goldens/end2end/http-0.13.0.json
@@ -123,6 +123,7 @@
     "repositoryUrl": "https://github.com/dart-lang/http",
     "issueTrackerUrl": "https://github.com/dart-lang/http/issues",
     "repository": {
+      "provider": "github",
       "baseUrl": "https://github.com/dart-lang/http",
       "branch": "master",
       "packagePath": "pkgs/http"

--- a/test/goldens/end2end/mime_type-0.3.2.json
+++ b/test/goldens/end2end/mime_type-0.3.2.json
@@ -93,6 +93,7 @@
     "repositoryUrl": "https://github.com/mitsuoka/mime_type",
     "issueTrackerUrl": "https://github.com/mitsuoka/mime_type/issues",
     "repository": {
+      "provider": "github",
       "baseUrl": "https://github.com/mitsuoka/mime_type",
       "branch": "master"
     }

--- a/test/goldens/end2end/nsd_android-1.2.0.json
+++ b/test/goldens/end2end/nsd_android-1.2.0.json
@@ -107,6 +107,7 @@
     "repositoryUrl": "https://github.com/sebastianhaberey/nsd/tree/main/nsd_android",
     "issueTrackerUrl": "https://github.com/sebastianhaberey/nsd/issues",
     "repository": {
+      "provider": "github",
       "baseUrl": "https://github.com/sebastianhaberey/nsd",
       "branch": "main",
       "packagePath": "nsd_android"

--- a/test/goldens/end2end/sdp_transform-0.2.0.json
+++ b/test/goldens/end2end/sdp_transform-0.2.0.json
@@ -109,6 +109,7 @@
     "repositoryUrl": "https://github.com/cloudwebrtc/dart-sdp-transform",
     "issueTrackerUrl": "https://github.com/cloudwebrtc/dart-sdp-transform/issues",
     "repository": {
+      "provider": "github",
       "baseUrl": "https://github.com/cloudwebrtc/dart-sdp-transform",
       "branch": "master"
     }

--- a/test/goldens/end2end/skiplist-0.1.0.json
+++ b/test/goldens/end2end/skiplist-0.1.0.json
@@ -95,6 +95,7 @@
     "repositoryUrl": "https://github.com/stevenroose/dart-skiplist",
     "issueTrackerUrl": "https://github.com/stevenroose/dart-skiplist/issues",
     "repository": {
+      "provider": "github",
       "baseUrl": "https://github.com/stevenroose/dart-skiplist",
       "branch": "master"
     }

--- a/test/goldens/end2end/url_launcher-6.1.2.json
+++ b/test/goldens/end2end/url_launcher-6.1.2.json
@@ -147,6 +147,7 @@
     "repositoryUrl": "https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher",
     "issueTrackerUrl": "https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22",
     "repository": {
+      "provider": "github",
       "baseUrl": "https://github.com/flutter/plugins",
       "branch": "main",
       "packagePath": "packages/url_launcher/url_launcher"

--- a/test/goldens/end2end/webdriver-3.0.0.json
+++ b/test/goldens/end2end/webdriver-3.0.0.json
@@ -113,6 +113,7 @@
     "repositoryUrl": "https://github.com/google/webdriver.dart",
     "issueTrackerUrl": "https://github.com/google/webdriver.dart/issues",
     "repository": {
+      "provider": "github",
       "baseUrl": "https://github.com/google/webdriver.dart",
       "branch": "master"
     }


### PR DESCRIPTION
This will be needed for URL rewrite rules (we shouldn't even try to rewrite URLs that are not known providers).