### PR TITLE
Fixing license match post-filtering calculation with traling contained range.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed small ambiguity in the order of license match evaluation.
 - Resolve `analysis_options.yaml` dev dependency to expose transitive formatter options.
 - Fixed license coverage calculation.
+- Fixed license match post-filtering.
 
 ## 0.22.23
 

--- a/lib/src/license_detection/token_matcher.dart
+++ b/lib/src/license_detection/token_matcher.dart
@@ -54,6 +54,8 @@ class Range {
         (end >= other.start && end <= other.end);
   }
 
+  bool containsIndex(int value) => start <= value && value < end;
+
   @override
   String toString() => 'Range($start-$end)';
 }

--- a/test/license_detector_test.dart
+++ b/test/license_detector_test.dart
@@ -258,6 +258,16 @@ void main() {
       160,
       1000,
     );
+
+    _testLongestUnclaimedTokenRange(
+      'Trailing contained range',
+      [
+        _dummyLicenseMatchInstance(0.9, '', start: 30, end: 940),
+        _dummyLicenseMatchInstance(0.9, '', start: 50, end: 70),
+      ],
+      60,
+      1000,
+    );
   });
 }
 

--- a/test/licenses/license_coverage_test.dart
+++ b/test/licenses/license_coverage_test.dart
@@ -16,10 +16,6 @@ void main() {
           license.content,
           relativePath: 'LICENSE',
         );
-        // TODO: fix detection and return at least one match (https://github.com/dart-lang/pana/issues/1484)
-        if (license.identifier == 'SSH-OpenSSH') {
-          continue;
-        }
         final match = detected
             .where((l) => l.spdxIdentifier == license.identifier)
             .single;


### PR DESCRIPTION
- Fixes #1484.
- The `findLongestUnclaimedTokenRange` is used to filter out detection results where the unclaimed/unrecognized range is too long (50+ tokens), however, with trailing contained ranges the calculation is wrong.
- Related to #1488, as the contained range is a smaller version of the license. In such cases we should also remove the smaller version, but in that case the edge case bug here wouldn't be noticeable.