### PR TITLE
Resolve lints/core.yaml if available locally, deprecate inspect option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.21.33
 
 - Upgraded to Dart 3.0.
+- Resolve `package:lints/core.yaml` locally before loading from GitHub.
+- `InspectOptions.analysisOptionsYaml` is now deprecated.
 
 **Breaking changes**:
 - `PanaProcessResult` no longer implements `dart:io`'s `ProcessResult`.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,6 +6,7 @@ analyzer:
     unused_import: error
     unused_local_variable: error
     dead_code: error
+    deprecated_member_use_from_same_package: ignore
 
 linter:
   rules:

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -33,6 +33,7 @@ class InspectOptions {
   final int? lineLength;
 
   /// The analysis options (in yaml format) to use for the analysis.
+  @Deprecated('Do not use, will be removed.')
   final String? analysisOptionsYaml;
 
   /// Whether pana should also access the remote repository specified in pubspec.yaml.


### PR DESCRIPTION
- #1229
- `pub.dev` provides the file content via `InspectOption`, which is looked up the same way as done here.
- maybe we can also add a hardcoded content as a fallback instead of the GitHub fetch (and verify it is up-to-date via test)