### PR TITLE
Better environment handling for SDKs, removing almost-duplicate method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 ## 0.22.0
 
+- `ToolEnvironment.create()` takes `configHomeDir` to specify config the home
+  directory used for the analysis (helps switching different analyzer SDKs).
+- `ToolEnvironment.create()` takes `pubHostedUrl` as `PackageAnalyzer.create()`
+  was removed.
+
 **BREAKING CHANGES**
 
 - Renamed `runProc` -> `runConstrained`.
 - Removed:
   - deprecated APIs
   - `InspectOptions.checkRemoteRepository` - repositories are verified by default
+  - `PackageAnalyzer.create()`
   - `ProcessOutput.asBytes`
   - `Report.joinSection()`
   - `ToolEnvironment`:

--- a/bin/pana.dart
+++ b/bin/pana.dart
@@ -144,14 +144,14 @@ Future main(List<String> args) async {
 
   try {
     final pubHostedUrl = result['hosted-url'] as String?;
-    final analyzer = await PackageAnalyzer.create(
+    final analyzer = PackageAnalyzer(await ToolEnvironment.create(
       pubCacheDir: pubCacheDir,
       panaCacheDir: Platform.environment['PANA_CACHE'],
-      sdkDir: result['dart-sdk'] as String?,
-      flutterDir: result['flutter-sdk'] as String?,
+      dartSdkDir: result['dart-sdk'] as String?,
+      flutterSdkDir: result['flutter-sdk'] as String?,
       pubHostedUrl: pubHostedUrl,
       environment: Platform.environment,
-    );
+    ));
     final options = InspectOptions(
       pubHostedUrl: pubHostedUrl,
       lineLength: int.tryParse(result['line-length'] as String? ?? ''),

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -46,30 +46,6 @@ class PackageAnalyzer {
   PackageAnalyzer(this._toolEnv, {UrlChecker? urlChecker})
       : _urlChecker = urlChecker ?? UrlChecker();
 
-  static Future<PackageAnalyzer> create({
-    String? sdkDir,
-    String? flutterDir,
-    String? pubCacheDir,
-    String? panaCacheDir,
-    String? pubHostedUrl,
-    String? dartdocVersion,
-    Map<String, String>? environment,
-  }) async {
-    return PackageAnalyzer(
-      await ToolEnvironment.create(
-        dartSdkDir: sdkDir,
-        flutterSdkDir: flutterDir,
-        pubCacheDir: pubCacheDir,
-        panaCacheDir: panaCacheDir,
-        environment: <String, String>{
-          if (pubHostedUrl != null) 'PUB_HOSTED_URL': pubHostedUrl,
-          ...?environment,
-        },
-        dartdocVersion: dartdocVersion,
-      ),
-    );
-  }
-
   Future<Summary> inspectPackage(
     String package, {
     String? version,

--- a/test/end2end_light_test.dart
+++ b/test/end2end_light_test.dart
@@ -18,10 +18,10 @@ void main() {
         .resolveSymbolicLinksSync();
     final pubCacheDir = p.join(tempDir, 'pub-cache');
     Directory(pubCacheDir).createSync();
-    analyzer = await PackageAnalyzer.create(
+    analyzer = PackageAnalyzer(await ToolEnvironment.create(
       pubCacheDir: pubCacheDir,
       dartdocVersion: 'any',
-    );
+    ));
   });
 
   tearDownAll(() async {

--- a/test/end2end_test.dart
+++ b/test/end2end_test.dart
@@ -37,12 +37,12 @@ void main() {
       httpClient: httpClient,
       blockPublishAfter: goldenDirLastModified,
     );
-    analyzer = await PackageAnalyzer.create(
+    analyzer = PackageAnalyzer(await ToolEnvironment.create(
       pubCacheDir: pubCacheDir,
       panaCacheDir: panaCacheDir,
       pubHostedUrl: 'http://127.0.0.1:${httpServer.port}',
       dartdocVersion: 'any',
-    );
+    ));
   });
 
   tearDownAll(() async {


### PR DESCRIPTION
- Removing `PackageAnalyzer.create` as it has very little benefit over `ToolEnvironment.create`.
- Consolidated `environment` handling in `ToolEnvironment`, added config home dir option.