### PR TITLE
Set FLUTTER_ROOT environment variable when running flutter commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.21.22
+
+- Set `FLUTTER_ROOT` environment variable when running `flutter` commands.
+
 ## 0.21.21
 
 - `PanaTags` fields provide a single place for most of the tags that a package can get.


### PR DESCRIPTION
- Follow-up to #1158.
- When running the analysis with the future Flutter SDK, we'll need to also set the FLUTTER_ROOT to the correct directory, otherwise on pub-dev it would use the stable's path.