### PR TITLE
bump version constraint of package:http

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   cli_util: ^0.3.0
   collection: ^1.15.0
   html: ^0.15.0
-  http: ^0.13.0
+  http: ^0.13.2
   io: ^1.0.0
   json_annotation: ^4.5.0
   logging: ^1.0.0


### PR DESCRIPTION
The [usage](https://github.com/dart-lang/pana/blob/efcfd1d8e917900817a8fd72bf16c795ab508a96/lib/src/download_utils.dart#L39) of the `RetryClient` class (imported from `package:http/retry.dart`) stipulates at least v0.13.2 of `package:http`
- see https://github.com/dart-lang/http/commit/69d6064dd92470ed7ccd50a808fc789ee7716fe8 where it was moved from `package:http_retry`
- also see https://github.com/dart-lang/http/blob/master/pkgs/http/CHANGELOG.md#0132