### PR TITLE
Verify 'executables' in 'pubspec.yaml' and check if the related files exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.22.7
 
 - Enable `macros` experiment pass-through in `analysis_options.yaml`.
+- Verify `executables` in `pubspec.yaml` and check if the related files exist.
+- Fixed `has:executable` check.
 
 ## 0.22.6
 

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -193,7 +193,7 @@ class PackageAnalyzer {
     final licenses = await context.licenses;
     tags.addAll((await context.licenceTags).tags);
 
-    if (await context.hasExecutableInBinDirectory) {
+    if ((await context.executablesInBinDirectory).isNotEmpty) {
       tags.add(PanaTags.hasExecutable);
     }
 

--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -349,25 +349,20 @@ class PackageContext {
     }
   }();
 
-  late final hasExecutableInBinDirectory = () async {
+  late final executablesInBinDirectory = () async {
     final binDir = Directory(p.join(packageDir, 'bin'));
     if (!await binDir.exists()) {
-      return false;
+      return <String>[];
     }
+    final executables = <String>[];
     final entries = await binDir.list().toList();
     for (final file in entries.whereType<File>()) {
       if (!file.path.endsWith('.dart')) {
         continue;
       }
-      // minimal sanity check without parsing the source code
-      final content = await file.readAsString();
-      if (content.contains('main')) {
-        continue;
-      }
-
-      return true;
+      executables.add(p.basename(file.path));
     }
-    return false;
+    return executables;
   }();
 }
 

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -165,6 +165,15 @@ class Pubspec {
         'iosPrefix',
         'pluginClass',
       }.any((_inner.flutter!['plugin'] as Map<String, dynamic>).containsKey);
+
+  late final executables = () {
+    final map = _content['executables'];
+    if (map == null || map is! Map) {
+      return const <String, String>{};
+    }
+    return map.map(
+        (k, v) => MapEntry(k.toString().trim(), (v ?? '').toString().trim()));
+  }();
 }
 
 final _range2 = VersionConstraint.parse('>=2.0.0 <3.0.0');

--- a/lib/src/report/template.dart
+++ b/lib/src/report/template.dart
@@ -183,6 +183,20 @@ Future<ReportSection> followsTemplate(PackageContext context) async {
               '${repository!.verificationFailure}'));
     }
 
+    final executableFiles = await context.executablesInBinDirectory;
+    for (final e in context.pubspec.executables.entries) {
+      final filename = e.value.endsWith('.dart')
+          ? e.value
+          : (e.value.isEmpty ? '${e.key}.dart' : '${e.value}.dart');
+      if (!executableFiles.contains(filename)) {
+        issues.add(Issue(
+          'Missing or invalid executable file: `bin/$filename`.',
+          suggestion: 'Update `executable` field in `pubspec.yaml` or '
+              'fix the missing or invalid file in the `bin/` directory.',
+        ));
+      }
+    }
+
     final unreachableFailuresIgnored =
         // every issue is about an URL being unreachable
         issues.isNotEmpty &&

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.22.7-dev';
+const packageVersion = '0.22.7';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,10 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.22.7-dev
+version: 0.22.7
 repository: https://github.com/dart-lang/pana
 topics:
   - tool
+  - analysis
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/test/goldens/end2end/gg-1.0.12.json
+++ b/test/goldens/end2end/gg-1.0.12.json
@@ -120,7 +120,8 @@
     "is:dart3-compatible",
     "license:mit",
     "license:fsf-libre",
-    "license:osi-approved"
+    "license:osi-approved",
+    "has:executable"
   ],
   "report": {
     "sections": [

--- a/test/goldens/end2end/onepub-1.1.0.json
+++ b/test/goldens/end2end/onepub-1.1.0.json
@@ -122,7 +122,8 @@
     "is:null-safe",
     "is:wasm-ready",
     "is:dart3-compatible",
-    "license:unknown"
+    "license:unknown",
+    "has:executable"
   ],
   "report": {
     "sections": [


### PR DESCRIPTION
- fixes bug with `has:executable` tagging
- verifies the `executables` entry in `pubspec.yaml` and reports it in the layout checks if any of the binary files is missing
