### PR TITLE
Start removing `dynamic` usages in tests

### DIFF
--- a/test/analysis_options_test.dart
+++ b/test/analysis_options_test.dart
@@ -40,7 +40,7 @@ void main() {
 
   test('passthrough for empty options', () {
     final content = updatePassthroughOptions(original: '', custom: '');
-    expect(json.decode(content), {});
+    expect(json.decode(content), <String, Object?>{});
   });
 
   test('passthrough for some options', () {

--- a/test/license_test.dart
+++ b/test/license_test.dart
@@ -9,7 +9,7 @@ import 'package:pana/src/license.dart';
 import 'package:test/test.dart';
 
 void main() {
-  Future expectFile(String path, expected) async {
+  Future<void> expectFile(String path, List<String> expected) async {
     final relativePath = path.substring('test/licenses/'.length);
     final licenses =
         await detectLicenseInFile(File(path), relativePath: relativePath);
@@ -23,9 +23,10 @@ void main() {
   group('AGPL', () {
     test('explicit', () async {
       expect(
-          await detectLicenseInContent('GNU AFFERO GENERAL PUBLIC LICENSE',
-              relativePath: 'LICENSE'),
-          []);
+        await detectLicenseInContent('GNU AFFERO GENERAL PUBLIC LICENSE',
+            relativePath: 'LICENSE'),
+        isEmpty,
+      );
       await expectFile('test/licenses/agpl_v3.txt', ['AGPL-3.0']);
     });
   });
@@ -33,10 +34,11 @@ void main() {
   group('Apache', () {
     test('explicit', () async {
       expect(
-          await detectLicenseInContent(
-              '   Apache License\n     Version 2.0, January 2004\n',
-              relativePath: 'LICENSE'),
-          []);
+        await detectLicenseInContent(
+            '   Apache License\n     Version 2.0, January 2004\n',
+            relativePath: 'LICENSE'),
+        isEmpty,
+      );
       await expectFile('test/licenses/apache_v2.txt', ['Apache-2.0']);
     });
   });
@@ -54,14 +56,16 @@ void main() {
   group('GPL', () {
     test('explicit', () async {
       expect(
-          await detectLicenseInContent(
-              ['GNU GENERAL PUBLIC LICENSE', 'Version 2, June 1991'].join('\n'),
-              relativePath: 'LICENSE'),
-          []);
+        await detectLicenseInContent(
+            ['GNU GENERAL PUBLIC LICENSE', 'Version 2, June 1991'].join('\n'),
+            relativePath: 'LICENSE'),
+        isEmpty,
+      );
       expect(
-          await detectLicenseInContent(['GNU GPL Version 2'].join('\n'),
-              relativePath: 'LICENSE'),
-          []);
+        await detectLicenseInContent(['GNU GPL Version 2'].join('\n'),
+            relativePath: 'LICENSE'),
+        isEmpty,
+      );
       await expectFile('test/licenses/gpl_v3.txt', ['GPL-3.0']);
     });
   });
@@ -69,10 +73,11 @@ void main() {
   group('LGPL', () {
     test('explicit', () async {
       expect(
-          await detectLicenseInContent(
-              '\nGNU LESSER GENERAL PUBLIC LICENSE\n    Version 3, 29 June 2007',
-              relativePath: 'LICENSE'),
-          []);
+        await detectLicenseInContent(
+            '\nGNU LESSER GENERAL PUBLIC LICENSE\n    Version 3, 29 June 2007',
+            relativePath: 'LICENSE'),
+        isEmpty,
+      );
       await expectFile('test/licenses/lgpl_v3.txt', ['LGPL-3.0']);
     });
   });
@@ -80,13 +85,15 @@ void main() {
   group('MIT', () {
     test('explicit', () async {
       expect(
-          await detectLicenseInContent('\n\n   The MIT license\n\n blah...',
-              relativePath: 'LICENSE'),
-          []);
+        await detectLicenseInContent('\n\n   The MIT license\n\n blah...',
+            relativePath: 'LICENSE'),
+        isEmpty,
+      );
       expect(
-          await detectLicenseInContent('MIT license\n\n blah...',
-              relativePath: 'LICENSE'),
-          []);
+        await detectLicenseInContent('MIT license\n\n blah...',
+            relativePath: 'LICENSE'),
+        isEmpty,
+      );
 
       await expectFile('test/licenses/mit.txt', ['MIT']);
       await expectFile('test/licenses/mit_without_mit.txt', ['MIT']);
@@ -96,10 +103,11 @@ void main() {
   group('MPL', () {
     test('explicit', () async {
       expect(
-          await detectLicenseInContent(
-              '\n\n   Mozilla Public License Version 2.0\n\n blah...',
-              relativePath: 'LICENSE'),
-          []);
+        await detectLicenseInContent(
+            '\n\n   Mozilla Public License Version 2.0\n\n blah...',
+            relativePath: 'LICENSE'),
+        isEmpty,
+      );
       await expectFile('test/licenses/mpl_v2.txt', ['MPL-2.0']);
     });
   });
@@ -107,17 +115,21 @@ void main() {
   group('Unlicense', () {
     test('explicit', () async {
       expect(
-          await detectLicenseInContent(
-              '\n\n   This is free and unencumbered software released into the public domain.\n',
-              relativePath: 'LICENSE'),
-          []);
+        await detectLicenseInContent(
+            '\n\n   This is free and unencumbered software released into the public domain.\n',
+            relativePath: 'LICENSE'),
+        isEmpty,
+      );
       await expectFile('test/licenses/unlicense.txt', ['Unlicense']);
     });
   });
 
   group('unknown', () {
     test('empty content', () async {
-      expect(await detectLicenseInContent('', relativePath: 'LICENSE'), []);
+      expect(
+        await detectLicenseInContent('', relativePath: 'LICENSE'),
+        isEmpty,
+      );
     });
   });
 
@@ -133,7 +145,7 @@ void main() {
     });
 
     test('no license files', () async {
-      expect(await detectLicenseInDir('lib/src/'), []);
+      expect(await detectLicenseInDir('lib/src/'), isEmpty);
     });
   });
 }

--- a/test/markdown_content_test.dart
+++ b/test/markdown_content_test.dart
@@ -30,7 +30,7 @@ void main() {
         'http://example.com/logo.png',
         'gopher://example.com/logo.png',
       ],
-      'links': [],
+      'links': <String>[],
       'isMalformedUtf8': false,
       'nonAsciiRatio': 0.0,
     });
@@ -52,8 +52,8 @@ void main() {
       ]);
       final content = await scanMarkdownFileContent(file);
       expect(content.toJson(), {
-        'images': [],
-        'links': [],
+        'images': <String>[],
+        'links': <String>[],
         'isMalformedUtf8': true,
         'nonAsciiRatio': greaterThan(0.01),
       });
@@ -67,8 +67,8 @@ void main() {
       ]);
       final content = await scanMarkdownFileContent(file);
       expect(content.toJson(), {
-        'images': [],
-        'links': [],
+        'images': <String>[],
+        'links': <String>[],
         'isMalformedUtf8': true,
         'nonAsciiRatio': greaterThan(0.01),
       });

--- a/test/package_server.dart
+++ b/test/package_server.dart
@@ -23,7 +23,8 @@ PackageServer? _globalPackageServer;
 ///
 /// Calls [callback] with a [PackageServerBuilder] that's used to specify
 /// which packages to serve.
-Future servePackages([void Function(PackageServerBuilder?)? callback]) async {
+Future<void> servePackages(
+    [void Function(PackageServerBuilder?)? callback]) async {
   _globalPackageServer = await PackageServer.start(callback ?? (_) {});
 
   addTearDown(() {
@@ -35,7 +36,7 @@ Future servePackages([void Function(PackageServerBuilder?)? callback]) async {
 /// registered.
 ///
 /// This will always replace a previous server.
-Future serveNoPackages() => servePackages((_) {});
+Future<void> serveNoPackages() => servePackages((_) {});
 
 class PackageServer {
   /// The underlying server.
@@ -109,7 +110,7 @@ class PackageServer {
   }
 
   /// Closes this server.
-  Future close() => _server.close();
+  Future<void> close() => _server.close();
 
   /// The [d.DirectoryDescriptor] describing the server layout of
   /// `/api/packages` on the test server.
@@ -166,11 +167,12 @@ class PackageServer {
 
 /// Returns a Map in the format used by the pub.dartlang.org API to represent a
 /// package version.
-Map _packageVersionApiMap(String hostedUrl, _ServedPackageVersion package) {
+Map<String, Object?> _packageVersionApiMap(
+    String hostedUrl, _ServedPackageVersion package) {
   final pubspec = package.pubspec;
   final name = pubspec['name'];
   final version = pubspec['version'];
-  final map = {
+  final map = <String, Object?>{
     'pubspec': pubspec,
     'version': version,
     'archive_url': '$hostedUrl/packages/$name/versions/$version.tar.gz',
@@ -201,12 +203,12 @@ class PackageServerBuilder {
   /// If [contents] is passed, it's used as the contents of the package. By
   /// default, a package just contains a dummy lib directory.
   void serve(String name, String version,
-      {Map<String, dynamic>? deps,
-      Map<String, dynamic>? pubspec,
+      {Map<String, Object>? deps,
+      Map<String, Object>? pubspec,
       Map<String, String>? versionData,
       Iterable<d.Descriptor>? contents,
       DateTime? published}) {
-    var pubspecFields = <String, dynamic>{
+    var pubspecFields = <String, Object>{
       'name': name,
       'version': version,
       'environment': {'sdk': '>=2.12.0 <4.0.0'}

--- a/test/tag/tag_end2end_test.dart
+++ b/test/tag/tag_end2end_test.dart
@@ -12,7 +12,7 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 import '../package_descriptor.dart';
 
 void _expectTagging(void Function(List<String>, List<Explanation>) f,
-    {dynamic tags = anything, dynamic explanations = anything}) {
+    {Object? tags = anything, Object? explanations = anything}) {
   final actualTags = <String>[];
   final actualExplanations = <Explanation>[];
   f(actualTags, actualExplanations);
@@ -52,7 +52,7 @@ void main() {
           explanations: isEmpty);
       _expectTagging(tagger.flutterPluginTags, tags: isEmpty);
     });
-    test('analyzes the primary libray', () async {
+    test('analyzes the primary library', () async {
       final descriptor = d.dir('cache', [
         packageWithPathDeps('my_package', lib: [
           d.file('a.dart', '''
@@ -190,7 +190,10 @@ int fourtyTwo() => fourtyThree() - 1;
           'environment': {'flutter': '>=1.2.0<=2.0.0'},
           'flutter': {
             'plugin': {
-              'platforms': {'web': {}, 'ios': {}}
+              'platforms': {
+                'web': <String, String>{},
+                'ios': <String, String>{}
+              }
             }
           }
         }),
@@ -219,7 +222,10 @@ int fourtyTwo() => fourtyThree() - 1;
           'environment': {'flutter': '>=1.2.0<=2.0.0'},
           'flutter': {
             'plugin': {
-              'platforms': {'web': {}, 'ios': {}}
+              'platforms': {
+                'web': <String, String>{},
+                'ios': <String, String>{},
+              }
             }
           }
         }),
@@ -232,7 +238,7 @@ int fourtyTwo() => fourtyThree() - 1;
       _expectTagging(tagger.flutterPluginTags, tags: isEmpty);
     });
     test('Flutter plugins declarations are respected', () async {
-      final decriptor = d.dir('cache', [
+      final descriptor = d.dir('cache', [
         packageWithPathDeps('my_package', lib: [
           d.file('my_package.dart', '''
 import 'dart:io';
@@ -243,7 +249,10 @@ int fourtyTwo() => 42;
           'environment': {'flutter': '>=1.2.0<=2.0.0'},
           'flutter': {
             'plugin': {
-              'platforms': {'web': {}, 'ios': {}}
+              'platforms': {
+                'web': <String, String>{},
+                'ios': <String, String>{},
+              }
             }
           }
         }, dependencies: [
@@ -263,14 +272,17 @@ int fourtyTwo() => 42;
           'environment': {'flutter': '>=1.2.0<=2.0.0'},
           'flutter': {
             'plugin': {
-              'platforms': {'web': {}, 'linux': {}}
+              'platforms': {
+                'web': <String, String>{},
+                'linux': <String, String>{},
+              }
             }
           }
         })
       ]);
 
-      await decriptor.create();
-      final tagger = Tagger('${decriptor.io.path}/my_package');
+      await descriptor.create();
+      final tagger = Tagger('${descriptor.io.path}/my_package');
       _expectTagging(tagger.sdkTags, tags: {'sdk:flutter'});
       _expectTagging(tagger.platformTags,
           tags: {'platform:ios', 'platform:web'});
@@ -279,7 +291,7 @@ int fourtyTwo() => 42;
     });
 
     test('Declaring top-level platforms', () async {
-      final decriptor = d.dir(
+      final descriptor = d.dir(
         'cache',
         [
           packageWithPathDeps(
@@ -293,8 +305,8 @@ int fourtyTwo() => 42;
           ),
         ],
       );
-      await decriptor.create();
-      final tagger = Tagger('${decriptor.io.path}/my_package');
+      await descriptor.create();
+      final tagger = Tagger('${descriptor.io.path}/my_package');
       _expectTagging(tagger.sdkTags, tags: {'sdk:flutter', 'sdk:dart'});
       _expectTagging(tagger.platformTags,
           tags: {'platform:windows', 'platform:android'});
@@ -304,7 +316,7 @@ int fourtyTwo() => 42;
     });
 
     test('Top-level platforms in dependency', () async {
-      final decriptor = d.dir('cache', [
+      final descriptor = d.dir('cache', [
         packageWithPathDeps('my_package', lib: [
           d.file('my_package.dart', '''
 import 'dart:io';
@@ -332,8 +344,8 @@ int fourtyTwo() => 42;
         })
       ]);
 
-      await decriptor.create();
-      final tagger = Tagger('${decriptor.io.path}/my_package');
+      await descriptor.create();
+      final tagger = Tagger('${descriptor.io.path}/my_package');
       _expectTagging(tagger.sdkTags, tags: {'sdk:flutter'});
       _expectTagging(tagger.platformTags, tags: {'platform:linux'});
       _expectTagging(tagger.runtimeTags, tags: isEmpty);
@@ -529,7 +541,7 @@ name: my_package
       _expectTagging(tagger.flutterPluginTags, tags: isEmpty);
     });
     test('no dart files with Flutter plugins declarations', () async {
-      final decriptor = d.dir('cache', [
+      final descriptor = d.dir('cache', [
         packageWithPathDeps(
           'my_package',
           lib: [d.file('asset.json', '{"status": "ok"}')],
@@ -537,15 +549,18 @@ name: my_package
             'environment': {'flutter': '>=1.2.0<=2.0.0'},
             'flutter': {
               'plugin': {
-                'platforms': {'web': {}, 'ios': {}}
+                'platforms': {
+                  'web': <String, String>{},
+                  'ios': <String, String>{},
+                }
               }
             }
           },
         ),
       ]);
 
-      await decriptor.create();
-      final tagger = Tagger('${decriptor.io.path}/my_package');
+      await descriptor.create();
+      final tagger = Tagger('${descriptor.io.path}/my_package');
       _expectTagging(tagger.sdkTags, tags: {'sdk:flutter'});
       _expectTagging(tagger.platformTags, tags: {
         'platform:ios',
@@ -557,7 +572,8 @@ name: my_package
   });
 }
 
-Matcher _explanation({finding = anything, explanation = anything}) {
+Matcher _explanation(
+    {Object? finding = anything, Object? explanation = anything}) {
   return allOf(
     HasFinding(finding),
     _HasDescription(explanation),
@@ -565,16 +581,16 @@ Matcher _explanation({finding = anything, explanation = anything}) {
 }
 
 class _HasDescription extends CustomMatcher {
-  _HasDescription(matcher)
+  _HasDescription(Object? matcher)
       : super('Explanation with a', 'explanation', matcher);
 
   @override
-  String? featureValueOf(actual) => (actual as Explanation).explanation;
+  String? featureValueOf(Object? actual) => (actual as Explanation).explanation;
 }
 
 class HasFinding extends CustomMatcher {
-  HasFinding(matcher) : super('Explanation with a', 'finding', matcher);
+  HasFinding(Object? matcher) : super('Explanation with a', 'finding', matcher);
 
   @override
-  String featureValueOf(actual) => (actual as Explanation).finding;
+  String featureValueOf(Object? actual) => (actual as Explanation).finding;
 }

--- a/test/tag/tag_external_test.dart
+++ b/test/tag/tag_external_test.dart
@@ -16,7 +16,7 @@ void main() {
     Set<String> allDart2jsLibs;
     late Set<String> publicDart2jsLibs;
 
-    Set<String> extractLibraries(Map<String, dynamic> map) {
+    Set<String> extractLibraries(Map<String, Object?> map) {
       return map.entries
           .where(
               (e) => e.value is Map && (e.value as Map)['supported'] != false)
@@ -30,10 +30,10 @@ void main() {
           'https://raw.githubusercontent.com/dart-lang/sdk/master/sdk/lib/libraries.json'));
       libraries = json.decode(librariesContent.body) as Map<String, dynamic>?;
       allVmLibs = extractLibraries(
-          libraries!['vm']['libraries'] as Map<String, dynamic>);
+          libraries!['vm']['libraries'] as Map<String, Object?>);
       publicVmLibs = allVmLibs.where((s) => !s.startsWith('_')).toSet();
       allDart2jsLibs = extractLibraries(
-          libraries!['dart2js']['libraries'] as Map<String, dynamic>);
+          libraries!['dart2js']['libraries'] as Map<String, Object?>);
       publicDart2jsLibs =
           allDart2jsLibs.where((s) => !s.startsWith('_')).toSet();
     });

--- a/test/tag/tag_null_safe_test.dart
+++ b/test/tag/tag_null_safe_test.dart
@@ -10,7 +10,7 @@ import 'package:test_descriptor/test_descriptor.dart' as d;
 import '../package_descriptor.dart';
 
 void expectTagging(void Function(List<String>, List<Explanation>) f,
-    {dynamic tags = anything, dynamic explanations = anything}) {
+    {Object? tags = anything, Object? explanations = anything}) {
   final actualTags = <String>[];
   final actualExplanations = <Explanation>[];
   f(actualTags, actualExplanations);
@@ -266,7 +266,8 @@ void main() {
   });
 }
 
-Matcher explanation({finding = anything, explanation = anything}) {
+Matcher explanation(
+    {Object? finding = anything, Object? explanation = anything}) {
   return allOf(
     HasFinding(finding),
     HasDescription(explanation),
@@ -274,15 +275,16 @@ Matcher explanation({finding = anything, explanation = anything}) {
 }
 
 class HasDescription extends CustomMatcher {
-  HasDescription(matcher) : super('Explanation with a', 'explanation', matcher);
+  HasDescription(Object? matcher)
+      : super('Explanation with a', 'explanation', matcher);
 
   @override
-  String? featureValueOf(actual) => (actual as Explanation).explanation;
+  String? featureValueOf(Object? actual) => (actual as Explanation).explanation;
 }
 
 class HasFinding extends CustomMatcher {
-  HasFinding(matcher) : super('Explanation with a', 'finding', matcher);
+  HasFinding(Object? matcher) : super('Explanation with a', 'finding', matcher);
 
   @override
-  String featureValueOf(actual) => (actual as Explanation).finding;
+  String featureValueOf(Object? actual) => (actual as Explanation).finding;
 }


### PR DESCRIPTION
Working towards enabling `package:dart_flutter_team_lints`, this fixes many of the instances of `dynamic` usage introduced within tests, which account for the majority in the package.
