### PR TITLE
Use different user agent for url checks

### DIFF
--- a/lib/src/download_utils.dart
+++ b/lib/src/download_utils.dart
@@ -14,7 +14,6 @@ import 'package:safe_url_check/safe_url_check.dart';
 import 'package:tar/tar.dart';
 
 import 'logging.dart';
-import 'model.dart';
 
 /// Downloads [package] and unpacks it into [destination]
 Future<void> downloadPackage(

--- a/lib/src/download_utils.dart
+++ b/lib/src/download_utils.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:http/retry.dart' as http_retry;
+import 'package:pana/pana.dart';
 import 'package:path/path.dart' as p;
 import 'package:safe_url_check/safe_url_check.dart';
 import 'package:tar/tar.dart';
@@ -121,7 +122,10 @@ class UrlChecker {
   /// A cached [UrlChecker] implementation should override this method,
   /// wrap it in a cached callback, still invoking it via `super.checkUrlExists()`.
   Future<bool> checkUrlExists(Uri uri) async {
-    return await safeUrlCheck(uri);
+    return await safeUrlCheck(
+      uri,
+      userAgent: 'pana/$packageVersion (https://pub.dev/packages/pana)',
+    );
   }
 
   /// Check the status of the URL, using validity checks, cache and

--- a/lib/src/download_utils.dart
+++ b/lib/src/download_utils.dart
@@ -8,12 +8,13 @@ import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:http/retry.dart' as http_retry;
-import 'package:pana/pana.dart';
 import 'package:path/path.dart' as p;
 import 'package:safe_url_check/safe_url_check.dart';
 import 'package:tar/tar.dart';
 
 import 'logging.dart';
+import 'model.dart';
+import 'version.dart';
 
 /// Downloads [package] and unpacks it into [destination]
 Future<void> downloadPackage(
@@ -121,10 +122,8 @@ class UrlChecker {
   /// A cached [UrlChecker] implementation should override this method,
   /// wrap it in a cached callback, still invoking it via `super.checkUrlExists()`.
   Future<bool> checkUrlExists(Uri uri) async {
-    return await safeUrlCheck(
-      uri,
-      userAgent: 'pana/$packageVersion (https://pub.dev/packages/pana)',
-    );
+    return await safeUrlCheck(uri,
+        userAgent: 'pana/$packageVersion (https://pub.dev/packages/pana)');
   }
 
   /// Check the status of the URL, using validity checks, cache and


### PR DESCRIPTION
[buymeacoffee.com](https://www.buymeacoffee.com/) doesn't like when the user agent contains the substring "git".

They suggested that we change the user agent.

```
> curl --head https://www.buymeacoffee.com/ -A git
HTTP/2 403 
date: Fri, 06 Jan 2023 08:46:57 GMT
content-type: text/plain; charset=UTF-8
content-length: 16
x-frame-options: SAMEORIGIN
referrer-policy: same-origin
cache-control: private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
expires: Thu, 01 Jan 1970 00:00:01 GMT
report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=hi%2Bg06I0cyl3vHpArxLQkQqVb5aWHCT4h%2BGBptu9rrW1lVYsvMaEs1gdy0PHfaObpqiPVQ11GyPwwVNTwpWZw00gm0l0O1C4QvVnumMPYUzo9uAFC2%2BTxqyidRL5gaaoFzzxMNjw"}],"group":"cf-nel","max_age":604800}
nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
server: cloudflare
cf-ray: 78532fa6fa242a05-CDG
alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400

> curl --head https://www.buymeacoffee.com/ -A gi
HTTP/2 200 
date: Fri, 06 Jan 2023 08:47:05 GMT
content-type: text/html; charset=utf-8
access-control-allow-origin: https://buymeacoffee.com
x-page-speed: 1.13.35.2-0
cache-control: max-age=31536000
cf-cache-status: HIT
age: 24590
last-modified: Fri, 06 Jan 2023 01:57:15 GMT
report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=BRpC5dERevzPnyIZnOLN6o2ReVAoylmJ3P3ELsn4luz6NcDybU3sgJvEp6eVloUlgxlbITn9PA4HuqUT1ssbnEKcq1knDYUKWnvLZu%2FatE3nmwDivSvK5DD1zpQmKpa%2BgFPTa20K"}],"group":"cf-nel","max_age":604800}
nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
server: cloudflare
cf-ray: 78532fda0d082a0f-CDG
alt-svc: h3=":443"; ma=86400, h3-29=":443"; ma=86400
```
