### PR TITLE
fix: Non-default branch

### DIFF
--- a/lib/src/repository/check_repository.dart
+++ b/lib/src/repository/check_repository.dart
@@ -70,7 +70,7 @@ Future<VerifiedRepository?> checkRepository(PackageContext context) async {
     late GitLocalRepository repo;
     try {
       repo = await GitLocalRepository.createLocalRepository(url.cloneUrl);
-      branch = await repo.detectDefaultBranch();
+      branch ??= await repo.detectDefaultBranch();
 
       // list all pubspec.yaml files
       final files = await repo.listFiles(branch);

--- a/test/goldens/end2end/audio_service-0.18.4.json
+++ b/test/goldens/end2end/audio_service-0.18.4.json
@@ -148,7 +148,7 @@
       "provider": "github",
       "host": "github.com",
       "repository": "ryanheise/audio_service",
-      "branch": "minor",
+      "branch": "master",
       "path": "audio_service"
     }
   },


### PR DESCRIPTION
Fixes the case where `repositoryUrl` points to a non-default branch. Before, `checkRepository` would overwrite this value with the default branch of the repo, causing some checks to fail if the package was not being tracked in the repo's main branch. This can be the case when publishing packages off a feature/next branch before merging to main.

This can be seen in the updated e2e golden for [audio_service](https://pub.dev/packages/audio_service) who's default branch is `minor`, but who's `repositoryUrl` points to `master`.