### PR TITLE
Limit the number of exported documentation entries on pub-data.json.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.21.43
+
+- Fix: limit number of documentation entries exported in `pub-data.json`.
+
 ## 0.21.42
 
 - Fix: global `dartdoc` activation is forced to happen from `pub.dev`.

--- a/lib/src/dartdoc/index_to_pubdata.dart
+++ b/lib/src/dartdoc/index_to_pubdata.dart
@@ -36,9 +36,19 @@ PubDartdocData dataFromDartdocIndex(DartdocIndex index) {
       documentation: (e.desc == null || e.desc!.isEmpty) ? null : e.desc,
     ));
   }
+
+  final documented = apiElements.where((e) => e.documentation != null).length;
+  if (documented > 1000) {
+    // Too much content, removing the documentation from everything except
+    // libraries and classes.
+    apiElements
+        .where((e) => e.kind != 'library' && e.kind != 'class')
+        .forEach((e) => e.documentation = null);
+  }
+
   return PubDartdocData(
     coverage: Coverage(
-      documented: apiElements.where((e) => e.documentation != null).length,
+      documented: documented,
       total: apiElements.length,
     ),
     apiElements: apiElements,

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.21.42';
+const packageVersion = '0.21.43-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.21.42
+version: 0.21.43-dev
 repository: https://github.com/dart-lang/pana
 topics:
   - tool


### PR DESCRIPTION
Copy of the code from https://github.com/dart-lang/pub-dev/blob/master/pkg/pub_dartdoc/lib/pub_data_generator.dart#L91-L97