### PR TITLE
Support SDK-specific configs (home-path, environment).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@
   - `ToolEnvironment`:
     - `create()` method dropped `useGlobalDartdoc` flag, will use global dartdoc
       when `dartdocVersion` is specified, otherwise uses the Dart SDK's `dart doc`.
+    - `create()` method dropped `dartSdkDir`, `flutterSdkDir`, and `environment`,
+      using `SdkConfig` for each of the SDKs.
     - removed parameters from `dartdoc()`
     - `detectFlutterUse()`
+    - `get dartSdkDir`
+    - `get flutterSdkDir`
     - `get environment`
     - `getFlutterVersion()`
   - `analysisOptionsFiles`

--- a/bin/pana.dart
+++ b/bin/pana.dart
@@ -147,10 +147,9 @@ Future main(List<String> args) async {
     final analyzer = PackageAnalyzer(await ToolEnvironment.create(
       pubCacheDir: pubCacheDir,
       panaCacheDir: Platform.environment['PANA_CACHE'],
-      dartSdkDir: result['dart-sdk'] as String?,
-      flutterSdkDir: result['flutter-sdk'] as String?,
+      dartSdkConfig: SdkConfig(rootPath: result['dart-sdk'] as String?),
+      flutterSdkConfig: SdkConfig(rootPath: result['flutter-sdk'] as String?),
       pubHostedUrl: pubHostedUrl,
-      environment: Platform.environment,
     ));
     final options = InspectOptions(
       pubHostedUrl: pubHostedUrl,

--- a/lib/src/batch/batch_compare_command.dart
+++ b/lib/src/batch/batch_compare_command.dart
@@ -9,7 +9,7 @@ import 'package:args/command_runner.dart';
 import 'package:pana/src/package_analyzer.dart';
 import 'package:yaml/yaml.dart' as yaml;
 
-import '../sdk_env.dart' show ToolEnvironment;
+import '../sdk_env.dart' show SdkConfig, ToolEnvironment;
 import '../utils.dart' show withTempDir;
 
 import 'batch_model.dart';
@@ -120,9 +120,14 @@ class BatchCompareCommand extends Command {
   Future<ToolEnvironment> _initToolEnv(
       BatchConfig config, String pubCache) async {
     return await ToolEnvironment.create(
-      dartSdkDir: config.dartSdk,
-      flutterSdkDir: config.flutterSdk,
-      environment: config.environment,
+      dartSdkConfig: SdkConfig(
+        rootPath: config.dartSdk,
+        environment: config.environment ?? const {},
+      ),
+      flutterSdkConfig: SdkConfig(
+        rootPath: config.flutterSdk,
+        environment: config.environment ?? const {},
+      ),
       pubCacheDir: pubCache,
     );
   }

--- a/lib/src/batch/batch_run_command.dart
+++ b/lib/src/batch/batch_run_command.dart
@@ -9,7 +9,7 @@ import 'package:args/command_runner.dart';
 import 'package:pana/src/package_analyzer.dart';
 import 'package:yaml/yaml.dart' as yaml;
 
-import '../sdk_env.dart' show ToolEnvironment;
+import '../sdk_env.dart' show SdkConfig, ToolEnvironment;
 import '../utils.dart' show withTempDir;
 
 import 'batch_model.dart';
@@ -100,9 +100,14 @@ class BatchRunCommand extends Command {
   Future<ToolEnvironment> _initToolEnv(
       BatchConfig config, String pubCache) async {
     return await ToolEnvironment.create(
-      dartSdkDir: config.dartSdk,
-      flutterSdkDir: config.flutterSdk,
-      environment: config.environment,
+      dartSdkConfig: SdkConfig(
+        rootPath: config.dartSdk,
+        environment: config.environment ?? const {},
+      ),
+      flutterSdkConfig: SdkConfig(
+        rootPath: config.flutterSdk,
+        environment: config.environment ?? const {},
+      ),
       pubCacheDir: pubCache,
     );
   }


### PR DESCRIPTION
- #1320 added config home, but there is still a chance that SDKs sharing the same home config directory would override each other's settings. The new `SdkConfig` ensures that complete separation is possible.
- Also fixing a possible `dartdoc` glitch (not necessarily bug, rather a hard to debug issue) by explicitly calling the `flutter` binary (or its embedded `dart` binary) for Flutter packages. Apparently if `FLUTTER_ROOT` is set, and we are calling an unrelated Dart SDK, `dartdoc` implicitly sets the `--sdk-dir` parameter to `<sdk-root>/bin/cache/dart-sdk/`, which is absent is the regular Dart SDK, and `dartdoc` fails.