### PR TITLE
Don't send analytics

### DIFF
--- a/bin/pana.dart
+++ b/bin/pana.dart
@@ -136,6 +136,7 @@ Future main(List<String> args) async {
       sdkDir: result['dart-sdk'] as String?,
       flutterDir: result['flutter-sdk'] as String?,
       pubHostedUrl: pubHostedUrl,
+      environment: Platform.environment,
     );
     final options = InspectOptions(
       pubHostedUrl: pubHostedUrl,

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -70,6 +70,7 @@ class PackageAnalyzer {
     String? flutterDir,
     String? pubCacheDir,
     String? pubHostedUrl,
+    Map<String, String>? environment,
   }) async {
     return PackageAnalyzer(await ToolEnvironment.create(
         dartSdkDir: sdkDir,
@@ -77,6 +78,7 @@ class PackageAnalyzer {
         pubCacheDir: pubCacheDir,
         environment: <String, String>{
           if (pubHostedUrl != null) 'PUB_HOSTED_URL': pubHostedUrl,
+          ...?environment,
         }));
   }
 

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -441,7 +441,7 @@ class ToolEnvironment {
           stderr,
         );
       }
-      print(environment);
+
       final result = await runProc(
         [
           ...pubCmd,

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -168,14 +168,26 @@ class ToolEnvironment {
       resolvedFlutterSdk,
       resolvedPubCache,
       resolvedFutureFlutterSdk,
-      [_join(resolvedDartSdk, 'bin', 'dart')],
-      [_join(resolvedDartSdk, 'bin', 'dart'), 'pub'],
-      [_join(resolvedDartSdk, 'bin', 'dart'), 'analyze'],
-      [_join(resolvedDartSdk, 'bin', 'dart'), 'doc'],
-      [_join(resolvedFlutterSdk, 'bin', 'flutter'), '--no-version-check'],
-      [_join(flutterDartSdkDir, 'bin', 'dart'), 'analyze'],
-      [_join(resolvedFutureDartSdk, 'bin', 'dart'), 'analyze'],
-      [_join(resolvedFutureFlutterDartSdkDir, 'bin', 'dart'), 'analyze'],
+      [_join(resolvedDartSdk, 'bin', 'dart'), '--no-analytics'],
+      [_join(resolvedDartSdk, 'bin', 'dart'), '--no-analytics', 'pub'],
+      [_join(resolvedDartSdk, 'bin', 'dart'), '--no-analytics', 'analyze'],
+      [_join(resolvedDartSdk, 'bin', 'dart'), '--no-analytics', 'doc'],
+      [
+        _join(resolvedFlutterSdk, 'bin', 'flutter'),
+        '--suppress-analytics',
+        '--no-version-check'
+      ],
+      [_join(flutterDartSdkDir, 'bin', 'dart'), '--no-analytics', 'analyze'],
+      [
+        _join(resolvedFutureDartSdk, 'bin', 'dart'),
+        '--no-analytics',
+        'analyze'
+      ],
+      [
+        _join(resolvedFutureFlutterDartSdkDir, 'bin', 'dart'),
+        '--no-analytics',
+        'analyze'
+      ],
       env,
       useGlobalDartdoc,
     );
@@ -429,7 +441,7 @@ class ToolEnvironment {
           stderr,
         );
       }
-
+      print(environment);
       final result = await runProc(
         [
           ...pubCmd,


### PR DESCRIPTION
Explicitly suppress analytics when invoking dart and flutter from pana.

This should already happen if pana is invoked with a ToolEnvironment with a 'CI=1' in the environment.

This PR also passes the surrounding environment into the subprocesses when bin/pana.dart is invoked.
