### PR TITLE
Draft: overriding analyzer and dartdoc process via detailed API.

### DIFF
--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -303,7 +303,6 @@ class PackageContext {
       packageDir,
       '.',
       usesFlutter,
-      inspectOptions: options,
     );
     final list = LineSplitter.split(output)
         .map((s) => parseCodeProblem(s, projectDir: packageDir))


### PR DESCRIPTION
Note: the analyzer override seems to be simple, while the dartdoc one is much more complex, which should be also repeated on the overrider's implementation too. Maybe the override could be specific to the strictly versioned use case?