### PR TITLE
Allow import of dart:_js_annotations on web

### DIFF
--- a/lib/src/tag/_specs.dart
+++ b/lib/src/tag/_specs.dart
@@ -44,6 +44,7 @@ class Runtime {
     'web_audio',
     'web_gl',
     'web_sql',
+    '_js_annotations' // Used by package:js.
   };
 
   static final _onNativeAot = {


### PR DESCRIPTION
This library is used by package:js: https://github.com/dart-lang/sdk/blob/main/pkg/js/lib/js.dart#L8

Otherwise a package using package:js will not be determined web-compatible.