### PR TITLE
Don't report hidden constructors as undocumented API symbols.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.21.45
+
+- Fix: don't report hidden constructors as undocumented API symbols.
+
 ## 0.21.44
 
 - Fix: `dart:ui_web` is now part of the SDK-detection library list.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.21.44';
+const packageVersion = '0.21.45';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.21.44
+version: 0.21.45
 repository: https://github.com/dart-lang/pana
 topics:
   - tool

--- a/test/goldens/end2end/async-2.11.0.json
+++ b/test/goldens/end2end/async-2.11.0.json
@@ -78,7 +78,7 @@
         "grantedPoints": 10,
         "maxPoints": 20,
         "status": "failed",
-        "summary": "### [*] 10/10 points: 20% or more of the public API has dartdoc comments\n\n246 out of 263 API elements (93.5 %) have documentation comments.\n\nSome symbols that are missing documentation: `AsyncMemoizer`, `ChunkedStreamReader`, `DelegatingFuture`, `DelegatingStream`, `ErrorResult`.\n\n### [x] 0/10 points: Package has an example\n\n<details>\n<summary>\nNo example found.\n</summary>\n\nSee [package layout](https://dart.dev/tools/pub/package-layout#examples) guidelines on how to add an example.\n</details>"
+        "summary": "### [*] 10/10 points: 20% or more of the public API has dartdoc comments\n\n246 out of 246 API elements (100.0 %) have documentation comments.\n\n### [x] 0/10 points: Package has an example\n\n<details>\n<summary>\nNo example found.\n</summary>\n\nSee [package layout](https://dart.dev/tools/pub/package-layout#examples) guidelines on how to add an example.\n</details>"
       },
       {
         "id": "platform",

--- a/test/goldens/end2end/async-2.11.0.json_report.md
+++ b/test/goldens/end2end/async-2.11.0.json_report.md
@@ -17,9 +17,7 @@ Detected license: `BSD-3-Clause`.
 
 ### [*] 10/10 points: 20% or more of the public API has dartdoc comments
 
-246 out of 263 API elements (93.5 %) have documentation comments.
-
-Some symbols that are missing documentation: `AsyncMemoizer`, `ChunkedStreamReader`, `DelegatingFuture`, `DelegatingStream`, `ErrorResult`.
+246 out of 246 API elements (100.0 %) have documentation comments.
 
 ### [x] 0/10 points: Package has an example
 

--- a/test/goldens/end2end/dnd-2.0.1.json
+++ b/test/goldens/end2end/dnd-2.0.1.json
@@ -63,7 +63,7 @@
         "grantedPoints": 20,
         "maxPoints": 20,
         "status": "passed",
-        "summary": "### [*] 10/10 points: 20% or more of the public API has dartdoc comments\n\n70 out of 77 API elements (90.9 %) have documentation comments.\n\nSome symbols that are missing documentation: `dnd`, `Acceptor`, `AnimationHelper`, `CloneAvatarHandler`, `DraggablesAcceptor`.\n\n### [*] 10/10 points: Package has an example\n"
+        "summary": "### [*] 10/10 points: 20% or more of the public API has dartdoc comments\n\n70 out of 72 API elements (97.2 %) have documentation comments.\n\nSome symbols that are missing documentation: `dnd`, `dnd.DraggablesAcceptor.draggableIds`.\n\n### [*] 10/10 points: Package has an example\n"
       },
       {
         "id": "platform",

--- a/test/goldens/end2end/dnd-2.0.1.json_report.md
+++ b/test/goldens/end2end/dnd-2.0.1.json_report.md
@@ -17,9 +17,9 @@ Detected license: `MIT`.
 
 ### [*] 10/10 points: 20% or more of the public API has dartdoc comments
 
-70 out of 77 API elements (90.9 %) have documentation comments.
+70 out of 72 API elements (97.2 %) have documentation comments.
 
-Some symbols that are missing documentation: `dnd`, `Acceptor`, `AnimationHelper`, `CloneAvatarHandler`, `DraggablesAcceptor`.
+Some symbols that are missing documentation: `dnd`, `dnd.DraggablesAcceptor.draggableIds`.
 
 ### [*] 10/10 points: Package has an example
 

--- a/test/goldens/end2end/url_launcher-6.1.12.json
+++ b/test/goldens/end2end/url_launcher-6.1.12.json
@@ -125,7 +125,7 @@
         "grantedPoints": 20,
         "maxPoints": 20,
         "status": "passed",
-        "summary": "### [*] 10/10 points: 20% or more of the public API has dartdoc comments\n\n29 out of 33 API elements (87.9 %) have documentation comments.\n\nSome symbols that are missing documentation: `link`, `url_launcher`, `LaunchMode`, `url_launcher_string`.\n\n### [*] 10/10 points: Package has an example\n"
+        "summary": "### [*] 10/10 points: 20% or more of the public API has dartdoc comments\n\n29 out of 32 API elements (90.6 %) have documentation comments.\n\nSome symbols that are missing documentation: `link`, `url_launcher`, `url_launcher_string`.\n\n### [*] 10/10 points: Package has an example\n"
       },
       {
         "id": "platform",

--- a/test/goldens/end2end/url_launcher-6.1.12.json_report.md
+++ b/test/goldens/end2end/url_launcher-6.1.12.json_report.md
@@ -17,9 +17,9 @@ Detected license: `BSD-3-Clause`.
 
 ### [*] 10/10 points: 20% or more of the public API has dartdoc comments
 
-29 out of 33 API elements (87.9 %) have documentation comments.
+29 out of 32 API elements (90.6 %) have documentation comments.
 
-Some symbols that are missing documentation: `link`, `url_launcher`, `LaunchMode`, `url_launcher_string`.
+Some symbols that are missing documentation: `link`, `url_launcher`, `url_launcher_string`.
 
 ### [*] 10/10 points: Package has an example
 


### PR DESCRIPTION
Fixes #1297.