### PR TITLE
Bump version constraint of pubspec_parse

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   markdown: ^5.0.0
   path: ^1.6.2
   pub_semver: ^2.0.0
-  pubspec_parse: ^1.0.0
+  pubspec_parse: ^1.2.0
   source_span: ^1.7.0
   tar: ^0.5.4
   yaml: ^3.0.0


### PR DESCRIPTION
The [usage](https://github.com/dart-lang/pana/blob/903a15ff305369d17a54d1f4aa4ae0add79acbd0/lib/src/pubspec.dart#L46) of the screenshots field stipulates at least v1.2.0 of package:pubspec_parse - see https://github.com/dart-lang/pubspec_parse/commit/47fa52db323ff3a3315c4462756e38a7020cb91d