### PR TITLE
Always verify repository as part of the analysis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **BREAKING CHANGES**
 
 - Removed deprecated APIs.
+- Removed `InspectOptions.checkRemoteRepository` - repositories are verified by default.
 - Renamed `runProc` -> `runWithTimeout`.
 - Removed `ProcessOutput.asBytes`.
 

--- a/bin/pana.dart
+++ b/bin/pana.dart
@@ -155,7 +155,6 @@ Future main(List<String> args) async {
     final options = InspectOptions(
       pubHostedUrl: pubHostedUrl,
       lineLength: int.tryParse(result['line-length'] as String? ?? ''),
-      checkRemoteRepository: true,
       dartdocOutputDir: runDartdoc ? dartdocOutputDir : null,
     );
     try {

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -31,15 +31,11 @@ class InspectOptions {
   final Duration? dartdocTimeout;
   final int? lineLength;
 
-  /// Whether pana should also access the remote repository specified in pubspec.yaml.
-  final bool checkRemoteRepository;
-
   InspectOptions({
     this.pubHostedUrl,
     this.dartdocOutputDir,
     this.dartdocTimeout,
     this.lineLength,
-    this.checkRemoteRepository = false,
   });
 }
 

--- a/lib/src/references/pubspec_urls.dart
+++ b/lib/src/references/pubspec_urls.dart
@@ -7,7 +7,6 @@ import 'package:path/path.dart' as p;
 import '../model.dart';
 import '../package_context.dart';
 import '../report/_common.dart';
-import '../repository/repository_url_parser.dart';
 
 class PubspecUrlsWithIssues {
   final UrlWithIssue homepage;
@@ -59,25 +58,13 @@ Future<PubspecUrlsWithIssues> checkPubspecUrls(PackageContext context) async {
   // and it can be verified as a valid repository.
   final verifiedRepository = await context.repository;
   final isVerifiedRepository = verifiedRepository?.repository != null;
-  if (pubspec.homepage != null && pubspec.repository == null) {
-    // We may switch these values if the repository has been verified, or
-    // if the verification was not enabled, but the URL parsing recognizes
-    // it as a valid repository.
-    var canUseHomepageAsRepository = isVerifiedRepository;
-    if (!canUseHomepageAsRepository &&
-        context.options.checkRemoteRepository == false) {
-      final r = tryParseRepositoryUrl(pubspec.homepage!);
-      if (r != null && r.provider != RepositoryProvider.unknown) {
-        canUseHomepageAsRepository = true;
-      }
-    }
-
-    // do the actual switch
-    if (canUseHomepageAsRepository) {
-      var r = repository;
-      repository = homepage;
-      homepage = r;
-    }
+  // We should switch these values if the repository has been verified.
+  if (isVerifiedRepository &&
+      pubspec.homepage != null &&
+      pubspec.repository == null) {
+    var r = repository;
+    repository = homepage;
+    homepage = r;
   }
 
   // Set known issue tracker link in cases where it was not provided.

--- a/test/end2end_test.dart
+++ b/test/end2end_test.dart
@@ -68,7 +68,6 @@ void main() {
           version: version,
           options: InspectOptions(
             pubHostedUrl: 'http://127.0.0.1:${httpServer.port}',
-            checkRemoteRepository: true,
             dartdocOutputDir: skipDartdoc ? null : dartdocOutputDir,
           ),
         );


### PR DESCRIPTION
Removing the option as we always want to verify the repository. (Maybe we want to separate it by network-using and restricted parts, but that may come in a later version).

Code change is largely indent after removing the `if (sharedContext.options.checkRemoteRepository) {` block.