### PR TITLE
Merge _retryProc into runConstrained.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 - Removed deprecated APIs.
 - Removed `InspectOptions.checkRemoteRepository` - repositories are verified by default.
-- Renamed `runProc` -> `runWithTimeout`.
+- Renamed `runProc` -> `runConstrained`.
 - Removed `ProcessOutput.asBytes`.
+- `ToolException` has reference to the entire `PanaProcessResult`, instead of just the `stderr`.
 
 ## 0.21.45
 

--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -129,7 +129,7 @@ class PackageContext {
       await outdated;
       return null;
     } on ToolException catch (e) {
-      stderr = e.stderr?.asString ?? e.message;
+      stderr = e.result?.stderr.asString ?? e.message;
     } catch (e) {
       stderr = e.toString();
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,16 +22,16 @@ dependencies:
   lints: ^3.0.0
   logging: ^1.0.0
   markdown: ^7.0.0
+  meta: ^1.4.0
   path: ^1.6.2
   pub_semver: ^2.0.0
   pubspec_parse: ^1.2.2
+  retry: ^3.0.1
+  safe_url_check: ^1.0.0
   source_span: ^1.7.0
+  string_scanner: ^1.1.0
   tar: ^1.0.0
   yaml: ^3.0.0
-  safe_url_check: ^1.0.0
-  retry: ^3.0.1
-  meta: ^1.4.0
-  string_scanner: ^1.1.0
   test: ^1.5.2 # needed for lib/src/third_party/diff_match_patch/test.dart
 
 dev_dependencies:


### PR DESCRIPTION
- using `RetryOptions` from `package:retry` as part of the API
- breaking change in `ToolException`: storing the entire process result instead of just the `stderr`.