### PR TITLE
Use explicit URL issue status and display the accepted ones in the results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Make example's `README.md` priority over any dart file in the examples directory.
 - Expose more precise repository verification status in `AnalysisResult`.
+- Track URL issues with explicit acceptance state (404 status does not cause score deduction).
+  Also display such URLs in `AnalysisResult`.
 
 ## 0.22.17
 

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -260,12 +260,12 @@ Future<AnalysisResult> _createAnalysisResult(
   final repoVerification = await context.repository;
   final repository = repoVerification.repository;
   final fundingUrls =
-      pubspecUrls.funding.map((e) => e.verifiedUrl).nonNulls.toList();
+      pubspecUrls.funding.map((e) => e.acceptedUrl).nonNulls.toList();
   return AnalysisResult(
-    homepageUrl: pubspecUrls.homepage.verifiedUrl,
-    repositoryUrl: pubspecUrls.repository.verifiedUrl,
-    issueTrackerUrl: pubspecUrls.issueTracker.verifiedUrl,
-    documentationUrl: pubspecUrls.documentation.verifiedUrl,
+    homepageUrl: pubspecUrls.homepage.acceptedUrl,
+    repositoryUrl: pubspecUrls.repository.acceptedUrl,
+    issueTrackerUrl: pubspecUrls.issueTracker.acceptedUrl,
+    documentationUrl: pubspecUrls.documentation.acceptedUrl,
     fundingUrls: fundingUrls.isEmpty ? null : fundingUrls,
     repositoryStatus: repoVerification.status,
     repository: repository,

--- a/lib/src/references/pubspec_urls.dart
+++ b/lib/src/references/pubspec_urls.dart
@@ -23,24 +23,31 @@ class PubspecUrlsWithIssues {
     required this.funding,
   });
 
-  Iterable<Issue> get issues => [
-        homepage.issue,
-        repository.issue,
-        issueTracker.issue,
-        documentation.issue,
-        ...funding.map((i) => i.issue),
-      ].whereType<Issue>();
+  late final _withIssues = [
+    homepage,
+    repository,
+    issueTracker,
+    documentation,
+    ...funding,
+  ].where((e) => e.issue != null).toList();
+
+  Iterable<Issue> get issues => _withIssues.map((e) => e.issue).nonNulls;
+
+  late final hasRejected = _withIssues.any((e) => !e.isAccepted);
 }
 
 class UrlWithIssue {
   final String? url;
   final Issue? issue;
 
-  UrlWithIssue(this.url, this.issue);
+  /// While the [url] may have issues, we could still display it, as the problem may be transient.
+  final bool isAccepted;
 
-  late final isOK = url != null && issue == null;
-  late final isNotOK = !isOK;
-  late final verifiedUrl = isOK ? url : null;
+  UrlWithIssue.accepted(this.url, {this.issue}) : isAccepted = true;
+  UrlWithIssue.rejected(this.issue, {this.url}) : isAccepted = false;
+
+  late final isVerified = url != null && isAccepted && issue == null;
+  late final acceptedUrl = isAccepted ? url : null;
 }
 
 /// Verifies the URLs in pubspec and builds the [PubspecUrlsWithIssues] object.
@@ -81,7 +88,7 @@ Future<PubspecUrlsWithIssues> checkPubspecUrls(PackageContext context) async {
       ).toString();
       final inferredResult = await _checkUrl(
           context, 'issue_tracker', 'Issue tracker URL', inferredUrl);
-      if (inferredResult.isOK) {
+      if (inferredResult.isVerified) {
         issueTracker = inferredResult;
       }
     }
@@ -111,8 +118,7 @@ Future<UrlWithIssue> _checkUrlInPubspec(
   final pubspec = context.pubspec;
   final content = pubspec.originalYaml[key];
   if (content != null && content is! String) {
-    return UrlWithIssue(
-      null,
+    return UrlWithIssue.rejected(
       Issue('The `$key` entry, if present, should be a string containing a url',
           span: tryGetSpanFromYamlMap(pubspec.originalYaml, key)),
     );
@@ -121,10 +127,10 @@ Future<UrlWithIssue> _checkUrlInPubspec(
 
   if (url == null || url.isEmpty) {
     if (isRequired) {
-      return UrlWithIssue(
-          null, Issue("`pubspec.yaml` doesn't have a `$key` entry."));
+      return UrlWithIssue.rejected(
+          Issue("`pubspec.yaml` doesn't have a `$key` entry."));
     }
-    return UrlWithIssue(null, null);
+    return UrlWithIssue.rejected(null);
   }
   return await _checkUrl(context, key, name, url);
 }
@@ -138,17 +144,17 @@ Future<UrlWithIssue> _checkUrl(
   final pubspec = context.pubspec;
   final status = await context.sharedContext.checkUrlStatus(url);
   if (status.isInvalid) {
-    return UrlWithIssue(
-      url,
+    return UrlWithIssue.rejected(
       Issue(
         "$name isn't valid.",
         span: tryGetSpanFromYamlMap(pubspec.originalYaml, key),
       ),
+      url: url,
     );
   } else if (!status.exists) {
-    return UrlWithIssue(
+    return UrlWithIssue.accepted(
       url,
-      Issue(
+      issue: Issue(
         "$name doesn't exist.",
         span: tryGetSpanFromYamlMap(pubspec.originalYaml, key),
         suggestion: 'At the time of the analysis `$url` was unreachable. '
@@ -156,8 +162,8 @@ Future<UrlWithIssue> _checkUrl(
       ),
     );
   } else if (!status.isSecure) {
-    return UrlWithIssue(
-      url,
+    return UrlWithIssue.rejected(
+      url: url,
       Issue(
         '$name is insecure.',
         span: tryGetSpanFromYamlMap(pubspec.originalYaml, key),
@@ -169,5 +175,5 @@ Future<UrlWithIssue> _checkUrl(
   if (problemCode != null) {
     context.urlProblems[url] = problemCode;
   }
-  return UrlWithIssue(url, null);
+  return UrlWithIssue.accepted(url);
 }

--- a/test/goldens/end2end/url_launcher-6.3.1.json
+++ b/test/goldens/end2end/url_launcher-6.3.1.json
@@ -167,6 +167,7 @@
   "screenshots": [],
   "result": {
     "repositoryUrl": "https://github.com/flutter/packages/tree/main/packages/url_launcher/url_launcher",
+    "issueTrackerUrl": "https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22",
     "repositoryStatus": "verified",
     "repository": {
       "provider": "github",


### PR DESCRIPTION
- #1403
- Instead of relying on the issue message string, store an explicit status whether the URL could be displayed or not. (non-secure URLs will not be displayed, but ones with 404 will be).
- The accepted URLs are also exposed in the `AnalysisResult`.