### PR TITLE
Remove ProcessOutput.asBytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Removed deprecated APIs.
 - Renamed `runProc` -> `runWithTimeout`.
+- Removed `ProcessOutput.asBytes`.
 
 ## 0.21.45
 


### PR DESCRIPTION
- We don't use the bytes output, only the `asString`, no need to keep the API method of it around. (We may re-add later if needed.)
- Also fixes decoding of the chunked bytes (which may be broken on non-aligned byte boundaries).
