### PR TITLE
Remove line-length from CLI args and API options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Removed `packageName` from `SdkConstraintStatus.fromSdkVersion` constructor.
 - Removed `ToolEnvironment` methods: `runUpgrade` (use `runPub` instead) and `withRestrictedAnalysisOptions` (no replacement).
 - SDK constraint is no longer added to old `pubspec.yaml`
+- Removed `--line-length` CLI argument and also `lineLength` from analysis options. Use [configurable page width](https://dart.dev/tools/dart-format#configuring-formatter-page-width) instead.
 
 ## 0.22.24
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Options:
   -j, --json                   Output log records and full report as JSON.
       --hosted-url             The server that hosts <package>.
                                (defaults to "https://pub.dev")
-  -l, --line-length            The line length to use with dart format.
       --hosted                 Download and analyze a hosted package (from https://pub.dev).
       --[no-]dartdoc           Run dartdoc and score the package on documentation coverage.
                                (defaults to on)

--- a/bin/pana.dart
+++ b/bin/pana.dart
@@ -58,11 +58,6 @@ final _parser = ArgParser()
     help: 'The server that hosts <package>.',
     defaultsTo: defaultHostedUrl,
   )
-  ..addOption(
-    'line-length',
-    abbr: 'l',
-    help: 'The line length to use with dart format.',
-  )
   ..addFlag(
     'hosted',
     help: 'Download and analyze a hosted package (from $defaultHostedUrl).',
@@ -203,7 +198,6 @@ Future<void> main(List<String> args) async {
     final options = InspectOptions(
       pubHostedUrl: pubHostedUrl,
       panaCacheDir: Platform.environment['PANA_CACHE'],
-      lineLength: int.tryParse(result['line-length'] as String? ?? ''),
       dartdocOutputDir: runDartdoc ? dartdocOutputDir : null,
       resourcesOutputDir: resourcesOutputDir,
       dartdocTimeout: _parseDuration(result['dartdoc-timeout'] as String?),

--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -47,9 +47,6 @@ class InspectOptions {
   /// [dartdocTimeout] and the remaining budget will be used.
   final Duration dartdocTimeout;
 
-  /// The line length parameter to be used for dart format checks.
-  final int? lineLength;
-
   InspectOptions({
     this.pubHostedUrl,
     this.panaCacheDir,
@@ -57,7 +54,6 @@ class InspectOptions {
     this.resourcesOutputDir,
     this.totalTimeout,
     Duration? dartdocTimeout,
-    this.lineLength,
   }) : dartdocTimeout = dartdocTimeout ?? const Duration(minutes: 5);
 }
 

--- a/lib/src/report/static_analysis.dart
+++ b/lib/src/report/static_analysis.dart
@@ -31,7 +31,6 @@ Future<ReportSection> staticAnalysis(PackageContext context) async {
           packageDir,
           context.toolEnvironment,
           usesFlutter: context.usesFlutter,
-          lineLength: context.options.lineLength,
         )
       : <Issue>[];
 
@@ -191,13 +190,11 @@ Future<List<Issue>> _formatPackage(
   String packageDir,
   ToolEnvironment toolEnvironment, {
   required bool usesFlutter,
-  int? lineLength,
 }) async {
   try {
     final unformattedFiles = await toolEnvironment.filesNeedingFormat(
       packageDir,
       usesFlutter,
-      lineLength: lineLength,
     );
     return unformattedFiles
         .map(

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -277,9 +277,8 @@ class ToolEnvironment {
 
   Future<List<String>> filesNeedingFormat(
     String packageDir,
-    bool usesFlutter, {
-    int? lineLength,
-  }) async {
+    bool usesFlutter,
+  ) async {
     final dirs = await listFocusDirs(packageDir);
     if (dirs.isEmpty) {
       return const [];
@@ -296,9 +295,6 @@ class ToolEnvironment {
           '--output=none',
           '--set-exit-if-changed',
         ];
-        if (lineLength != null && lineLength > 0) {
-          params.addAll(<String>['--line-length', lineLength.toString()]);
-        }
         params.add(fullPath);
 
         final result = await runConstrained(

--- a/test/goldens/help.txt
+++ b/test/goldens/help.txt
@@ -8,7 +8,6 @@ Options:
   -j, --json                   Output log records and full report as JSON.
       --hosted-url             The server that hosts <package>.
                                (defaults to "https://pub.dev")
-  -l, --line-length            The line length to use with dart format.
       --hosted                 Download and analyze a hosted package (from https://pub.dev).
       --[no-]dartdoc           Run dartdoc and score the package on documentation coverage.
                                (defaults to on)


### PR DESCRIPTION
The configurable page width is supported since Dart SDK 3.7, which is more than 8 months old. I think we could remove these with the current breaking changes, or we should at minimum deprecate them.