### PR TITLE
Allow more characters in repository path segments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.21.33
 
+- Allow more characters in repository path segments.
 - Upgraded to Dart 3.0.
 
 **Breaking changes**:

--- a/lib/src/repository/git_local_repository.dart
+++ b/lib/src/repository/git_local_repository.dart
@@ -11,7 +11,7 @@ import '../utils.dart' show runProc, PanaProcessResult;
 
 final _acceptedBranchNameRegExp = RegExp(r'^[a-z0-9]+$');
 final _acceptedPathSegmentsRegExp =
-    RegExp(r'^[a-z0-9_\-\.]+$', caseSensitive: false);
+    RegExp(r'^[a-z0-9_\-\.\{\}\(\)]+$', caseSensitive: false);
 
 /// The value to indicate we are fetching the branch without depth restriction.
 const unlimitedFetchDepth = 0;


### PR DESCRIPTION
- This is one option to fix #1200, by allowing more characters to be part of the path segments.
- (Please review the alternative too: #1232.)