### PR TITLE
Move PanaCache out of ToolEnvironment (also from public API), adding in InspectOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Updated dependency: `tar: ^2.0.0`.
 - New text logging format.
+- *Breaking change:* Removed `ToolEnvironment.panaCache` field (not intended for public API).
 
 ## 0.22.7
 

--- a/bin/pana.dart
+++ b/bin/pana.dart
@@ -171,7 +171,6 @@ Future<void> main(List<String> args) async {
     final pubHostedUrl = result['hosted-url'] as String?;
     final analyzer = PackageAnalyzer(await ToolEnvironment.create(
       pubCacheDir: pubCacheDir,
-      panaCacheDir: Platform.environment['PANA_CACHE'],
       dartSdkConfig: SdkConfig(
         rootPath: result['dart-sdk'] as String?,
         configHomePath: result['dart-config-home'] as String?,
@@ -185,6 +184,7 @@ Future<void> main(List<String> args) async {
     ));
     final options = InspectOptions(
       pubHostedUrl: pubHostedUrl,
+      panaCacheDir: Platform.environment['PANA_CACHE'],
       lineLength: int.tryParse(result['line-length'] as String? ?? ''),
       dartdocOutputDir: runDartdoc ? dartdocOutputDir : null,
       resourcesOutputDir: resourcesOutputDir,

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -29,6 +29,9 @@ class InspectOptions {
   /// The PUB_HOSTED_URL to use for the package download and dependency analysis.
   final String? pubHostedUrl;
 
+  /// The cache directory for cross-analysis (shared) pana results.
+  final String? panaCacheDir;
+
   /// The output directory to copy the generated docs. When not specified,
   /// the generated docs will be discarded.
   final String? dartdocOutputDir;
@@ -54,6 +57,7 @@ class InspectOptions {
 
   InspectOptions({
     this.pubHostedUrl,
+    this.panaCacheDir,
     this.dartdocOutputDir,
     this.resourcesOutputDir,
     this.totalTimeout,

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -15,7 +15,6 @@ import 'internal_model.dart';
 import 'logging.dart';
 import 'model.dart' show PanaRuntimeInfo;
 import 'package_analyzer.dart' show InspectOptions;
-import 'pana_cache.dart';
 import 'tool/flutter_tool.dart';
 import 'tool/run_constrained.dart';
 import 'utils.dart';
@@ -75,7 +74,6 @@ class SdkConfig {
 
 class ToolEnvironment {
   final String? pubCacheDir;
-  final PanaCache panaCache;
   final _DartSdk _dartSdk;
   final _FlutterSdk _flutterSdk;
   PanaRuntimeInfo? _runtimeInfo;
@@ -85,7 +83,6 @@ class ToolEnvironment {
 
   ToolEnvironment._(
     this.pubCacheDir,
-    this.panaCache,
     this._dartSdk,
     this._flutterSdk,
     this._dartdocVersion,
@@ -93,11 +90,9 @@ class ToolEnvironment {
 
   ToolEnvironment.fake({
     this.pubCacheDir,
-    PanaCache? panaCache,
     Map<String, String> environment = const <String, String>{},
     required PanaRuntimeInfo runtimeInfo,
-  })  : panaCache = panaCache ?? PanaCache(),
-        _dartSdk = _DartSdk._(SdkConfig(environment: environment)),
+  })  : _dartSdk = _DartSdk._(SdkConfig(environment: environment)),
         _flutterSdk = _FlutterSdk._(SdkConfig(environment: environment),
             _DartSdk._(SdkConfig(environment: environment))),
         _dartdocVersion = null,
@@ -129,7 +124,7 @@ class ToolEnvironment {
     SdkConfig? dartSdkConfig,
     SdkConfig? flutterSdkConfig,
     String? pubCacheDir,
-    String? panaCacheDir,
+    @Deprecated('parameter no longer used') String? panaCacheDir,
     String? pubHostedUrl,
 
     /// When specified, this version of `dartdoc` will be initialized
@@ -142,7 +137,6 @@ class ToolEnvironment {
     dartSdkConfig ??= SdkConfig(rootPath: cli.getSdkPath());
     flutterSdkConfig ??= SdkConfig();
     final resolvedPubCache = await _resolve(pubCacheDir);
-    final resolvedPanaCache = await _resolve(panaCacheDir);
 
     final origPubEnvValue = Platform.environment[_pubEnvironmentKey] ?? '';
     final origPubEnvValues = origPubEnvValue
@@ -170,7 +164,6 @@ class ToolEnvironment {
 
     final toolEnv = ToolEnvironment._(
       resolvedPubCache,
-      PanaCache(path: resolvedPanaCache),
       await _DartSdk.detect(dartSdkConfig, env),
       flutterSdk,
       dartdocVersion,

--- a/test/end2end_test.dart
+++ b/test/end2end_test.dart
@@ -53,7 +53,6 @@ void main() {
           dartSdkConfig: SdkConfig(configHomePath: dartConfigDir),
           flutterSdkConfig: SdkConfig(configHomePath: flutterConfigDir),
           pubCacheDir: pubCacheDir,
-          panaCacheDir: panaCacheDir,
           pubHostedUrl: 'http://127.0.0.1:${httpServer.port}',
           dartdocVersion: 'any',
         ));
@@ -66,6 +65,7 @@ void main() {
           version: version,
           options: InspectOptions(
             pubHostedUrl: 'http://127.0.0.1:${httpServer.port}',
+            panaCacheDir: panaCacheDir,
             dartdocOutputDir: skipDartdoc ? null : dartdocOutputDir,
           ),
         );


### PR DESCRIPTION
- Removing the `panaCache` field from `ToolEnvironment` is breaking change, but I don't expect anybody using it, esp. because (a) it was not documented and (b) the `PanaCache` class is not exposed in the API.
- `InspectOptions` is a better place for specifying its value (if there is any shared cache between analysis sessions).

Note: `SharedAnalysisContext` is not a public API, we may use it there without any issues.