### PR TITLE
New text logging format + moving initialization to new method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.22.8
 
 - Updated dependency: `tar: ^2.0.0`.
+- New text logging format.
 
 ## 0.22.7
 

--- a/bin/pana.dart
+++ b/bin/pana.dart
@@ -13,6 +13,7 @@ import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart' as log;
 import 'package:pana/pana.dart';
+import 'package:pana/src/logging.dart';
 import 'package:path/path.dart' as p;
 
 const defaultHostedUrl = 'https://pub.dev';
@@ -132,22 +133,7 @@ Future<void> main(List<String> args) async {
   }
 
   log.Logger.root.level = log.Level.ALL;
-
-  if (isJson) {
-    log.Logger.root.onRecord.listen((log) {
-      final map = {
-        if (log.loggerName.isNotEmpty) 'logName': log.loggerName,
-        'level': log.level.name,
-        'message': log.message,
-        if (log.error != null) 'error': log.error.toString(),
-        if (log.stackTrace != null) 'stackTrace': log.stackTrace.toString(),
-      };
-
-      stderr.writeln(json.encode(map));
-    });
-  } else {
-    log.Logger.root.onRecord.listen(_logWriter);
-  }
+  initializePanaLogging(isJson: isJson);
 
   // Docker is WEIRD
   // The SIGTERM signal sent to `docker run...` DOES propagate a signal to the
@@ -273,35 +259,6 @@ Future<void> main(List<String> args) async {
   }
 
   await subscription.cancel();
-}
-
-void _logWriter(log.LogRecord record) {
-  var wroteHeader = false;
-
-  final output = <String>[];
-  final prefix = '${record.time} ${record.level.name}:';
-  final emptyPrefix = ' ' * prefix.length;
-  void printLinesWithPrefix(String lines) {
-    for (final line in lines.split('\n')) {
-      final currentPrefix = wroteHeader ? emptyPrefix : prefix;
-      output.add('$currentPrefix $line');
-      wroteHeader = true;
-    }
-  }
-
-  printLinesWithPrefix(record.message);
-  final e = record.error;
-  if (e != null) {
-    printLinesWithPrefix(e.toString());
-    final st = record.stackTrace;
-    if (st != null) {
-      printLinesWithPrefix(st.toString());
-    }
-  }
-
-  overrideAnsiOutput(stderr.supportsAnsiEscapes, () {
-    stderr.writeln(darkGray.wrap(output.join('\n')));
-  });
 }
 
 /// A merged stream of all signals that tell the test runner to shut down

--- a/lib/src/logging.dart
+++ b/lib/src/logging.dart
@@ -3,7 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
 
+import 'package:io/ansi.dart';
 import 'package:logging/logging.dart';
 
 final Logger _log = Logger('pana');
@@ -16,3 +19,50 @@ Future<R> withLogger<R>(Future<R> Function() fn, {Logger? logger}) => runZoned(
     );
 
 Logger get log => (Zone.current[_key] as Logger?) ?? _log;
+
+void initializePanaLogging({bool isJson = false}) {
+  if (isJson) {
+    Logger.root.onRecord.listen((log) {
+      final map = {
+        if (log.loggerName.isNotEmpty) 'logName': log.loggerName,
+        'level': log.level.name,
+        'message': log.message,
+        if (log.error != null) 'error': log.error.toString(),
+        if (log.stackTrace != null) 'stackTrace': log.stackTrace.toString(),
+      };
+
+      stderr.writeln(json.encode(map));
+    });
+  } else {
+    Logger.root.onRecord.listen(_logWriter);
+  }
+}
+
+void _logWriter(LogRecord record) {
+  var wroteHeader = false;
+
+  final output = <String>[];
+  final prefix = '${record.time} ${record.level.name}:';
+  final emptyPrefix = ' ' * prefix.length;
+  void printLinesWithPrefix(String lines) {
+    for (final line in lines.split('\n')) {
+      final currentPrefix = wroteHeader ? emptyPrefix : prefix;
+      output.add('$currentPrefix $line');
+      wroteHeader = true;
+    }
+  }
+
+  printLinesWithPrefix(record.message);
+  final e = record.error;
+  if (e != null) {
+    printLinesWithPrefix(e.toString());
+    final st = record.stackTrace;
+    if (st != null) {
+      printLinesWithPrefix(st.toString());
+    }
+  }
+
+  overrideAnsiOutput(stderr.supportsAnsiEscapes, () {
+    stderr.writeln(darkGray.wrap(output.join('\n')));
+  });
+}


### PR DESCRIPTION
The new format is the combination of the current one (which blanks out the prefix on repeated lines) and `pub-dev`'s worker format (which adds a timestamp in the prefix. It also makes the json logging simpler. The code refactor is in the second commit.

This is a less-important, but still required step before the pub worker can invoke the `pana` process without depending on it (while keeping the log format). As the next step, while the `pub_worker` still depends on `pana` as a library, it may use the separate method to initialize the logging.