### PR TITLE
Detect more Apache and BSD licenses by skipping induced phrase check.

### DIFF
--- a/lib/src/license_detection/confidence.dart
+++ b/lib/src/license_detection/confidence.dart
@@ -280,8 +280,8 @@ const lesserGplChange = -2;
 final _inducedPhrases = {
   'AGPL': ['affero'],
   'Atmel': ['atmel'],
-  'Apache': ['apache'],
-  'BSD': ['bsd'],
+  // 'Apache': ['apache'],
+  // 'BSD': ['bsd'],
   'BSD-3-Clause-Attribution': ['acknowledgment'],
   'bzip2': ['seward'],
   'GPL-2.0-with-GCC-exception': ['gcc linking exception'],

--- a/test/license_confidence_test.dart
+++ b/test/license_confidence_test.dart
@@ -153,13 +153,13 @@ void _testVerifyNoGplChange(
 
 void testInducedPhraseChange() {
   group('Induced phrase change:', () {
-    test('Throws exception', () {
+    test('Apache license no longer throws', () {
       expect(
           () => verifyInducedPhraseChange('Apache', [
                 Diff(Operation.equal, 'some equal text'),
-                Diff(Operation.insert, 'apache')
+                Diff(Operation.insert, 'apache license')
               ]),
-          throwsA(isA<LicenseMismatchException>()));
+          returnsNormally);
     });
 
     test('Returns normally', () {

--- a/test/license_test.dart
+++ b/test/license_test.dart
@@ -46,7 +46,8 @@ void main() {
       await expectFile('test/licenses/bsd_2_clause.txt', ['BSD-2-Clause']);
       await expectFile(
           'test/licenses/bsd_2_clause_in_comments.txt', ['BSD-2-Clause']);
-      await expectFile('test/licenses/bsd_3_clause.txt', ['unknown']);
+      await expectFile(
+          'test/licenses/bsd_3_clause.txt', ['BSD-3-Clause-Clear']);
       await expectFile('test/licenses/bsd_revised.txt', ['BSD-3-Clause']);
     });
   });


### PR DESCRIPTION
Using #1184 to compare licenses on pub.dev, the following changes happened:

```
 36                    +Apache-2.0: about, about_custom, button_uz, dart_inject, dio_retry_plus, expandable_text_widget, ez_flutter_common, fcapi, flutter_2d_amap, flutter_file_preview, flutter_font_icons, flutter_mapbox, flutter_mapbox_nav, flutter_mapbox_navigation, flutter_vtmap_navigation, flutter_zoom, flutterfileselector, full_screen_image, full_screen_image_null_safe, hw_package_demo, hw_plugin_demo, ios_rotate_image, iwaju_utils, jazzicon, mkuna_bamantra, mwl_util_package, platform_svg, plugng, plus_dio_retry, scrollable_list, sigmob_plugin, simple_dart_api, wolfizutils, xfvoice, xfvoice2, ziggeo
     6            +BSD-3-Clause-Clear: bd_l10n, cli_goodies, db_navigator, db_test_coverage, utils_flutter, vcshooks
     1               +BSD-4-Clause-UC: sysexits
```

There are interesting misses: e.g. in `flutterfileselector`, which has a headline of BSD, but looks like Apache. However, most of the changes are correct, and overall, I think it is positive change. 