### PR TITLE
Add js_interop_unsafe as a web library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.21.43
 
 - Fix: limit number of documentation entries exported in `pub-data.json`.
+- Fix: Add `dart:js_interop_unsafe` as a web library.
 
 ## 0.21.42
 

--- a/lib/src/tag/_specs.dart
+++ b/lib/src/tag/_specs.dart
@@ -38,6 +38,7 @@ class Runtime {
     'indexed_db',
     'js',
     'js_interop',
+    'js_interop_unsafe',
     'js_util',
     'svg',
     'web_audio',


### PR DESCRIPTION
Fixes https://github.com/dart-lang/pana/issues/1285

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
