### PR TITLE
Only use library directives where necessary

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -26,5 +26,6 @@ linter:
     - throw_in_finally
     - unawaited_futures
     - unnecessary_lambdas
+    - unnecessary_library_directive
     - unnecessary_null_aware_assignments
     - unnecessary_statements

--- a/lib/src/code_problem.dart
+++ b/lib/src/code_problem.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library pana.code_problem;
-
 import 'package:path/path.dart' as p;
 
 import 'internal_model.dart';

--- a/lib/src/license.dart
+++ b/lib/src/license.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library pana.license;
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/lib/src/maintenance.dart
+++ b/lib/src/maintenance.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library pana.maintenance;
-
 import 'package:json_annotation/json_annotation.dart';
 
 /// Returns the candidates in priority order to display under the 'Example' tab.

--- a/lib/src/pkg_resolution.dart
+++ b/lib/src/pkg_resolution.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library pana.pkg_resolution;
-
 import 'dart:convert';
 
 class PubEntry {

--- a/test/ensure_build_test.dart
+++ b/test/ensure_build_test.dart
@@ -1,4 +1,6 @@
 @Tags(['presubmit-only'])
+library;
+
 import 'dart:io';
 
 import 'package:build_verify/build_verify.dart';


### PR DESCRIPTION
On the road to switching to `package:dart_flutter_team_lints`.