### PR TITLE
License text preprocessing to detect ISC license.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.21.16
 
+- Preprocess license texts for better match.
 - Explain `HEAD` request for URL checks.
 
 ## 0.21.15

--- a/lib/src/license.dart
+++ b/lib/src/license.dart
@@ -42,10 +42,9 @@ Future<List<License>> detectLicenseInFile(File file,
 ///
 /// [1]: https://spdx.org/licenses/
 Future<List<License>> detectLicenseInContent(
-  String originalContent, {
+  String content, {
   required String relativePath,
 }) async {
-  var content = originalContent;
   final licenseResult = await detectLicense(content, 0.95);
 
   if (licenseResult.unclaimedTokenPercentage > 0.5 ||

--- a/lib/src/license_detection/license.dart
+++ b/lib/src/license_detection/license.dart
@@ -4,6 +4,10 @@
 
 part of 'license_detector.dart';
 
+/// Regular expression to match the common pattern of `Copyright (c) yyyy[-yyyy] <name>.`
+final _copyrightRegExp =
+    RegExp(r'^copyright.+\d{4}.{0,100}$', caseSensitive: false);
+
 @sealed
 class License {
   /// SPDX identifier of the license, is empty in case of unknown license.
@@ -21,9 +25,22 @@ class License {
   License._(this.content, this.tokens, this.tokenFrequency, this.identifier);
 
   factory License.parse({required String identifier, required String content}) {
-    final tokens = tokenize(content);
+    // Remove some known patterns from the licenses that are not needed during matching.
+    final lines = content.split('\n');
+
+    // Remove `<IDENTIFIER> License:` as the first line, found in ISC license
+    if (lines.isNotEmpty &&
+        lines.first.toLowerCase() == '${identifier.toLowerCase()} license:') {
+      lines.removeAt(0);
+    }
+
+    // Remove `Copyright (c) yyyy[-yyyy] <name>.` and similar patterns.
+    lines.removeWhere((line) => _copyrightRegExp.matchAsPrefix(line) != null);
+
+    final strippedContent = lines.join('\n');
+    final tokens = tokenize(strippedContent);
     final table = generateFrequencyTable(tokens);
-    return License._(content, tokens, table, identifier);
+    return License._(strippedContent, tokens, table, identifier);
   }
 }
 
@@ -195,7 +212,7 @@ class LicenseMatch {
 /// [Token.value] is mapped to the number of occurrences in the license text.
 @visibleForTesting
 Map<String, int> generateFrequencyTable(List<Token> tokens) {
-  var table = <String, int>{};
+  final table = <String, int>{};
 
   for (var token in tokens) {
     table[token.value] = (table[token.value] ?? 0) + 1;
@@ -244,22 +261,15 @@ List<License> loadLicensesFromDirectories(Iterable<String> directories) {
 /// [1]: https://github.com/spdx/license-list-XML/blob/master/DOCS/license-fields.md#explanation-of-spdx-license-list-fields
 @visibleForTesting
 List<License> licensesFromFile(String path) {
-  var licenses = <License>[];
+  final licenses = <License>[];
   final file = File(path);
 
-  final rawContent = file.readAsBytesSync();
+  final content = file.readAsStringSync();
   final identifier = file.uri.pathSegments.last.split('.txt').first;
 
   if (_invalidIdentifier.hasMatch(identifier)) {
     throw ArgumentError(
         'Invalid file name: expected: "path/to/file/<spdx-identifier>.txt" actual: $path');
-  }
-  var content = '';
-
-  try {
-    content = utf8.decode(rawContent);
-  } on FormatException {
-    throw ArgumentError('Invalid utf-8 encoding: $path');
   }
 
   licenses.add(License.parse(identifier: identifier, content: content));
@@ -309,7 +319,7 @@ List<NGram> generateChecksums(List<Token> tokens, int granularity) {
 /// checksum value.
 @visibleForTesting
 Map<int, List<NGram>> generateChecksumMap(List<NGram> nGrams) {
-  var table = <int, List<NGram>>{};
+  final table = <int, List<NGram>>{};
   for (var gram in nGrams) {
     table.putIfAbsent(gram.checksum, () => []).add(gram);
   }

--- a/lib/src/license_detection/license.dart
+++ b/lib/src/license_detection/license.dart
@@ -6,7 +6,7 @@ part of 'license_detector.dart';
 
 /// Regular expression to match the common pattern of `Copyright (c) yyyy[-yyyy] <name>.`
 final _copyrightRegExp =
-    RegExp(r'^copyright\s+(?:(c)|©)\s+\d{4}.{0,100}$', caseSensitive: false);
+    RegExp(r'^copyright\s+(?:\(c\)|©)\s+\d{4}.{0,100}$', caseSensitive: false);
 
 @sealed
 class License {

--- a/lib/src/license_detection/license.dart
+++ b/lib/src/license_detection/license.dart
@@ -6,7 +6,7 @@ part of 'license_detector.dart';
 
 /// Regular expression to match the common pattern of `Copyright (c) yyyy[-yyyy] <name>.`
 final _copyrightRegExp =
-    RegExp(r'^copyright.+\d{4}.{0,100}$', caseSensitive: false);
+    RegExp(r'^copyright\s+(?:(c)|©)\s+\d{4}.{0,100}$', caseSensitive: false);
 
 @sealed
 class License {

--- a/lib/src/license_detection/token_matcher.dart
+++ b/lib/src/license_detection/token_matcher.dart
@@ -56,6 +56,9 @@ class Range {
     return (start >= other.start && start <= other.end) ||
         (end >= other.start && end <= other.end);
   }
+
+  @override
+  String toString() => 'Range($start-$end)';
 }
 
 /// Returns a list of [MatchRange] for [unknownLicense] that might be the best possible match for [knownLicense].

--- a/test/licenses/isc_license_test.dart
+++ b/test/licenses/isc_license_test.dart
@@ -1,0 +1,33 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pana/src/license.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ISC', () {
+    test('weak_cache', () async {
+      final input =
+          '''Copyright 2022 Yaroslav Vorobev and contributors. All rights reserved.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+''';
+
+      final detected =
+          await detectLicenseInContent(input, relativePath: 'LICENSE');
+      expect(detected, hasLength(1));
+      expect(detected.single.spdxIdentifier, 'ISC');
+    });
+  });
+}


### PR DESCRIPTION
- Fixes #1071.
- The current code produced a high score, but not enough to cross the threshold. Removing the known patterns from all the licenses (both the patterns and the input in question) should increase the confidence for all kind of licenses.
- Also did small cleanups as I was debugging the code.