### PR TITLE
Always use English locale for git commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.21.15
 
 - Improved URL resolver.
+- Always use English locale for git commands.
 
 ## 0.21.14
 

--- a/lib/src/repository/git_local_repository.dart
+++ b/lib/src/repository/git_local_repository.dart
@@ -61,6 +61,10 @@ class GitLocalRepository {
   }) async {
     final pr = await runProc(
       ['git', ...args],
+      environment: {
+        'LANG': 'C', // default English locale that is always present
+        'LC_ALL': 'en_US',
+      },
       workingDirectory: localPath,
       maxOutputBytes: maxOutputBytes,
     );


### PR DESCRIPTION
- Fixes https://github.com/dart-lang/pana/issues/1095.
- Replaces #1097.