### PR TITLE
Always non-nullable DartdocResult.

### DIFF
--- a/lib/src/report/documentation.dart
+++ b/lib/src/report/documentation.dart
@@ -62,7 +62,7 @@ Future<ReportSection> hasDocumentation(PackageContext context) async {
   Subsection? documentation;
   if (dartdocPubData != null) {
     documentation = await createDocumentationCoverageSection(dartdocPubData);
-  } else if (dartdocResult != null) {
+  } else if (dartdocResult.wasRunning) {
     documentation = dartdocFailedSubsection(
         dartdocResult.errorReason ?? 'Running or processing dartdoc failed.');
   }


### PR DESCRIPTION
- Remove the reference of the process result, as it is not used later.
- Non-nullability resolves the ambiguity of the null return value.
- Explicit error message if the expected output files are missing (while the process otherwise completed).