### PR TITLE
Migrating Summary.licenseFile and Summary.licenses to AnalysisResult.licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Updated dependency: `tar: ^2.0.0`.
 - New text logging format.
+- Migrating `Summary.licenseFile` and `Summary.licenses` to `AnalysisResult.licenses`.
 - *Breaking change:* Removed `ToolEnvironment.panaCache` field (not intended for public API).
 
 ## 0.22.7

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -51,7 +51,9 @@ class Summary {
   final String? packageName;
   final Version? packageVersion;
   final Pubspec? pubspec;
+  @Deprecated('Use `result.licenses` instead.')
   final LicenseFile? licenseFile;
+  @Deprecated('Use `result.licenses` instead.')
   final List<License>? licenses;
 
   /// The packages that are either direct-, dev- or transient dependencies.
@@ -160,6 +162,8 @@ class PanaRuntimeInfo {
 @JsonSerializable()
 class License {
   /// The file path that was recognized as a license.
+  @Deprecated(
+      'The field will be removed, as we only accept `LICENSE` as filename.')
   final String path;
 
   /// The SPDX identifier of the license.
@@ -177,6 +181,7 @@ class License {
 }
 
 @JsonSerializable()
+@Deprecated('The class will be removed.')
 class LicenseFile {
   final String path;
   final String name;
@@ -207,6 +212,7 @@ class LicenseFile {
   int get hashCode => path.hashCode ^ name.hashCode ^ version.hashCode;
 }
 
+@Deprecated('The class will be removed.')
 abstract class LicenseNames {
   static const String agpl = 'AGPL';
   static const String apache = 'Apache';
@@ -327,6 +333,7 @@ class AnalysisResult {
   final List<String>? fundingUrls;
   final Repository? repository;
   final String? contributingUrl;
+  final List<License>? licenses;
   final int? grantedPoints;
   final int? maxPoints;
 
@@ -338,6 +345,7 @@ class AnalysisResult {
     this.fundingUrls,
     this.repository,
     this.contributingUrl,
+    this.licenses,
     this.grantedPoints,
     this.maxPoints,
   });

--- a/lib/src/model.g.dart
+++ b/lib/src/model.g.dart
@@ -201,6 +201,9 @@ AnalysisResult _$AnalysisResultFromJson(Map<String, dynamic> json) =>
           ? null
           : Repository.fromJson(json['repository'] as Map<String, dynamic>),
       contributingUrl: json['contributingUrl'] as String?,
+      licenses: (json['licenses'] as List<dynamic>?)
+          ?.map((e) => License.fromJson(e as Map<String, dynamic>))
+          .toList(),
       grantedPoints: (json['grantedPoints'] as num?)?.toInt(),
       maxPoints: (json['maxPoints'] as num?)?.toInt(),
     );
@@ -221,6 +224,7 @@ Map<String, dynamic> _$AnalysisResultToJson(AnalysisResult instance) {
   writeNotNull('fundingUrls', instance.fundingUrls);
   writeNotNull('repository', instance.repository?.toJson());
   writeNotNull('contributingUrl', instance.contributingUrl);
+  writeNotNull('licenses', instance.licenses?.map((e) => e.toJson()).toList());
   writeNotNull('grantedPoints', instance.grantedPoints);
   writeNotNull('maxPoints', instance.maxPoints);
   return val;

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -307,6 +307,7 @@ Future<AnalysisResult> _createAnalysisResult(
     fundingUrls: fundingUrls.isEmpty ? null : fundingUrls,
     repository: repository,
     contributingUrl: repoVerification?.contributingUrl,
+    licenses: await context.licenses,
     grantedPoints: report.grantedPoints,
     maxPoints: report.maxPoints,
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   html: ^0.15.0
   http: ^1.0.0
   io: ^1.0.0
-  json_annotation: ^4.8.1
+  json_annotation: ^4.9.0
   lints: ^4.0.0
   logging: ^1.0.0
   markdown: ^7.0.0

--- a/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
+++ b/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
@@ -80,6 +80,12 @@
   "screenshots": [],
   "result": {
     "homepageUrl": "https://github.com/dart-lang/pub-dev",
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "BSD-3-Clause"
+      }
+    ],
     "grantedPoints": 25,
     "maxPoints": 160
   },

--- a/test/goldens/end2end/async-2.11.0.json
+++ b/test/goldens/end2end/async-2.11.0.json
@@ -118,6 +118,12 @@
       "branch": "master"
     },
     "contributingUrl": "https://github.com/dart-lang/async/blob/master/CONTRIBUTING.md",
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "BSD-3-Clause"
+      }
+    ],
     "grantedPoints": 150,
     "maxPoints": 160
   },

--- a/test/goldens/end2end/audio_service-0.18.10.json
+++ b/test/goldens/end2end/audio_service-0.18.10.json
@@ -187,6 +187,12 @@
       "path": "audio_service"
     },
     "contributingUrl": "https://github.com/ryanheise/audio_service/blob/minor/CONTRIBUTING.md",
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "MIT"
+      }
+    ],
     "grantedPoints": 140,
     "maxPoints": 150
   },

--- a/test/goldens/end2end/bulma_min-0.7.4.json
+++ b/test/goldens/end2end/bulma_min-0.7.4.json
@@ -88,6 +88,12 @@
       "repository": "agilord/bulma_min",
       "branch": "master"
     },
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "MIT"
+      }
+    ],
     "grantedPoints": 30,
     "maxPoints": 150
   },

--- a/test/goldens/end2end/dnd-2.0.1.json
+++ b/test/goldens/end2end/dnd-2.0.1.json
@@ -102,6 +102,12 @@
       "repository": "marcojakob/dart-dnd",
       "branch": "master"
     },
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "MIT"
+      }
+    ],
     "grantedPoints": 140,
     "maxPoints": 160
   },

--- a/test/goldens/end2end/gg-1.0.12.json
+++ b/test/goldens/end2end/gg-1.0.12.json
@@ -177,6 +177,12 @@
       "repository": "inlavigo/gg",
       "branch": "main"
     },
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "MIT"
+      }
+    ],
     "grantedPoints": 120,
     "maxPoints": 150
   },

--- a/test/goldens/end2end/http-0.13.0.json
+++ b/test/goldens/end2end/http-0.13.0.json
@@ -124,6 +124,12 @@
       "path": "pkgs/http"
     },
     "contributingUrl": "https://github.com/dart-lang/http/blob/master/CONTRIBUTING.md",
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "BSD-3-Clause"
+      }
+    ],
     "grantedPoints": 140,
     "maxPoints": 150
   },

--- a/test/goldens/end2end/lints-1.0.0.json
+++ b/test/goldens/end2end/lints-1.0.0.json
@@ -91,6 +91,12 @@
   },
   "screenshots": [],
   "result": {
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "BSD-3-Clause"
+      }
+    ],
     "grantedPoints": 130,
     "maxPoints": 150
   },

--- a/test/goldens/end2end/mime_type-0.3.2.json
+++ b/test/goldens/end2end/mime_type-0.3.2.json
@@ -81,6 +81,7 @@
       "repository": "mitsuoka/mime_type",
       "branch": "master"
     },
+    "licenses": [],
     "grantedPoints": 5,
     "maxPoints": 150
   },

--- a/test/goldens/end2end/nsd_android-1.2.2.json
+++ b/test/goldens/end2end/nsd_android-1.2.2.json
@@ -118,6 +118,12 @@
       "branch": "main",
       "path": "nsd_android"
     },
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "MIT"
+      }
+    ],
     "grantedPoints": 140,
     "maxPoints": 150
   },

--- a/test/goldens/end2end/onepub-1.1.0.json
+++ b/test/goldens/end2end/onepub-1.1.0.json
@@ -172,6 +172,12 @@
   "screenshots": [],
   "result": {
     "homepageUrl": "https://github.com/noojee/onepub.dev",
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "unknown"
+      }
+    ],
     "grantedPoints": 120,
     "maxPoints": 160
   },

--- a/test/goldens/end2end/sdp_transform-0.2.0.json
+++ b/test/goldens/end2end/sdp_transform-0.2.0.json
@@ -97,6 +97,12 @@
       "repository": "cloudwebrtc/dart-sdp-transform",
       "branch": "master"
     },
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "MIT"
+      }
+    ],
     "grantedPoints": 40,
     "maxPoints": 150
   },

--- a/test/goldens/end2end/skiplist-0.1.0.json
+++ b/test/goldens/end2end/skiplist-0.1.0.json
@@ -94,6 +94,12 @@
       "repository": "stevenroose/dart-skiplist",
       "branch": "master"
     },
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "MIT"
+      }
+    ],
     "grantedPoints": 20,
     "maxPoints": 150
   },

--- a/test/goldens/end2end/steward-0.3.1.json
+++ b/test/goldens/end2end/steward-0.3.1.json
@@ -127,6 +127,12 @@
       "branch": "main"
     },
     "contributingUrl": "https://github.com/pyrestudios/steward/blob/main/CONTRIBUTING.md",
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "MIT"
+      }
+    ],
     "grantedPoints": 130,
     "maxPoints": 150
   },

--- a/test/goldens/end2end/url_launcher-6.1.12.json
+++ b/test/goldens/end2end/url_launcher-6.1.12.json
@@ -165,6 +165,12 @@
       "path": "packages/url_launcher/url_launcher"
     },
     "contributingUrl": "https://github.com/flutter/packages/blob/main/CONTRIBUTING.md",
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "BSD-3-Clause"
+      }
+    ],
     "grantedPoints": 160,
     "maxPoints": 160
   },

--- a/test/goldens/end2end/webdriver-3.0.0.json
+++ b/test/goldens/end2end/webdriver-3.0.0.json
@@ -121,6 +121,12 @@
       "branch": "master"
     },
     "contributingUrl": "https://github.com/google/webdriver.dart/blob/master/CONTRIBUTING.md",
+    "licenses": [
+      {
+        "path": "LICENSE",
+        "spdxIdentifier": "Apache-2.0"
+      }
+    ],
     "grantedPoints": 100,
     "maxPoints": 150
   },


### PR DESCRIPTION
- Deprecated classes and fields that will become obsolete.
- Added new `licenses` field to `AnalysisResult`.
- The change is an overdue migration that also cleans up a half-migration of `LicenseFile`.
- I've considered to use another class name instead of reusing `License`, but the name seems to be fit, and its migration would be too complicated. We just won't need to remove the `path` field, and we may add confidence classification or score later to it. (An upcoming breaking change should clean up these loose threads.)