### PR TITLE
Prepare release: 0.21.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Explain `HEAD` request for URL checks.
 - Grant 10 points for using only OSI-approved licenses.
+- Fix: don't resolve dependencies in example folder of flutter packages.
+- Fix: handle `CheckedFromJsonException` during repository verification.
 
 ## 0.21.15
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.21.16-dev';
+const packageVersion = '0.21.16';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: Evaluate the health and quality of a Dart package
-version: 0.21.16-dev
+version: 0.21.16
 repository: https://github.com/dart-lang/pana
 
 environment:
@@ -15,7 +15,7 @@ dependencies:
   html: ^0.15.0
   http: ^0.13.2
   io: ^1.0.0
-  json_annotation: ^4.5.0
+  json_annotation: ^4.6.0
   logging: ^1.0.0
   markdown: ^6.0.0
   path: ^1.6.2


### PR DESCRIPTION
- added CHANGELOG entries
- bumped version constraint for `json_annotation` (was a warning from build_runner)
- bumped release version