### PR TITLE
Fix: revert the extra line in <summary> blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.21.23
 
 - Fix: tar extraction issue with directory entries.
-- Fix: revert the extra line in <summary> blocks.
+- Fix: revert the extra line in `<summary>` blocks.
 
 ## 0.21.22
 


### PR DESCRIPTION
we can have changed it to code highlighting