### PR TITLE
Run 'dartdoc' at a later part of the report.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.22.2
+
+- `dartdoc` processing is run as the last step of the generated report.
+
 ## 0.22.1
 
 - Fix: unspecified `--dartdoc-version` will use the latest version in an isolated

--- a/lib/src/report/create_report.dart
+++ b/lib/src/report/create_report.dart
@@ -37,11 +37,20 @@ Future<Report> createReport(PackageContext context) async {
     );
   }
 
+  final templateReport = await followsTemplate(context);
+  final platformReport = await multiPlatform(context.packageDir, pubspec);
+  final staticAnalysisReport = await staticAnalysis(context);
+  final dependenciesReport = await trustworthyDependency(context);
+
+  // Create the documentation report (and run `dartdoc`) as the last step
+  // to allow better budgeting for large packages.
+  final documentationReport = await hasDocumentation(context);
+
   return Report(sections: [
-    await followsTemplate(context),
-    await hasDocumentation(context),
-    await multiPlatform(context.packageDir, pubspec),
-    await staticAnalysis(context),
-    await trustworthyDependency(context),
+    templateReport,
+    documentationReport,
+    platformReport,
+    staticAnalysisReport,
+    dependenciesReport,
   ]);
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.22.1';
+const packageVersion = '0.22.2-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.22.1
+version: 0.22.2-dev
 repository: https://github.com/dart-lang/pana
 topics:
   - tool


### PR DESCRIPTION
This is a follow-up to https://github.com/dart-lang/pub-dev/issues/7430, as it still a pending issue: a large package needs to run `dartdoc` after every other time-consuming analysis (e.g. static analysis or formatted files). Otherwise, e.g. in the case of `package:aws_client` the total timeout is almost exhausted by the time `dartdoc` is being killed because of the dartdoc timeout, and the analysis still needs to run formatting checks.