### PR TITLE
Passthru dartdoc option for showUndocumentedCategories

### DIFF
--- a/lib/src/dartdoc/dartdoc_options.dart
+++ b/lib/src/dartdoc/dartdoc_options.dart
@@ -61,5 +61,6 @@ final _passThroughKeys = <String>[
   // 'examplePathPrefix',
   'exclude',
   'include',
+  'showUndocumentedCategories',
   'nodoc',
 ];


### PR DESCRIPTION
We think the `showUndocumentedCategories` might allow topics that don't have any `/// {@category <category>}` annotated elements to also be displayed.

CC @HosseinYousefi 