### PR TITLE
Make example's README.md priority over any dart file in the examples directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.22.18-dev
+
+- Make example's `README.md` priority over any dart file in the examples directory.
+
 ## 0.22.17
 
 - Fixed lower dependency constraint for `cli_util`.

--- a/lib/src/maintenance.dart
+++ b/lib/src/maintenance.dart
@@ -7,6 +7,7 @@ import 'package:json_annotation/json_annotation.dart';
 /// Returns the candidates in priority order to display under the 'Example' tab.
 List<String> exampleFileCandidates(String package) {
   return <String>[
+    'example/README.md',
     'example/example.md',
     'example/lib/main.dart',
     'example/bin/main.dart',
@@ -20,7 +21,6 @@ List<String> exampleFileCandidates(String package) {
     'example/lib/example.dart',
     'example/bin/example.dart',
     'example/example.dart',
-    'example/README.md',
   ];
 }
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.22.17';
+const packageVersion = '0.22.18-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.22.17
+version: 0.22.18-dev
 repository: https://github.com/dart-lang/pana
 topics:
   - tool


### PR DESCRIPTION
- https://github.com/dart-lang/pub-dev/issues/8436
- https://dart.dev/tools/pub/package-layout#examples says that "if your package has many files under its example directory, including a file named README.md, then your package's Example tab displays the contents of example/README.md", which means we should bump the README.md to the top of that list.