### PR TITLE
Remove 'pubspec_overrides.yaml' when running 'pub upgrade' or 'pub outdated'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Improved URL resolver.
 - Always use English locale for git commands.
+- Fix: Remove `pubspec_overrides.yaml` when running `pub upgrade` or `pub outdated`.
 
 ## 0.21.14
 


### PR DESCRIPTION
Fixes #1089