### PR TITLE
Always use dart format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.21.36
+- Always use `dart format`
+
 ## 0.21.35
 
 - Merge Dart 3 compatibility report into static analysis.

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -231,7 +231,7 @@ class ToolEnvironment {
 
       final result = await runProc(
         [
-          ...usesFlutter ? _flutterSdk.flutterCmd : _dartSdk.dartCmd,
+          ..._dartSdk.dartCmd,
           ...params,
         ],
         environment: environment,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.21.35
+version: 0.21.36
 repository: https://github.com/dart-lang/pana
 topics:
   - tool


### PR DESCRIPTION
The `flutter format` command was deprecated some time ago, and removed in Flutter 3.13.0
This PR replaces the `flutter format` call with `dart format`

- #1245

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
