### PR TITLE
Remove 'required' from AnalysisResult's contributingUrl.

### DIFF
--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -372,7 +372,7 @@ class AnalysisResult {
     this.documentationUrl,
     this.fundingUrls,
     this.repository,
-    required this.contributingUrl,
+    this.contributingUrl,
   });
 
   factory AnalysisResult.fromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
This was a leftover artifact (when I created the PR to check the potential uses).