### PR TITLE
Mark renderSimpleSectionSummary as deprecated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.22.9
 
 - Updated suggestion for packages depending on SDK `_macros`.
+- Deprecated the `renderSimpleSectionSummary` method in public API.
 
 ## 0.22.8
 

--- a/lib/src/report/_common.dart
+++ b/lib/src/report/_common.dart
@@ -150,6 +150,7 @@ String? _reportStatusMarker(ReportStatus status) => const {
     }[status];
 
 /// Renders a summary block for sections that can have only a single issue.
+@Deprecated('Do not use this API, it will be removed.')
 String renderSimpleSectionSummary({
   required String title,
   required String? description,


### PR DESCRIPTION
https://github.com/dart-lang/pub-dev/pull/7871