### PR TITLE
Fix future-compatibility check: run pub get in a separate copy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.21.26
 
 - Upgrading CI for new SDKs and enabling `pubspec.yaml` for Dart 3.
+- Future SDK check is running on a copy, and resolves dependencies first.
 
 ## 0.21.25
 

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
@@ -139,7 +138,7 @@ class PackageAnalyzer {
     final sharedContext = _createSharedContext(options: options);
     return withTempDir((tempDir) async {
       final rootDir = await _detectGitRoot(packageDir) ?? packageDir;
-      await _copy(rootDir, tempDir);
+      await copyDir(rootDir, tempDir);
       final relativeDir = path.relative(packageDir, from: rootDir);
       return await _inspect(sharedContext, path.join(tempDir, relativeDir));
     });
@@ -334,23 +333,6 @@ Future<String?> _detectGitRoot(String packageDir) async {
     return pr.stdout.asString.trim();
   }
   return null;
-}
-
-Future<void> _copy(String from, String to) async {
-  await for (final fse in Directory(from).list(recursive: true)) {
-    if (fse is File) {
-      final relativePath = path.relative(fse.path, from: from);
-      final newFile = File(path.join(to, relativePath));
-      await newFile.parent.create(recursive: true);
-      await fse.copy(newFile.path);
-    } else if (fse is Link) {
-      final relativePath = path.relative(fse.path, from: from);
-      final linkTarget = await fse.target();
-      final newLink = Link(path.join(to, relativePath));
-      await newLink.parent.create(recursive: true);
-      await newLink.create(linkTarget);
-    }
-  }
 }
 
 Future<AnalysisResult> _createAnalysisResult(PackageContext context) async {

--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -3,9 +3,11 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:collection/collection.dart';
 import 'package:pana/src/tag/license_tags.dart';
+import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 
 import 'code_problem.dart';
@@ -22,7 +24,7 @@ import 'references/pubspec_urls.dart';
 import 'repository/check_repository.dart';
 import 'screenshots.dart';
 import 'sdk_env.dart';
-import 'utils.dart' show listFocusDirs;
+import 'utils.dart' show copyDir, listFocusDirs, withTempDir;
 
 /// Shared (intermediate) results between different packages or versions.
 /// External systems that may be independent of the archive content may be
@@ -170,7 +172,7 @@ class PackageContext {
     if (_codeProblems != null) return _codeProblems!;
     try {
       log.info('Analyzing package...');
-      _codeProblems = await _staticAnalysis();
+      _codeProblems = await _staticAnalysis(packageDir: packageDir);
       return _codeProblems!;
     } on ToolException catch (e) {
       errors.add(messages.runningDartanalyzerFailed(usesFlutter, e.message));
@@ -179,6 +181,7 @@ class PackageContext {
   }
 
   Future<List<CodeProblem>> _staticAnalysis({
+    required String packageDir,
     bool useFutureSdk = false,
   }) async {
     final dirs = await listFocusDirs(packageDir);
@@ -204,13 +207,38 @@ class PackageContext {
 
   /// True if the configured future SDK analyzed the package without any error.
   late final isCompatibleWithFutureSdk = () async {
-    try {
-      log.info('Analyzing package with future SDK...');
-      final problems = await _staticAnalysis(useFutureSdk: true);
-      return !problems.any((e) => e.isError);
-    } on ToolException catch (_) {
-      return false;
-    }
+    return await withTempDir((tempPackageDir) async {
+      try {
+        log.info('Prepare package for future SDK compatibility check.');
+        // Copy package to temp directory and delete the .dart_tool directory inside it.
+        await copyDir(packageDir, tempPackageDir);
+        final tempDartToolDir = Directory(p.join(tempPackageDir, '.dart_tool'));
+        if (await tempDartToolDir.exists()) {
+          await tempDartToolDir.delete(recursive: true);
+        }
+
+        log.info('Resolve dependencies with future SDK...');
+        final pr = await toolEnvironment.runUpgrade(
+          tempPackageDir,
+          usesFlutter,
+          useFutureSdk: true,
+          retryCount: 1,
+        );
+        print(pr.asJoinedOutput);
+        if (pr.wasError) {
+          return false;
+        }
+
+        log.info('Analyzing package with future SDK...');
+        final problems = await _staticAnalysis(
+          packageDir: tempPackageDir,
+          useFutureSdk: true,
+        );
+        return !problems.any((e) => e.isError);
+      } on ToolException catch (_) {
+        return false;
+      }
+    });
   }();
 
   late final Future<Outdated> outdated = toolEnvironment.runPubOutdated(

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -239,6 +239,23 @@ Future<T> withTempDir<T>(FutureOr<T> Function(String path) fn) async {
   }
 }
 
+Future<void> copyDir(String from, String to) async {
+  await for (final fse in Directory(from).list(recursive: true)) {
+    if (fse is File) {
+      final relativePath = p.relative(fse.path, from: from);
+      final newFile = File(p.join(to, relativePath));
+      await newFile.parent.create(recursive: true);
+      await fse.copy(newFile.path);
+    } else if (fse is Link) {
+      final relativePath = p.relative(fse.path, from: from);
+      final linkTarget = await fse.target();
+      final newLink = Link(p.join(to, relativePath));
+      await newLink.parent.create(recursive: true);
+      await newLink.create(linkTarget);
+    }
+  }
+}
+
 Future<String> getVersionListing(String package, {Uri? pubHostedUrl}) async {
   final url = (pubHostedUrl ?? Uri.parse('https://pub.dartlang.org'))
       .resolve('/api/packages/$package');

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.21.26-dev';
+const packageVersion = '0.21.26';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.21.26-dev
+version: 0.21.26
 repository: https://github.com/dart-lang/pana
 
 environment:


### PR DESCRIPTION
- Updated `ToolEnvironment` to also have `pub upgrade` support with future SDK (note: these become a bit more complex than we've initially planned for, a refactor is due)
-  Updated the compatibility check: copies the package into a temp directory, deletes `.dart_tool`, runs `pub upgrade` before running the analysis.