### PR TITLE
Fix configuration directory issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.22.2
 
 - `dartdoc` processing is run as the last step of the generated report.
+- Fix: missing custom SDK environment (config directory use) when invoking Flutter.
 
 ## 0.22.1
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.22.2-dev';
+const packageVersion = '0.22.2';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.22.2-dev
+version: 0.22.2
 repository: https://github.com/dart-lang/pana
 topics:
   - tool

--- a/test/end2end_test.dart
+++ b/test/end2end_test.dart
@@ -29,15 +29,21 @@ void main() {
         .resolveSymbolicLinksSync();
     final pubCacheDir = p.join(tempDir, 'pub-cache');
     final panaCacheDir = p.join(tempDir, 'pana-cache');
+    final dartConfigDir = p.join(tempDir, 'config', 'dart');
+    final flutterConfigDir = p.join(tempDir, 'config', 'flutter');
     final goldenDirLastModified = await _detectGoldenLastModified();
     Directory(pubCacheDir).createSync();
     Directory(panaCacheDir).createSync();
+    Directory(dartConfigDir).createSync(recursive: true);
+    Directory(flutterConfigDir).createSync(recursive: true);
     httpClient = http.Client();
     httpServer = await _startLocalProxy(
       httpClient: httpClient,
       blockPublishAfter: goldenDirLastModified,
     );
     analyzer = PackageAnalyzer(await ToolEnvironment.create(
+      dartSdkConfig: SdkConfig(configHomePath: dartConfigDir),
+      flutterSdkConfig: SdkConfig(configHomePath: flutterConfigDir),
       pubCacheDir: pubCacheDir,
       panaCacheDir: panaCacheDir,
       pubHostedUrl: 'http://127.0.0.1:${httpServer.port}',


### PR DESCRIPTION
- added missing reference to `flutterSdk.environment`
- handling the `Welcome to Flutter` screen by stripping it away from the output (in case any future regression happens)
- added config dir option to end2end test, it may help to expose future regression