### PR TITLE
Code cleanup in ToolEnvironment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.21.31
 
 - Dart 3 compatibility section label includes Flutter 3.10 when applicable.
+- Code cleanup in `ToolEnvironment`.
 
 ## 0.21.30
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.21.31-dev';
+const packageVersion = '0.21.31';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.21.31-dev
+version: 0.21.31
 repository: https://github.com/dart-lang/pana
 
 environment:


### PR DESCRIPTION
`_futureFlutterSdkDir` is redundant and could have been misused, better to use one of the `_FlutterSdk`s.