### PR TITLE
Fix: force global dartdoc activation from pub.dev.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.21.42
+
+- Fix: global `dartdoc` activation is forced to happen from `pub.dev`.
+
 ## 0.21.41
 
 - Pana binary now runs `dartdoc` and generates report based on the coverage

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -471,7 +471,10 @@ class ToolEnvironment {
             'dartdoc',
             if (_globalDartdocVersion != null) _globalDartdocVersion!,
           ],
-          environment: _environment,
+          environment: {
+            ..._environment,
+            'PUB_HOSTED_URL': 'https://pub.dev',
+          },
         ));
         _globalDartdocActivated = true;
       }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.21.41';
+const packageVersion = '0.21.42';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.21.41
+version: 0.21.42
 repository: https://github.com/dart-lang/pana
 topics:
   - tool


### PR DESCRIPTION
This effects local development on `pub.dev`, and also when running pana against dependencies on a private package repository. Without this change these services would need to pass-through proxy `package:dartdoc` and its dependencies, or otherwise `pana` should allow pre-activation of the global scope.

I think it is better to force this activation from `pub.dev` for now, and if needed we can add option to override it - if the need for that is present.