### PR TITLE
Detect library hrefs with or without ending slash.

### DIFF
--- a/lib/src/dartdoc/dartdoc_internals.dart
+++ b/lib/src/dartdoc/dartdoc_internals.dart
@@ -17,6 +17,7 @@ bool isHrefALibrary(String? href) {
   if (href.endsWith('.html')) {
     return false;
   }
-  // libraries have no slash in their hrefs
-  return !href.contains('/');
+  final segments = href.split('/').where((s) => s.isNotEmpty).toList();
+  // libraries have only a single segment
+  return segments.length == 1;
 }

--- a/lib/src/dartdoc/dartdoc_internals.dart
+++ b/lib/src/dartdoc/dartdoc_internals.dart
@@ -17,7 +17,11 @@ bool isHrefALibrary(String? href) {
   if (href.endsWith('.html')) {
     return false;
   }
-  final segments = href.split('/').where((s) => s.isNotEmpty).toList();
+  final segments = href.split('/');
+  // remove if the last segment is empty, indicating a trailing slash
+  if (segments.last.isEmpty) {
+    segments.removeLast();
+  }
   // libraries have only a single segment
   return segments.length == 1;
 }

--- a/test/dartdoc/dartdoc_internals_test.dart
+++ b/test/dartdoc/dartdoc_internals_test.dart
@@ -1,0 +1,25 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pana/src/dartdoc/dartdoc_internals.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('dartdoc internals', () {
+    test('isHrefALibrary: negative', () async {
+      expect(isHrefALibrary(null), false);
+      expect(isHrefALibrary(''), false);
+      expect(isHrefALibrary('index.html'), false);
+      expect(isHrefALibrary('retry.html'), false);
+      expect(isHrefALibrary('retry/retry.html'), false);
+      expect(isHrefALibrary('a/b'), false);
+    });
+
+    test('isHrefALibrary: positive', () async {
+      expect(isHrefALibrary('x/x-library.html'), true);
+      expect(isHrefALibrary('x'), true);
+      expect(isHrefALibrary('x/'), true);
+    });
+  });
+}


### PR DESCRIPTION
This is assuming that the new href URLs in dartdoc will get an ending slash: https://github.com/dart-lang/dartdoc/issues/3936