### PR TITLE
Remove PackageAnalyzer.inspectVersions()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - deprecated APIs
   - `InspectOptions.checkRemoteRepository` - repositories are verified by default
   - `PackageAnalyzer.create()`
+  - `PackageAnalyzer.inspectVersions()`
   - `ProcessOutput.asBytes`
   - `Report.joinSection()`
   - `ToolEnvironment`:

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -68,39 +68,6 @@ class PackageAnalyzer {
     }, logger: logger);
   }
 
-  Future<List<Summary>> inspectVersions(
-    String package,
-    List<String> versions, {
-    InspectOptions? options,
-    Logger Function(String version)? loggerFn,
-    Future<void> Function(String version, String filename, Uint8List data)?
-        storeResourceFn,
-  }) async {
-    final results = <Summary>[];
-    final sharedContext = _createSharedContext(options: options);
-    for (final version in versions) {
-      final summary = await withLogger(
-        () async {
-          return withTempDir((tempDir) async {
-            await downloadPackage(package, version,
-                destination: tempDir, pubHostedUrl: options!.pubHostedUrl);
-            return await _inspect(
-              sharedContext,
-              tempDir,
-              storeResource: storeResourceFn == null
-                  ? null
-                  : (filename, data) =>
-                      storeResourceFn(version, filename, data),
-            );
-          });
-        },
-        logger: loggerFn == null ? null : loggerFn(version),
-      );
-      results.add(summary);
-    }
-    return results;
-  }
-
   Future<Summary> inspectDir(String packageDir, {InspectOptions? options}) {
     final sharedContext = _createSharedContext(options: options);
     return withTempDir((tempDir) async {


### PR DESCRIPTION
In the end we haven't used this for analysis on pub.dev, let's remove it.

In the future we may want to have two isolation level for analysis, and it may complicate this method unnecessarily.