### PR TITLE
Fix pana fails with custom PUB_HOSTED_URL containing a path

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -164,9 +164,17 @@ Future<void> copyDir(String from, String to) async {
 }
 
 Future<String> getVersionListing(String package, {Uri? pubHostedUrl}) async {
-  final url = (pubHostedUrl ?? Uri.parse('https://pub.dartlang.org')).resolve(
-    'api/packages/$package',
-  );
+  var url = (pubHostedUrl ?? Uri.parse('https://pub.dartlang.org'))
+      .normalizePath();
+  // If we have a path of only '/'
+  if (url.path == '/') {
+    url = url.replace(path: '');
+  }
+  // If there is a path, and it doesn't end in a slash we normalize to slash
+  if (url.path.isNotEmpty && !url.path.endsWith('/')) {
+    url = url.replace(path: '${url.path}/');
+  }
+  url = url.resolve('api/packages/$package');
   log.fine('Downloading: $url');
 
   return await retry(


### PR DESCRIPTION
FIXES #1521  pana fails with custom PUB_HOSTED_URL containing a path

When using a custom PUB_HOSTED_URL that includes a path (e.g., hosted on a custom Artifactory server), the pana command fails to analyze packages. The issue seems to occur because the pana package strips away the path component of the PUB_HOSTED_URL when resolving the API endpoint.

My local tests confirm that our custom pub repo can be used after the change.