### PR TITLE
Do not block repository check when `pubspec.yaml` is in path that is not accepted.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.21.33
 
+- Do not block repository check when `pubspec.yaml` is in path that is not accepted.
 - Upgraded to Dart 3.0.
 
 **Breaking changes**:

--- a/lib/src/repository/check_repository.dart
+++ b/lib/src/repository/check_repository.dart
@@ -95,7 +95,7 @@ Future<VerifiedRepository?> checkRepository({
             path,
             maxOutputBytes: _maxPubspecBytes,
           );
-        } on ArgumentError catch (e) {
+        } on GitToolException catch (e) {
           log.info('Unable to read "$path".', e);
           return _PubspecMatch(path, false, 'Unable to read `$path`: $e.');
         }

--- a/lib/src/repository/check_repository.dart
+++ b/lib/src/repository/check_repository.dart
@@ -87,12 +87,18 @@ Future<VerifiedRepository?> checkRepository({
       }
 
       Future<_PubspecMatch> matchRepoPubspecYaml(String path) async {
+        late String content;
         // checkout the pubspec.yaml at the assumed location
-        final content = await repo.showStringContent(
-          branch!,
-          path,
-          maxOutputBytes: _maxPubspecBytes,
-        );
+        try {
+          content = await repo.showStringContent(
+            branch!,
+            path,
+            maxOutputBytes: _maxPubspecBytes,
+          );
+        } on ArgumentError catch (e) {
+          log.info('Unable to read "$path".', e);
+          return _PubspecMatch(path, false, 'Unable to read `$path`: $e.');
+        }
         if (content.trim().isEmpty) {
           return _PubspecMatch(
               path, false, '`$path` from the repository is empty.');

--- a/lib/src/repository/git_local_repository.dart
+++ b/lib/src/repository/git_local_repository.dart
@@ -214,17 +214,17 @@ class GitLocalRepository {
 
   void _assertBranchFormat(String branch) {
     if (_acceptedBranchNameRegExp.matchAsPrefix(branch) == null) {
-      throw ArgumentError('Branch name "$branch" is not accepted.');
+      throw GitToolException.argument('Branch name "$branch" is not accepted.');
     }
   }
 
   void _assertPathFormat(String path) {
     if (p.normalize(path) != path) {
-      throw ArgumentError('Path "$path" is not normalized.');
+      throw GitToolException.argument('Path "$path" is not normalized.');
     }
     if (p.split(path).any((segment) =>
         _acceptedPathSegmentsRegExp.matchAsPrefix(segment) == null)) {
-      throw ArgumentError('Path "$path" is not accepted.');
+      throw GitToolException.argument('Path "$path" is not accepted.');
     }
   }
 }
@@ -237,6 +237,8 @@ class GitToolException implements Exception {
 
   factory GitToolException.failedToRun(String command, PanaProcessResult pr) =>
       GitToolException('Failed to run `$command`.', pr.asJoinedOutput);
+
+  GitToolException.argument(this.message) : output = null;
 
   @override
   String toString() => [message, output].whereType<String>().join('\n');

--- a/test/repository/git_local_repository_test.dart
+++ b/test/repository/git_local_repository_test.dart
@@ -54,7 +54,7 @@ void main() {
 
       test('not expected branch format', () async {
         await expectLater(
-            () => fn('not//accepted'), throwsA(isA<ArgumentError>()));
+            () => fn('not//accepted'), throwsA(isA<GitToolException>()));
       });
     }
 


### PR DESCRIPTION
- This is one option to fix #1200, by allowing it to continue when the path is not accepted.
- (Please review the alternative too: #1233 .)