### PR TITLE
Make example-detection work on case-preserving file systems

### DIFF
--- a/lib/src/report/documentation.dart
+++ b/lib/src/report/documentation.dart
@@ -21,8 +21,13 @@ Future<ReportSection> hasDocumentation(
   // TODO: run dartdoc for coverage
 
   final candidates = exampleFileCandidates(pubspec.name);
-  final examplePath = candidates
-      .firstWhereOrNull((c) => File(p.join(packageDir, c)).existsSync());
+  // Because we care about the file-names case, we first list all files, and
+  // then test for presence of candidates in that list.
+  //
+  // This should work on case-preserving but insensitive file-systems.
+  final files = Directory(packageDir).listSync(recursive: true).map(
+      (e) => p.posix.joinAll(p.split(p.relative(e.path, from: packageDir))));
+  final examplePath = candidates.firstWhereOrNull(files.contains);
   final issues = <Issue>[
     if (examplePath == null)
       Issue(

--- a/test/screenshot_test.dart
+++ b/test/screenshot_test.dart
@@ -236,7 +236,7 @@ void main() {
     final descriptor =
         package('my_package', pubspecExtras: pubspecExtras, extraFiles: [
       d.dir('example', [
-        d.file('EXAMPLE.md', 'Example'),
+        d.file('example.md', 'Example'),
       ]),
       d.file('static.webp',
           File(p.join(_testImagesDir, 'static.webp')).readAsBytesSync())


### PR DESCRIPTION
This makes the build green again.

We should probably list all the files once, and do the same for all our file checks (readme, changelog...)