### PR TITLE
Refactor environment handling in ToolEnvironment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Renamed `runProc` -> `runConstrained`.
 - Removed `ProcessOutput.asBytes`.
 - `ToolException` has reference to the entire `PanaProcessResult`, instead of just the `stderr`.
+- `ToolEnvironment` does not expose `environment`.
 
 ## 0.21.45
 

--- a/lib/src/report/dependencies.dart
+++ b/lib/src/report/dependencies.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart'
@@ -283,12 +284,13 @@ Future<List<OutdatedVersionDescription>> computeOutdatedVersions(
   }
   final result = <OutdatedVersionDescription>[];
 
-  final hostUrlString = context.toolEnvironment.environment['PUB_HOSTED_URL'];
-  final environmentUri = (hostUrlString != null && hostUrlString.isNotEmpty)
-      ? Uri.tryParse(hostUrlString)
-      : null;
+  final pubHostedUrlFromEnv = Platform.environment['PUB_HOSTED_URL'];
+  final pubHostedUriFromEnv =
+      (pubHostedUrlFromEnv != null && pubHostedUrlFromEnv.isNotEmpty)
+          ? Uri.tryParse(pubHostedUrlFromEnv)
+          : null;
   final versionListing = jsonDecode(await getVersionListing(name,
-      pubHostedUrl: hostedDependency.hosted?.url ?? environmentUri));
+      pubHostedUrl: hostedDependency.hosted?.url ?? pubHostedUriFromEnv));
 
   try {
     final versions = tryGetFromJson<List>(

--- a/test/goldens/end2end/http-0.13.0.json
+++ b/test/goldens/end2end/http-0.13.0.json
@@ -122,6 +122,7 @@
       "branch": "master",
       "path": "pkgs/http"
     },
+    "contributingUrl": "https://github.com/dart-lang/http/blob/master/CONTRIBUTING.md",
     "grantedPoints": 120,
     "maxPoints": 130
   },


### PR DESCRIPTION
- Fixes an unrelated CI test failure.
- Moves the environment field into the Dart/Flutter SDK entity. (Precursor to also have the HOME directory be specific to an SDK).