### PR TITLE
Improved URL resolver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.21.15
+
+- Improved URL resolver.
+
 ## 0.21.14
 
 - Predefined platform assignments for binary-only packages.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.21.14';
+const packageVersion = '0.21.15-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.21.14
+version: 0.21.15-dev
 repository: https://github.com/dart-lang/pana
 
 environment:


### PR DESCRIPTION
- Fix: do not strip query parameters.
- Fix: GitHub relative and absolute links (without scheme and host name) must be inside the repository.
- Fix: unknown providers may not use `branch` in the final URL path.
- New feature: `relativeFrom` parameter to indicate the source of the references (e.g. `example/README.md`)
- Added missing tests for unknown providers.
