### PR TITLE
Fix: static analysis is done only when the package resolution was successful.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.21.38
 
 - Added `dart:ui_web` as Flutter Web platform.
+- Fix: static analysis is done only when the package resolution was successful.
 
 ## 0.21.37
 

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -251,6 +251,8 @@ class PackageAnalyzer {
       } else {
         tags.add(PanaTags.hasError);
       }
+    } else {
+      tags.add(PanaTags.hasError);
     }
 
     final licenses = await context.licenses;

--- a/lib/src/report/static_analysis.dart
+++ b/lib/src/report/static_analysis.dart
@@ -89,6 +89,15 @@ Future<_AnalysisResult> _analyzePackage(PackageContext context) async {
   final dirs = await listFocusDirs(context.packageDir);
 
   try {
+    final resolveErrorMessage = await context.resolveErrorMessage;
+    if (resolveErrorMessage != null) {
+      return _AnalysisResult(
+        [Issue(resolveErrorMessage)],
+        [],
+        [],
+        context.usesFlutter ? 'flutter pub get' : 'dart pub get',
+      );
+    }
     final list = await context.staticAnalysis();
 
     return _AnalysisResult(

--- a/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
+++ b/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
@@ -28,6 +28,7 @@
   ],
   "allDependencies": [],
   "tags": [
+    "has:error",
     "license:bsd-3-clause",
     "license:fsf-libre",
     "license:osi-approved"
@@ -61,10 +62,10 @@
       {
         "id": "analysis",
         "title": "Pass static analysis",
-        "grantedPoints": 50,
+        "grantedPoints": 0,
         "maxPoints": 50,
-        "status": "passed",
-        "summary": "### [*] 50/50 points: code has no errors, warnings, lints, or formatting issues\n"
+        "status": "failed",
+        "summary": "### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues\n\n* Running `dart pub outdated` failed with the following output:\n\n```\nThe current Dart SDK version is {{sdk-version}}.\nBecause _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.\n```\n"
       },
       {
         "id": "dependency",
@@ -79,7 +80,7 @@
   "screenshots": [],
   "result": {
     "homepageUrl": "https://github.com/dart-lang/pub-dev",
-    "grantedPoints": 65,
+    "grantedPoints": 15,
     "maxPoints": 130
   },
   "urlProblems": [],

--- a/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json_report.md
+++ b/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json_report.md
@@ -81,9 +81,16 @@ Could not determine supported platforms as package resolution failed.
 Run `dart pub get` for more information.
 </details>
 
-## 50/50 Pass static analysis
+## 0/50 Pass static analysis
 
-### [*] 50/50 points: code has no errors, warnings, lints, or formatting issues
+### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues
+
+* Running `dart pub outdated` failed with the following output:
+
+```
+The current Dart SDK version is {{sdk-version}}.
+Because _dummy_pkg requires SDK version >=2.12.0-0 <2.12.0, version solving failed.
+```
 
 
 ## 0/20 Support up-to-date dependencies

--- a/test/goldens/end2end/bulma_min-0.7.4.json
+++ b/test/goldens/end2end/bulma_min-0.7.4.json
@@ -29,6 +29,7 @@
   ],
   "allDependencies": [],
   "tags": [
+    "has:error",
     "license:mit",
     "license:fsf-libre",
     "license:osi-approved"
@@ -62,10 +63,10 @@
       {
         "id": "analysis",
         "title": "Pass static analysis",
-        "grantedPoints": 50,
+        "grantedPoints": 0,
         "maxPoints": 50,
-        "status": "passed",
-        "summary": "### [*] 50/50 points: code has no errors, warnings, lints, or formatting issues\n"
+        "status": "failed",
+        "summary": "### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues\n\n* Running `dart pub outdated` failed with the following output:\n\n```\nThe lower bound of \"sdk: '>=1.0.0 <3.0.0'\" must be 2.12.0'\nor higher to enable null safety.\n```\n"
       },
       {
         "id": "dependency",
@@ -87,7 +88,7 @@
       "repository": "agilord/bulma_min",
       "branch": "master"
     },
-    "grantedPoints": 80,
+    "grantedPoints": 30,
     "maxPoints": 130
   },
   "urlProblems": [],

--- a/test/goldens/end2end/bulma_min-0.7.4.json_report.md
+++ b/test/goldens/end2end/bulma_min-0.7.4.json_report.md
@@ -37,9 +37,16 @@ Could not determine supported platforms as package resolution failed.
 Run `dart pub get` for more information.
 </details>
 
-## 50/50 Pass static analysis
+## 0/50 Pass static analysis
 
-### [*] 50/50 points: code has no errors, warnings, lints, or formatting issues
+### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues
+
+* Running `dart pub outdated` failed with the following output:
+
+```
+The lower bound of "sdk: '>=1.0.0 <3.0.0'" must be 2.12.0'
+or higher to enable null safety.
+```
 
 
 ## 0/20 Support up-to-date dependencies

--- a/test/goldens/end2end/mime_type-0.3.2.json
+++ b/test/goldens/end2end/mime_type-0.3.2.json
@@ -24,6 +24,7 @@
   "licenses": [],
   "allDependencies": [],
   "tags": [
+    "has:error",
     "license:unknown"
   ],
   "report": {
@@ -58,7 +59,7 @@
         "grantedPoints": 0,
         "maxPoints": 50,
         "status": "failed",
-        "summary": "### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues\n\nFound 6 issues. Showing the first 2:\n\n<details>\n<summary>\nERROR: A value of type 'Null' can't be returned from the function 'mime' because it has a return type of 'String'.\n</summary>\n\n`lib/mime_type.dart:8:12`\n\n```\n  ╷\n8 │     return null;\n  │            ^^^^\n  ╵\n```\n\nTo reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/mime_type.dart`\n</details>\n<details>\n<summary>\nERROR: A value of type 'String?' can't be returned from the function 'mime' because it has a return type of 'String'.\n</summary>\n\n`lib/mime_type.dart:14:12`\n\n```\n   ╷\n14 │     return _mimeMaps[extension.toLowerCase()];\n   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n   ╵\n```\n\nTo reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/mime_type.dart`\n</details>"
+        "summary": "### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues\n\n* Running `dart pub outdated` failed with the following output:\n\n```\nThe lower bound of \"sdk: '>=0.8.10 <3.0.0'\" must be 2.12.0'\nor higher to enable null safety.\n```\n"
       },
       {
         "id": "dependency",

--- a/test/goldens/end2end/mime_type-0.3.2.json_report.md
+++ b/test/goldens/end2end/mime_type-0.3.2.json_report.md
@@ -70,40 +70,13 @@ Run `dart pub get` for more information.
 
 ### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues
 
-Found 6 issues. Showing the first 2:
-
-<details>
-<summary>
-ERROR: A value of type 'Null' can't be returned from the function 'mime' because it has a return type of 'String'.
-</summary>
-
-`lib/mime_type.dart:8:12`
+* Running `dart pub outdated` failed with the following output:
 
 ```
-  ╷
-8 │     return null;
-  │            ^^^^
-  ╵
+The lower bound of "sdk: '>=0.8.10 <3.0.0'" must be 2.12.0'
+or higher to enable null safety.
 ```
 
-To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/mime_type.dart`
-</details>
-<details>
-<summary>
-ERROR: A value of type 'String?' can't be returned from the function 'mime' because it has a return type of 'String'.
-</summary>
-
-`lib/mime_type.dart:14:12`
-
-```
-   ╷
-14 │     return _mimeMaps[extension.toLowerCase()];
-   │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   ╵
-```
-
-To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/mime_type.dart`
-</details>
 
 ## 0/20 Support up-to-date dependencies
 

--- a/test/goldens/end2end/sdp_transform-0.2.0.json
+++ b/test/goldens/end2end/sdp_transform-0.2.0.json
@@ -38,6 +38,7 @@
     "test"
   ],
   "tags": [
+    "has:error",
     "license:mit",
     "license:fsf-libre",
     "license:osi-approved"
@@ -74,7 +75,7 @@
         "grantedPoints": 0,
         "maxPoints": 50,
         "status": "failed",
-        "summary": "### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues\n\nFound 10 issues. Showing the first 2:\n\n<details>\n<summary>\nERROR: The class 'List' doesn't have an unnamed constructor.\n</summary>\n\n`lib/src/parser.dart:100:33`\n\n```\n    ╷\n100 │           location['invalid'] = List();\n    │                                 ^^^^\n    ╵\n```\n\nTo reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/src/parser.dart`\n</details>\n<details>\n<summary>\nERROR: The constructor returns type 'List<dynamic>' that isn't of expected type 'List<String>'.\n</summary>\n\n`lib/src/parser.dart:140:24`\n\n```\n    ╷\n140 │   List<String> parts = List();\n    │                        ^^^^^^\n    ╵\n```\n\nTo reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/src/parser.dart`\n</details>"
+        "summary": "### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues\n\n* Running `dart pub outdated` failed with the following output:\n\n```\nThe lower bound of \"sdk: '>=1.0.0 <3.0.0'\" must be 2.12.0'\nor higher to enable null safety.\n```\n"
       },
       {
         "id": "dependency",

--- a/test/goldens/end2end/sdp_transform-0.2.0.json_report.md
+++ b/test/goldens/end2end/sdp_transform-0.2.0.json_report.md
@@ -47,40 +47,13 @@ See [package layout](https://dart.dev/tools/pub/package-layout#examples) guideli
 
 ### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues
 
-Found 10 issues. Showing the first 2:
-
-<details>
-<summary>
-ERROR: The class 'List' doesn't have an unnamed constructor.
-</summary>
-
-`lib/src/parser.dart:100:33`
+* Running `dart pub outdated` failed with the following output:
 
 ```
-    ╷
-100 │           location['invalid'] = List();
-    │                                 ^^^^
-    ╵
+The lower bound of "sdk: '>=1.0.0 <3.0.0'" must be 2.12.0'
+or higher to enable null safety.
 ```
 
-To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/src/parser.dart`
-</details>
-<details>
-<summary>
-ERROR: The constructor returns type 'List<dynamic>' that isn't of expected type 'List<String>'.
-</summary>
-
-`lib/src/parser.dart:140:24`
-
-```
-    ╷
-140 │   List<String> parts = List();
-    │                        ^^^^^^
-    ╵
-```
-
-To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/src/parser.dart`
-</details>
 
 ## 0/20 Support up-to-date dependencies
 

--- a/test/goldens/end2end/skiplist-0.1.0.json
+++ b/test/goldens/end2end/skiplist-0.1.0.json
@@ -35,6 +35,7 @@
     "test"
   ],
   "tags": [
+    "has:error",
     "license:mit",
     "license:fsf-libre",
     "license:osi-approved"
@@ -71,7 +72,7 @@
         "grantedPoints": 0,
         "maxPoints": 50,
         "status": "failed",
-        "summary": "### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues\n\nFound 37 issues. Showing the first 2:\n\n<details>\n<summary>\nERROR: Target of URI doesn't exist: 'package:quiver_iterables/iterables.dart'.\n</summary>\n\n`lib/skiplist.dart:12:8`\n\n```\n   ╷\n12 │ import \"package:quiver_iterables/iterables.dart\" as iterables;\n   │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n   ╵\n```\n\nTo reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/skiplist.dart`\n</details>\n<details>\n<summary>\nERROR: Non-nullable instance field '_header' must be initialized.\n</summary>\n\n`lib/skiplist.dart:48:3`\n\n```\n   ╷\n48 │   SkipList({double this.p: 1 / 4, int this.maxLevel: 8}) {\n   │   ^^^^^^^^\n   ╵\n```\n\nTo reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/skiplist.dart`\n</details>"
+        "summary": "### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues\n\n* Running `dart pub outdated` failed with the following output:\n\n```\nThe lower bound of \"sdk: '>=1.0.0 <=3.1.0'\" must be 2.12.0'\nor higher to enable null safety.\n```\n"
       },
       {
         "id": "dependency",

--- a/test/goldens/end2end/skiplist-0.1.0.json_report.md
+++ b/test/goldens/end2end/skiplist-0.1.0.json_report.md
@@ -48,40 +48,13 @@ Run `dart pub get` for more information.
 
 ### [x] 0/50 points: code has no errors, warnings, lints, or formatting issues
 
-Found 37 issues. Showing the first 2:
-
-<details>
-<summary>
-ERROR: Target of URI doesn't exist: 'package:quiver_iterables/iterables.dart'.
-</summary>
-
-`lib/skiplist.dart:12:8`
+* Running `dart pub outdated` failed with the following output:
 
 ```
-   ╷
-12 │ import "package:quiver_iterables/iterables.dart" as iterables;
-   │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   ╵
+The lower bound of "sdk: '>=1.0.0 <=3.1.0'" must be 2.12.0'
+or higher to enable null safety.
 ```
 
-To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/skiplist.dart`
-</details>
-<details>
-<summary>
-ERROR: Non-nullable instance field '_header' must be initialized.
-</summary>
-
-`lib/skiplist.dart:48:3`
-
-```
-   ╷
-48 │   SkipList({double this.p: 1 / 4, int this.maxLevel: 8}) {
-   │   ^^^^^^^^
-   ╵
-```
-
-To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/skiplist.dart`
-</details>
 
 ## 0/20 Support up-to-date dependencies
 


### PR DESCRIPTION
Fixes issues like the following score page:
<img width="603" alt="image" src="https://github.com/dart-lang/pana/assets/4778111/a22866e6-a77c-40c2-8e3c-7db5f91de3c7">
