### PR TITLE
Fix exit-code-threshold help text and reorganize code to match

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Usage: pana [<options>] --hosted <published package name> [<version>]
 Options:
       --dart-sdk               The directory of the Dart SDK.
       --flutter-sdk            The directory of the Flutter SDK.
-      --exit-code-threshold    The exit code will indicate if (max - granted points) <= threshold.
+      --exit-code-threshold    The exit code will indicate if (max - granted points) > threshold.
   -j, --json                   Output log records and full report as JSON.
       --hosted-url             The server that hosts <package>.
                                (defaults to "https://pub.dev")

--- a/bin/pana.dart
+++ b/bin/pana.dart
@@ -34,7 +34,7 @@ final _parser = ArgParser()
   )
   ..addOption('exit-code-threshold',
       help:
-          'The exit code will indicate if (max - granted points) <= threshold.')
+          'The exit code will indicate if (max - granted points) > threshold.')
   ..addFlag('json',
       abbr: 'j',
       help: 'Output log records and full report as JSON.',
@@ -266,8 +266,8 @@ Future<void> main(List<String> args) async {
       }
       if (exitCodeThreshold != null &&
           exitCodeThreshold >= 0 &&
-          exitCodeThreshold + summary.report!.grantedPoints <
-              summary.report!.maxPoints) {
+          summary.report!.maxPoints - summary.report!.grantedPoints >
+              exitCodeThreshold) {
         exitCode = 127;
       }
     } catch (e, stack) {

--- a/test/goldens/help.txt
+++ b/test/goldens/help.txt
@@ -4,7 +4,7 @@ Usage: pana [<options>] --hosted <published package name> [<version>]
 Options:
       --dart-sdk               The directory of the Dart SDK.
       --flutter-sdk            The directory of the Flutter SDK.
-      --exit-code-threshold    The exit code will indicate if (max - granted points) <= threshold.
+      --exit-code-threshold    The exit code will indicate if (max - granted points) > threshold.
   -j, --json                   Output log records and full report as JSON.
       --hosted-url             The server that hosts <package>.
                                (defaults to "https://pub.dev")


### PR DESCRIPTION
Unless I'm crazy, the help text for `exit-code-threshold` was wrong. I also refactored the relevant code to have the same structure to reduce confusion.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
