### PR TITLE
New platform tagging with separate Dart and Flutter runtimes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.21.20
 
 - Renamed tag: `has:errors` -> `has:error`.
+- New platform tagging with separate SDK runtimes.
 
 ## 0.21.19
 

--- a/lib/src/tag/_common.dart
+++ b/lib/src/tag/_common.dart
@@ -16,6 +16,26 @@ typedef Explainer<N> = Explanation? Function(List<N> path);
 /// Explainer should give an explanation of the problem.
 typedef Predicate<T> = Explainer<T>? Function(T node);
 
+/// The accumulated values of a tagging step.
+class TaggingResult {
+  final Set<String> tags;
+  final List<Explanation> explanations;
+
+  TaggingResult(this.tags, this.explanations);
+
+  factory TaggingResult.merge(Iterable<TaggingResult> results) {
+    final tags = <String>{};
+    final explanations = <Explanation>[];
+    for (final result in results) {
+      tags.addAll(result.tags);
+      explanations.addAll(result.explanations);
+    }
+    return TaggingResult(tags, explanations);
+  }
+
+  bool get isSuccess => tags.isNotEmpty && explanations.isEmpty;
+}
+
 /// Indicates an issue.
 class Explanation {
   final String finding;

--- a/lib/src/tag/_specs.dart
+++ b/lib/src/tag/_specs.dart
@@ -121,15 +121,15 @@ class Runtime {
 /// A platform where Dart and Flutter can be deployed.
 class Platform {
   final String name;
-  final Runtime runtime;
+  final Runtime dartRuntime;
+  final Runtime flutterRuntime;
   final String tag;
-  final bool allowsNativeJit;
 
   Platform(
-    this.name,
-    this.runtime, {
+    this.name, {
+    required this.dartRuntime,
+    required this.flutterRuntime,
     required this.tag,
-    this.allowsNativeJit = false,
   });
 
   static final List<Platform> recognizedPlatforms = [
@@ -154,36 +154,39 @@ class Platform {
 
   static final android = Platform(
     'Android',
-    Runtime.broadNative,
+    dartRuntime: Runtime.nativeAot,
+    flutterRuntime: Runtime.flutterNative,
     tag: 'platform:android',
   );
   static final ios = Platform(
     'iOS',
-    Runtime.broadNative,
+    dartRuntime: Runtime.nativeAot,
+    flutterRuntime: Runtime.flutterNative,
     tag: 'platform:ios',
   );
   static final linux = Platform(
     'Linux',
-    Runtime.broadNative,
+    dartRuntime: Runtime.nativeJit,
+    flutterRuntime: Runtime.flutterNative,
     tag: 'platform:linux',
-    allowsNativeJit: true,
   );
   static final macos = Platform(
     'macOS',
-    Runtime.broadNative,
+    dartRuntime: Runtime.nativeJit,
+    flutterRuntime: Runtime.flutterNative,
     tag: 'platform:macos',
-    allowsNativeJit: true,
   );
   static final web = Platform(
     'Web',
-    Runtime.broadWeb,
+    dartRuntime: Runtime.web,
+    flutterRuntime: Runtime.flutterWeb,
     tag: 'platform:web',
   );
   static final windows = Platform(
     'Windows',
-    Runtime.broadNative,
+    dartRuntime: Runtime.nativeJit,
+    flutterRuntime: Runtime.flutterNative,
     tag: 'platform:windows',
-    allowsNativeJit: true,
   );
 
   @override

--- a/lib/src/tag/_specs.dart
+++ b/lib/src/tag/_specs.dart
@@ -121,7 +121,7 @@ class Runtime {
 /// A platform where Dart and Flutter can be deployed.
 class Platform {
   final String name;
-  final Runtime dartRuntime;
+  final Runtime? dartRuntime;
   final Runtime flutterRuntime;
   final String tag;
 
@@ -160,7 +160,7 @@ class Platform {
   );
   static final ios = Platform(
     'iOS',
-    dartRuntime: Runtime.nativeAot,
+    dartRuntime: null,
     flutterRuntime: Runtime.flutterNative,
     tag: 'platform:ios',
   );

--- a/lib/src/tag/_violations.dart
+++ b/lib/src/tag/_violations.dart
@@ -90,19 +90,11 @@ import '_specs.dart';
 
 /// Detects forbidden imports given a runtime.
 PathFinder<Uri> runtimeViolationFinder(
-  LibraryGraph libraryGraph,
-  Runtime runtime,
-  Explainer<Uri> explainer, {
-  Set<String> additionalLibs = const <String>{},
-}) {
-  final allEnabledLibs = <String>{
-    ...runtime.enabledLibs,
-    ...additionalLibs,
-  };
+    LibraryGraph libraryGraph, Runtime runtime, Explainer<Uri> explainer) {
   return PathFinder<Uri>(libraryGraph, (Uri uri) {
     final uriString = uri.toString();
     if (uriString.startsWith('dart:') &&
-        !allEnabledLibs.contains(uriString.substring(5))) {
+        !runtime.enabledLibs.contains(uriString.substring(5))) {
       return explainer;
     }
     return null;

--- a/lib/src/tag/tagger.dart
+++ b/lib/src/tag/tagger.dart
@@ -234,8 +234,8 @@ class Tagger {
     final platformResults = <TaggingResult>[];
     for (final platform in Platform.recognizedPlatforms) {
       final results = [
-        if (!_usesFlutter)
-          _checkRuntime(platform, platform.dartRuntime,
+        if (!_usesFlutter && platform.dartRuntime != null)
+          _checkRuntime(platform, platform.dartRuntime!,
               trustDeclarations: trustDeclarations),
         _checkRuntime(platform, platform.flutterRuntime,
             trustDeclarations: trustDeclarations),


### PR DESCRIPTION
The top-level tagging methods with `List<String> tags, List<Explanation> explanations` could be moved to use `TaggingResult` as the next step.