### PR TITLE
Pre-compute missing documentation symbol before pruning the results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix: limit number of documentation entries exported in `pub-data.json`.
 - Fix: Add `dart:js_interop_unsafe` as a web library.
+- Pre-compute missing documentation symbol before pruning the results.
 
 ## 0.21.42
 

--- a/lib/src/dartdoc/dartdoc.dart
+++ b/lib/src/dartdoc/dartdoc.dart
@@ -41,10 +41,8 @@ Future<Subsection> createDocumentationCoverageSection(
     PubDartdocData data) async {
   final documented = data.coverage?.documented ?? 0;
   final total = data.coverage?.total ?? 0;
-  final symbolsMissingDocumentation = data.apiElements
-      ?.where((e) => e.documentation == null || e.documentation!.isEmpty)
-      .map((e) => e.name)
-      .toList();
+  final symbolsMissingDocumentation =
+      data.coverage?.symbolsMissingDocumentation;
 
   final maxPoints = 10;
   final ratio = total <= 0 ? 1.0 : documented / total;

--- a/lib/src/dartdoc/index_to_pubdata.dart
+++ b/lib/src/dartdoc/index_to_pubdata.dart
@@ -38,6 +38,12 @@ PubDartdocData dataFromDartdocIndex(DartdocIndex index) {
   }
 
   final documented = apiElements.where((e) => e.documentation != null).length;
+  final symbolsMissingDocumentation = apiElements
+      .where((e) => e.documentation == null)
+      .map((e) => e.name)
+      .take(5)
+      .toList();
+
   if (documented > 1000) {
     // Too much content, removing the documentation from everything except
     // libraries and classes.
@@ -50,6 +56,7 @@ PubDartdocData dataFromDartdocIndex(DartdocIndex index) {
     coverage: Coverage(
       documented: documented,
       total: apiElements.length,
+      symbolsMissingDocumentation: symbolsMissingDocumentation,
     ),
     apiElements: apiElements,
   );

--- a/lib/src/dartdoc/pub_dartdoc_data.dart
+++ b/lib/src/dartdoc/pub_dartdoc_data.dart
@@ -64,9 +64,15 @@ class Coverage {
   /// The number of API elements with accepted documentation.
   final int documented;
 
+  /// Some of the API symbols that are without accepted documentation.
+  ///
+  /// To limit the output size, we only store the a subset of the missing symbols.
+  final List<String>? symbolsMissingDocumentation;
+
   Coverage({
     required this.total,
     required this.documented,
+    required this.symbolsMissingDocumentation,
   });
 
   factory Coverage.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/dartdoc/pub_dartdoc_data.dart
+++ b/lib/src/dartdoc/pub_dartdoc_data.dart
@@ -66,7 +66,7 @@ class Coverage {
 
   /// Some of the API symbols that are without accepted documentation.
   ///
-  /// To limit the output size, we only store the a subset of the missing symbols.
+  /// To limit the output size, we only store a subset of the missing symbols.
   final List<String>? symbolsMissingDocumentation;
 
   Coverage({

--- a/lib/src/dartdoc/pub_dartdoc_data.g.dart
+++ b/lib/src/dartdoc/pub_dartdoc_data.g.dart
@@ -64,9 +64,25 @@ Map<String, dynamic> _$ApiElementToJson(ApiElement instance) {
 Coverage _$CoverageFromJson(Map<String, dynamic> json) => Coverage(
       total: json['total'] as int,
       documented: json['documented'] as int,
+      symbolsMissingDocumentation:
+          (json['symbolsMissingDocumentation'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList(),
     );
 
-Map<String, dynamic> _$CoverageToJson(Coverage instance) => <String, dynamic>{
-      'total': instance.total,
-      'documented': instance.documented,
-    };
+Map<String, dynamic> _$CoverageToJson(Coverage instance) {
+  final val = <String, dynamic>{
+    'total': instance.total,
+    'documented': instance.documented,
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull(
+      'symbolsMissingDocumentation', instance.symbolsMissingDocumentation);
+  return val;
+}


### PR DESCRIPTION
- Fixes the edge case of #1282, where a large but overall under-documented package removes some documentation which may be reported as missing.
- It also enables the separation of entries data (part of a long-term refactoring of pub-data.json to better fit the indexing). 