### PR TITLE
Remove some methods and method parameters from ToolEnvironment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Renamed `runProc` -> `runConstrained`.
 - Removed `ProcessOutput.asBytes`.
 - `ToolException` has reference to the entire `PanaProcessResult`, instead of just the `stderr`.
-- `ToolEnvironment` does not expose `environment`.
+- `ToolEnvironment`:
+  - removed parameters from `dartdoc()`
+  - removed `get environment`, `detectFlutterUse()` and `getFlutterVersion()`
 
 ## 0.21.45
 

--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -241,7 +241,6 @@ class PackageContext {
         final pr = await toolEnvironment.dartdoc(
           packageDir,
           dartdocOutputDir,
-          validateLinks: false,
           timeout: timeout,
           usesFlutter: usesFlutter,
         );


### PR DESCRIPTION
- `'--no-validate-links'` in `dartdoc()` is always set anyway, no need to keep the optional parameter (similarly the other parameters are never set, we can remove them).
- removing further methods that are never called or restringing the visibility of them (`_getFlutterVersion()`).