### PR TITLE
Expose more precise repository verification status in 'AnalysisResult'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.22.18-dev
 
 - Make example's `README.md` priority over any dart file in the examples directory.
+- Expose more precise repository verification status in `AnalysisResult`.
 
 ## 0.22.17
 

--- a/lib/src/internal_model.dart
+++ b/lib/src/internal_model.dart
@@ -214,11 +214,13 @@ class UrlStatus {
 
 @JsonSerializable(includeIfNull: false, explicitToJson: true)
 class VerifiedRepository {
+  final RepositoryStatus status;
   final Repository? repository;
   final String? contributingUrl;
   final String? verificationFailure;
 
   VerifiedRepository({
+    required this.status,
     this.repository,
     this.contributingUrl,
     this.verificationFailure,

--- a/lib/src/internal_model.g.dart
+++ b/lib/src/internal_model.g.dart
@@ -84,6 +84,7 @@ Map<String, dynamic> _$UrlStatusToJson(UrlStatus instance) => <String, dynamic>{
 
 VerifiedRepository _$VerifiedRepositoryFromJson(Map<String, dynamic> json) =>
     VerifiedRepository(
+      status: $enumDecode(_$RepositoryStatusEnumMap, json['status']),
       repository: json['repository'] == null
           ? null
           : Repository.fromJson(json['repository'] as Map<String, dynamic>),
@@ -93,8 +94,18 @@ VerifiedRepository _$VerifiedRepositoryFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$VerifiedRepositoryToJson(VerifiedRepository instance) =>
     <String, dynamic>{
+      'status': _$RepositoryStatusEnumMap[instance.status]!,
       if (instance.repository?.toJson() case final value?) 'repository': value,
       if (instance.contributingUrl case final value?) 'contributingUrl': value,
       if (instance.verificationFailure case final value?)
         'verificationFailure': value,
     };
+
+const _$RepositoryStatusEnumMap = {
+  RepositoryStatus.unspecified: 'unspecified',
+  RepositoryStatus.invalid: 'invalid',
+  RepositoryStatus.missing: 'missing',
+  RepositoryStatus.failed: 'failed',
+  RepositoryStatus.verified: 'verified',
+  RepositoryStatus.inconclusive: 'inconclusive',
+};

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -331,6 +331,7 @@ class AnalysisResult {
   final String? issueTrackerUrl;
   final String? documentationUrl;
   final List<String>? fundingUrls;
+  final RepositoryStatus? repositoryStatus;
   final Repository? repository;
   final String? contributingUrl;
   final List<License>? licenses;
@@ -343,6 +344,7 @@ class AnalysisResult {
     this.issueTrackerUrl,
     this.documentationUrl,
     this.fundingUrls,
+    this.repositoryStatus,
     this.repository,
     this.contributingUrl,
     this.licenses,
@@ -354,6 +356,36 @@ class AnalysisResult {
       _$AnalysisResultFromJson(json);
 
   Map<String, dynamic> toJson() => _$AnalysisResultToJson(this);
+}
+
+/// The status of the repository verification.
+enum RepositoryStatus {
+  /// The repository URL was not specified, empty, or we were not able to
+  /// infer it (e.g. from `homepage`).
+  ///
+  /// No verification was done.
+  unspecified,
+
+  /// The specified URL was not a valid or secure URL.
+  ///
+  /// No verification was done.
+  invalid,
+
+  /// There was no repository found on the specified URL.
+  /// The issue may be transient, a repeated access may find it.
+  ///
+  /// No verification was done.
+  missing,
+
+  /// The repository did not pass verification tests.
+  failed,
+
+  /// The repository passed verification tests.
+  verified,
+
+  /// The repository verification encountered a failure, result is
+  /// not conclusive.
+  inconclusive;
 }
 
 /// NOTE: the content of the class is experimental, clients should not rely on it yet.

--- a/lib/src/model.g.dart
+++ b/lib/src/model.g.dart
@@ -176,6 +176,8 @@ AnalysisResult _$AnalysisResultFromJson(Map<String, dynamic> json) =>
       fundingUrls: (json['fundingUrls'] as List<dynamic>?)
           ?.map((e) => e as String)
           .toList(),
+      repositoryStatus: $enumDecodeNullable(
+          _$RepositoryStatusEnumMap, json['repositoryStatus']),
       repository: json['repository'] == null
           ? null
           : Repository.fromJson(json['repository'] as Map<String, dynamic>),
@@ -195,6 +197,9 @@ Map<String, dynamic> _$AnalysisResultToJson(AnalysisResult instance) =>
       if (instance.documentationUrl case final value?)
         'documentationUrl': value,
       if (instance.fundingUrls case final value?) 'fundingUrls': value,
+      if (_$RepositoryStatusEnumMap[instance.repositoryStatus]
+          case final value?)
+        'repositoryStatus': value,
       if (instance.repository?.toJson() case final value?) 'repository': value,
       if (instance.contributingUrl case final value?) 'contributingUrl': value,
       if (instance.licenses?.map((e) => e.toJson()).toList() case final value?)
@@ -202,6 +207,15 @@ Map<String, dynamic> _$AnalysisResultToJson(AnalysisResult instance) =>
       if (instance.grantedPoints case final value?) 'grantedPoints': value,
       if (instance.maxPoints case final value?) 'maxPoints': value,
     };
+
+const _$RepositoryStatusEnumMap = {
+  RepositoryStatus.unspecified: 'unspecified',
+  RepositoryStatus.invalid: 'invalid',
+  RepositoryStatus.missing: 'missing',
+  RepositoryStatus.failed: 'failed',
+  RepositoryStatus.verified: 'verified',
+  RepositoryStatus.inconclusive: 'inconclusive',
+};
 
 Repository _$RepositoryFromJson(Map<String, dynamic> json) => Repository(
       provider:

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -258,7 +258,7 @@ Future<AnalysisResult> _createAnalysisResult(
     PackageContext context, Report report) async {
   final pubspecUrls = await context.pubspecUrlsWithIssues;
   final repoVerification = await context.repository;
-  final repository = repoVerification?.repository;
+  final repository = repoVerification.repository;
   final fundingUrls =
       pubspecUrls.funding.map((e) => e.verifiedUrl).nonNulls.toList();
   return AnalysisResult(
@@ -267,8 +267,9 @@ Future<AnalysisResult> _createAnalysisResult(
     issueTrackerUrl: pubspecUrls.issueTracker.verifiedUrl,
     documentationUrl: pubspecUrls.documentation.verifiedUrl,
     fundingUrls: fundingUrls.isEmpty ? null : fundingUrls,
+    repositoryStatus: repoVerification.status,
     repository: repository,
-    contributingUrl: repoVerification?.contributingUrl,
+    contributingUrl: repoVerification.contributingUrl,
     licenses: await context.licenses,
     grantedPoints: report.grantedPoints,
     maxPoints: report.maxPoints,

--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -16,6 +16,7 @@ import 'internal_model.dart';
 import 'license.dart';
 import 'logging.dart';
 import 'messages.dart' as messages;
+import 'model.dart';
 import 'package_analyzer.dart' show InspectOptions;
 import 'pana_cache.dart';
 import 'pkg_resolution.dart';
@@ -61,12 +62,16 @@ class SharedAnalysisContext {
     return status;
   }
 
-  Future<VerifiedRepository?> verifyRepository(
+  Future<VerifiedRepository> verifyRepository(
     String package,
     String? repositoryOrHomepage,
   ) async {
-    if (repositoryOrHomepage == null) {
-      return null;
+    repositoryOrHomepage = repositoryOrHomepage?.trim();
+    if (repositoryOrHomepage == null || repositoryOrHomepage.isEmpty) {
+      return VerifiedRepository(
+        status: RepositoryStatus.unspecified,
+        verificationFailure: 'Repository URL is missing.',
+      );
     }
     final cacheType = 'repository';
     final cacheKey = '$package/$repositoryOrHomepage';
@@ -79,9 +84,7 @@ class SharedAnalysisContext {
       packageName: package,
       sourceUrl: repositoryOrHomepage,
     );
-    if (repository != null) {
-      await panaCache.writeData(cacheType, cacheKey, repository.toJson());
-    }
+    await panaCache.writeData(cacheType, cacheKey, repository.toJson());
     return repository;
   }
 }

--- a/lib/src/references/pubspec_urls.dart
+++ b/lib/src/references/pubspec_urls.dart
@@ -57,7 +57,8 @@ Future<PubspecUrlsWithIssues> checkPubspecUrls(PackageContext context) async {
   // Switch homepage and repository if only homepage is given,
   // and it can be verified as a valid repository.
   final verifiedRepository = await context.repository;
-  final isVerifiedRepository = verifiedRepository?.repository != null;
+  final status = verifiedRepository.status;
+  final isVerifiedRepository = status == RepositoryStatus.verified;
   // We should switch these values if the repository has been verified.
   if (isVerifiedRepository &&
       pubspec.homepage != null &&
@@ -69,7 +70,7 @@ Future<PubspecUrlsWithIssues> checkPubspecUrls(PackageContext context) async {
 
   // Set known issue tracker link in cases where it was not provided.
   if (pubspec.issueTracker == null && isVerifiedRepository) {
-    final vr = verifiedRepository!.repository!;
+    final vr = verifiedRepository.repository!;
     final repoSegments = vr.repository;
     if (RepositoryProvider.isGitHubCompatible(vr.provider) &&
         repoSegments != null) {

--- a/lib/src/report/template.dart
+++ b/lib/src/report/template.dart
@@ -171,9 +171,7 @@ Future<ReportSection> followsTemplate(PackageContext context) async {
 
     final repository = await context.repository;
     final repositoryStatus = repository.status;
-    final repositoryFailed = repositoryStatus != RepositoryStatus.verified &&
-        repositoryStatus != RepositoryStatus.inconclusive;
-    if (repositoryFailed) {
+    if (repositoryStatus == RepositoryStatus.failed) {
       issues.add(Issue('Failed to verify repository URL.',
           suggestion:
               'Please provide a valid [`repository`](https://dart.dev/tools/pub/pubspec#repository) URL in `pubspec.yaml`, such that:\n\n'

--- a/lib/src/report/template.dart
+++ b/lib/src/report/template.dart
@@ -170,7 +170,10 @@ Future<ReportSection> followsTemplate(PackageContext context) async {
     issues.addAll(pubspecUrls.issues);
 
     final repository = await context.repository;
-    if (repository?.verificationFailure != null) {
+    final repositoryStatus = repository.status;
+    final repositoryFailed = repositoryStatus != RepositoryStatus.verified &&
+        repositoryStatus != RepositoryStatus.inconclusive;
+    if (repositoryFailed) {
       issues.add(Issue('Failed to verify repository URL.',
           suggestion:
               'Please provide a valid [`repository`](https://dart.dev/tools/pub/pubspec#repository) URL in `pubspec.yaml`, such that:\n\n'
@@ -179,7 +182,7 @@ Future<ReportSection> followsTemplate(PackageContext context) async {
               '    * contains `name: ${pubspec.name}`,\n'
               '    * contains a `version` property, and,\n'
               '    * does not contain a `publish_to` property.\n\n'
-              '${repository!.verificationFailure}'));
+              '${repository.verificationFailure ?? 'status: `${repositoryStatus.name}`'}'));
     }
 
     final executableFiles = await context.executablesInBinDirectory;
@@ -202,7 +205,7 @@ Future<ReportSection> followsTemplate(PackageContext context) async {
             issues.every((issue) =>
                 (issue.suggestion ?? '').contains('was unreachable')) &&
             // repository verification succeeded
-            repository?.repository != null;
+            repository.repository != null;
 
     final status = issues.isEmpty
         ? ReportStatus.passed

--- a/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
+++ b/test/goldens/end2end/_dummy_pkg-1.0.0-null-safety.1.json
@@ -80,6 +80,7 @@
   "screenshots": [],
   "result": {
     "homepageUrl": "https://github.com/dart-lang/pub-dev",
+    "repositoryStatus": "failed",
     "licenses": [
       {
         "path": "LICENSE",

--- a/test/goldens/end2end/async-2.11.0.json
+++ b/test/goldens/end2end/async-2.11.0.json
@@ -111,6 +111,7 @@
   "result": {
     "repositoryUrl": "https://github.com/dart-lang/async",
     "issueTrackerUrl": "https://github.com/dart-lang/async/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/audio_service-0.18.15.json
+++ b/test/goldens/end2end/audio_service-0.18.15.json
@@ -188,6 +188,7 @@
   "result": {
     "repositoryUrl": "https://github.com/ryanheise/audio_service/tree/minor/audio_service",
     "issueTrackerUrl": "https://github.com/ryanheise/audio_service/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/bulma_min-0.7.4.json
+++ b/test/goldens/end2end/bulma_min-0.7.4.json
@@ -82,6 +82,7 @@
   "result": {
     "repositoryUrl": "https://github.com/agilord/bulma_min",
     "issueTrackerUrl": "https://github.com/agilord/bulma_min/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/dnd-2.0.1.json
+++ b/test/goldens/end2end/dnd-2.0.1.json
@@ -96,6 +96,7 @@
     "homepageUrl": "https://code.makery.ch/library/dart-drag-and-drop/",
     "repositoryUrl": "https://github.com/marcojakob/dart-dnd",
     "issueTrackerUrl": "https://github.com/marcojakob/dart-dnd/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/gg-1.0.12.json
+++ b/test/goldens/end2end/gg-1.0.12.json
@@ -171,6 +171,7 @@
   "result": {
     "repositoryUrl": "https://github.com/inlavigo/gg.git",
     "issueTrackerUrl": "https://github.com/inlavigo/gg/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/http-0.13.0.json
+++ b/test/goldens/end2end/http-0.13.0.json
@@ -116,6 +116,7 @@
   "result": {
     "repositoryUrl": "https://github.com/dart-lang/http",
     "issueTrackerUrl": "https://github.com/dart-lang/http/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/lints-1.0.0.json
+++ b/test/goldens/end2end/lints-1.0.0.json
@@ -53,7 +53,7 @@
         "grantedPoints": 20,
         "maxPoints": 30,
         "status": "failed",
-        "summary": "### [x] 0/10 points: Provide a valid `pubspec.yaml`\n\n* `pubspec.yaml` doesn't have a `homepage` entry.\n\n* `pubspec.yaml` doesn't have a `repository` entry.\n\n<details>\n<summary>\nFailed to verify repository URL.\n</summary>\n\nPlease provide a valid [`repository`](https://dart.dev/tools/pub/pubspec#repository) URL in `pubspec.yaml`, such that:\n\n * `repository` can be cloned,\n * a clone of the repository contains a `pubspec.yaml`, which:,\n    * contains `name: lints`,\n    * contains a `version` property, and,\n    * does not contain a `publish_to` property.\n\nRepository URL is missing.\n</details>\n\n### [*] 5/5 points: Provide a valid `README.md`\n\n### [*] 5/5 points: Provide a valid `CHANGELOG.md`\n\n### [*] 10/10 points: Use an OSI-approved license\n\nDetected license: `BSD-3-Clause`.\n"
+        "summary": "### [x] 0/10 points: Provide a valid `pubspec.yaml`\n\n* `pubspec.yaml` doesn't have a `homepage` entry.\n\n* `pubspec.yaml` doesn't have a `repository` entry.\n\n### [*] 5/5 points: Provide a valid `README.md`\n\n### [*] 5/5 points: Provide a valid `CHANGELOG.md`\n\n### [*] 10/10 points: Use an OSI-approved license\n\nDetected license: `BSD-3-Clause`.\n"
       },
       {
         "id": "documentation",

--- a/test/goldens/end2end/lints-1.0.0.json
+++ b/test/goldens/end2end/lints-1.0.0.json
@@ -53,7 +53,7 @@
         "grantedPoints": 20,
         "maxPoints": 30,
         "status": "failed",
-        "summary": "### [x] 0/10 points: Provide a valid `pubspec.yaml`\n\n* `pubspec.yaml` doesn't have a `homepage` entry.\n\n* `pubspec.yaml` doesn't have a `repository` entry.\n\n### [*] 5/5 points: Provide a valid `README.md`\n\n### [*] 5/5 points: Provide a valid `CHANGELOG.md`\n\n### [*] 10/10 points: Use an OSI-approved license\n\nDetected license: `BSD-3-Clause`.\n"
+        "summary": "### [x] 0/10 points: Provide a valid `pubspec.yaml`\n\n* `pubspec.yaml` doesn't have a `homepage` entry.\n\n* `pubspec.yaml` doesn't have a `repository` entry.\n\n<details>\n<summary>\nFailed to verify repository URL.\n</summary>\n\nPlease provide a valid [`repository`](https://dart.dev/tools/pub/pubspec#repository) URL in `pubspec.yaml`, such that:\n\n * `repository` can be cloned,\n * a clone of the repository contains a `pubspec.yaml`, which:,\n    * contains `name: lints`,\n    * contains a `version` property, and,\n    * does not contain a `publish_to` property.\n\nRepository URL is missing.\n</details>\n\n### [*] 5/5 points: Provide a valid `README.md`\n\n### [*] 5/5 points: Provide a valid `CHANGELOG.md`\n\n### [*] 10/10 points: Use an OSI-approved license\n\nDetected license: `BSD-3-Clause`.\n"
       },
       {
         "id": "documentation",
@@ -91,6 +91,7 @@
   },
   "screenshots": [],
   "result": {
+    "repositoryStatus": "unspecified",
     "licenses": [
       {
         "path": "LICENSE",

--- a/test/goldens/end2end/lints-1.0.0.json_report.md
+++ b/test/goldens/end2end/lints-1.0.0.json_report.md
@@ -6,6 +6,22 @@
 
 * `pubspec.yaml` doesn't have a `repository` entry.
 
+<details>
+<summary>
+Failed to verify repository URL.
+</summary>
+
+Please provide a valid [`repository`](https://dart.dev/tools/pub/pubspec#repository) URL in `pubspec.yaml`, such that:
+
+ * `repository` can be cloned,
+ * a clone of the repository contains a `pubspec.yaml`, which:,
+    * contains `name: lints`,
+    * contains a `version` property, and,
+    * does not contain a `publish_to` property.
+
+Repository URL is missing.
+</details>
+
 ### [*] 5/5 points: Provide a valid `README.md`
 
 ### [*] 5/5 points: Provide a valid `CHANGELOG.md`

--- a/test/goldens/end2end/lints-1.0.0.json_report.md
+++ b/test/goldens/end2end/lints-1.0.0.json_report.md
@@ -6,22 +6,6 @@
 
 * `pubspec.yaml` doesn't have a `repository` entry.
 
-<details>
-<summary>
-Failed to verify repository URL.
-</summary>
-
-Please provide a valid [`repository`](https://dart.dev/tools/pub/pubspec#repository) URL in `pubspec.yaml`, such that:
-
- * `repository` can be cloned,
- * a clone of the repository contains a `pubspec.yaml`, which:,
-    * contains `name: lints`,
-    * contains a `version` property, and,
-    * does not contain a `publish_to` property.
-
-Repository URL is missing.
-</details>
-
 ### [*] 5/5 points: Provide a valid `README.md`
 
 ### [*] 5/5 points: Provide a valid `CHANGELOG.md`

--- a/test/goldens/end2end/mime_type-0.3.2.json
+++ b/test/goldens/end2end/mime_type-0.3.2.json
@@ -75,6 +75,7 @@
   "result": {
     "repositoryUrl": "https://github.com/mitsuoka/mime_type",
     "issueTrackerUrl": "https://github.com/mitsuoka/mime_type/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/nsd_android-2.1.2.json
+++ b/test/goldens/end2end/nsd_android-2.1.2.json
@@ -111,6 +111,7 @@
   "result": {
     "repositoryUrl": "https://github.com/sebastianhaberey/nsd/tree/main/nsd_android",
     "issueTrackerUrl": "https://github.com/sebastianhaberey/nsd/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/onepub-1.1.0.json
+++ b/test/goldens/end2end/onepub-1.1.0.json
@@ -170,6 +170,7 @@
   "screenshots": [],
   "result": {
     "homepageUrl": "https://github.com/noojee/onepub.dev",
+    "repositoryStatus": "failed",
     "licenses": [
       {
         "path": "LICENSE",

--- a/test/goldens/end2end/sdp_transform-0.2.0.json
+++ b/test/goldens/end2end/sdp_transform-0.2.0.json
@@ -91,6 +91,7 @@
   "result": {
     "repositoryUrl": "https://github.com/cloudwebrtc/dart-sdp-transform",
     "issueTrackerUrl": "https://github.com/cloudwebrtc/dart-sdp-transform/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/skiplist-0.1.0.json
+++ b/test/goldens/end2end/skiplist-0.1.0.json
@@ -88,6 +88,7 @@
   "result": {
     "repositoryUrl": "https://github.com/stevenroose/dart-skiplist",
     "issueTrackerUrl": "https://github.com/stevenroose/dart-skiplist/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/steward-0.3.1.json
+++ b/test/goldens/end2end/steward-0.3.1.json
@@ -120,6 +120,7 @@
   "result": {
     "repositoryUrl": "https://www.github.com/pyrestudios/steward",
     "issueTrackerUrl": "https://github.com/pyrestudios/steward/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/url_launcher-6.3.1.json
+++ b/test/goldens/end2end/url_launcher-6.3.1.json
@@ -167,6 +167,7 @@
   "screenshots": [],
   "result": {
     "repositoryUrl": "https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",

--- a/test/goldens/end2end/webdriver-3.0.0.json
+++ b/test/goldens/end2end/webdriver-3.0.0.json
@@ -114,6 +114,7 @@
   "result": {
     "repositoryUrl": "https://github.com/google/webdriver.dart",
     "issueTrackerUrl": "https://github.com/google/webdriver.dart/issues",
+    "repositoryStatus": "verified",
     "repository": {
       "provider": "github",
       "host": "github.com",


### PR DESCRIPTION
- #1403
- I think we may have a path to introduce stricter checks without breaking the pana output much, this is a first step to it.
- Note: this follows the previous concept of keeping the `AnalysisResult` object compact, while exposing any issue or failure message in the report.