### PR TITLE
Refactor: GitTool for high-level git commands.

### DIFF
--- a/lib/src/package_analyzer.dart
+++ b/lib/src/package_analyzer.dart
@@ -258,16 +258,16 @@ Future<String?> _detectGitRoot(
   SandboxRunner sandboxRunner,
   String packageDir,
 ) async {
-  try {
-    final pr = await runGitIsolated(sandboxRunner, [
-      'rev-parse',
-      '--show-toplevel',
-    ], workingDirectory: packageDir);
-    return pr.stdout.asString.trim();
-  } on GitToolException catch (_) {
-    // not in a git directory (or git is broken) - ignore exception
-  }
-  return null;
+  /// Runs `git` with a temporary config directory, isolating it from any global
+  /// user settings.
+  return await withTempDir((path) async {
+    final tool = GitTool(
+      sandboxRunner: sandboxRunner,
+      homePath: path,
+      workingDirectory: packageDir,
+    );
+    return await tool.detectRootDir();
+  });
 }
 
 Future<AnalysisResult> _createAnalysisResult(

--- a/lib/src/repository/git_local_repository.dart
+++ b/lib/src/repository/git_local_repository.dart
@@ -5,11 +5,9 @@
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
-import 'package:retry/retry.dart';
 
 import '../sandbox_runner.dart';
 import '../tool/git_tool.dart';
-import '../tool/run_constrained.dart';
 
 final _acceptedBranchNameRegExp = RegExp(r'^[a-z0-9]+$');
 final _acceptedPathSegmentsRegExp = RegExp(
@@ -80,41 +78,16 @@ class GitLocalRepository {
     }
   }
 
-  Future<PanaProcessResult> _runGit(
-    List<String> args, {
-    int? maxOutputBytes,
-    GitToolException Function(PanaProcessResult pr)? createException,
-  }) async {
-    return await runGit(
-      sandboxRunner,
-      args,
-      homePath: homePath,
-      workingDirectory: localPath,
-      maxOutputBytes: maxOutputBytes,
-      createException: createException,
-    );
-  }
-
-  Future<PanaProcessResult> _runGitWithRetry(
-    List<String> args, {
-    int maxAttempts = 3,
-    GitToolException Function(PanaProcessResult pr)? createException,
-    int? maxOutputBytes,
-  }) async {
-    return await retry(
-      () => _runGit(
-        args,
-        maxOutputBytes: maxOutputBytes,
-        createException: createException,
-      ),
-      maxAttempts: maxAttempts,
-      retryIf: (e) => e is GitToolException,
-    );
-  }
+  /// The git tool for running git commands.
+  late final _gitTool = GitTool(
+    sandboxRunner: sandboxRunner,
+    homePath: homePath,
+    workingDirectory: localPath,
+  );
 
   Future<void> _init() async {
-    await _runGit(['init']);
-    await _runGit(['remote', 'add', 'origin', origin]);
+    await _gitTool.init();
+    await _gitTool.addRemote('origin', origin);
   }
 
   /// Detects the default branch name (typically `master` or `main`)
@@ -124,22 +97,7 @@ class GitLocalRepository {
   /// branch name is missing, or if the default branch name has
   /// unexpected pattern.
   Future<String> detectDefaultBranch() async {
-    final pr = await _runGitWithRetry(['remote', 'show', 'origin']);
-    final output = pr.stdout.asString;
-    final lines = output.split('\n');
-    for (final line in lines) {
-      final parts = line.trim().split(':');
-      if (parts.length == 2 && parts[0].trim() == 'HEAD branch') {
-        final branch = parts[1].trim();
-        if (_acceptedBranchNameRegExp.matchAsPrefix(branch) != null) {
-          return branch;
-        } else {
-          throw GitToolException('Could not accept branch name: `$branch`.');
-        }
-      }
-      // DEFAULT_BRANCH=$(git rev-parse --abbrev-ref $FIRST_REMOTE/HEAD)
-    }
-    throw GitToolException('Could not find HEAD branch.', output);
+    return await _gitTool.detectDefaultBranch('origin');
   }
 
   /// Return the String content of the file in [branch] and [path].
@@ -153,11 +111,7 @@ class GitLocalRepository {
     _assertBranchFormat(branch);
     _assertPathFormat(path);
     await _fetch(branch, 1);
-    final pr = await _runGitWithRetry([
-      'show',
-      'origin/$branch:$path',
-    ], createException: (_) => GitToolException('Could not read `$path`.'));
-    return pr.stdout.asString;
+    return await _gitTool.showFile('origin/$branch', path);
   }
 
   /// List file names of [branch].
@@ -166,17 +120,7 @@ class GitLocalRepository {
   Future<List<String>> listFiles(String branch) async {
     _assertBranchFormat(branch);
     await _fetch(branch, 1);
-    final pr = await _runGitWithRetry(
-      ['ls-tree', '-r', '--name-only', '--full-tree', 'origin/$branch'],
-      createException: (pr) =>
-          GitToolException('Could not list `$branch`.', pr.asTrimmedOutput),
-    );
-    return pr.stdout
-        .toString()
-        .split('\n')
-        .map((e) => e.trim())
-        .where((e) => e.isNotEmpty)
-        .toList();
+    return await _gitTool.listFiles('origin/$branch');
   }
 
   /// Deletes the local directory.
@@ -191,13 +135,11 @@ class GitLocalRepository {
       return;
     }
     _assertBranchFormat(branch);
-    await _runGitWithRetry([
-      'fetch',
-      if (depth != unlimitedFetchDepth) ...['--depth', '$depth'],
-      '--no-recurse-submodules',
+    await _gitTool.fetch(
       'origin',
       branch,
-    ]);
+      depth: depth == unlimitedFetchDepth ? null : depth,
+    );
     _fetchedDepthsPerBranch[branch] = depth;
   }
 

--- a/lib/src/tool/git_tool.dart
+++ b/lib/src/tool/git_tool.dart
@@ -3,16 +3,16 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:path/path.dart' as p;
+import 'package:retry/retry.dart';
 
 import '../sandbox_runner.dart';
-import '../utils.dart';
 import 'run_constrained.dart';
 
 /// Runs `git` in an isolated environment using the [homePath] to access its
 /// default configuration. This can be used to prevent the `git` process to
 /// access the user's custom configuration files and settings, allowing a safe
 /// and reproducible execution.
-Future<PanaProcessResult> runGit(
+Future<PanaProcessResult> _runGit(
   SandboxRunner sandboxRunner,
   List<String> args, {
   required String homePath,
@@ -48,21 +48,134 @@ Future<PanaProcessResult> runGit(
   return pr;
 }
 
-/// Runs `git` with a temporary config directory, isolating it from any global
-/// user settings.
-Future<PanaProcessResult> runGitIsolated(
-  SandboxRunner sandboxRunner,
-  List<String> args, {
-  required String workingDirectory,
-}) async {
-  return await withTempDir((path) async {
-    return runGit(
-      sandboxRunner,
+/// Encapsulates high-level git operations.
+class GitTool {
+  final SandboxRunner _sandboxRunner;
+  final String _homePath;
+  final String _workingDirectory;
+
+  GitTool({
+    required SandboxRunner sandboxRunner,
+    required String homePath,
+    required String workingDirectory,
+  }) : _sandboxRunner = sandboxRunner,
+       _homePath = homePath,
+       _workingDirectory = workingDirectory;
+
+  /// Runs a git command with the configured paths.
+  Future<PanaProcessResult> _run(
+    List<String> args, {
+    int? maxOutputBytes,
+    GitToolException Function(PanaProcessResult pr)? createException,
+  }) async {
+    return await _runGit(
+      _sandboxRunner,
       args,
-      homePath: path,
-      workingDirectory: workingDirectory,
+      homePath: _homePath,
+      workingDirectory: _workingDirectory,
+      maxOutputBytes: maxOutputBytes,
+      createException: createException,
     );
-  });
+  }
+
+  /// Runs a git command with retry logic.
+  Future<PanaProcessResult> _runWithRetry(
+    List<String> args, {
+    int maxAttempts = 3,
+    int? maxOutputBytes,
+    GitToolException Function(PanaProcessResult pr)? createException,
+  }) async {
+    return await retry(
+      () => _run(
+        args,
+        maxOutputBytes: maxOutputBytes,
+        createException: createException,
+      ),
+      maxAttempts: maxAttempts,
+      retryIf: (e) => e is GitToolException,
+    );
+  }
+
+  /// Initialize a new git repository.
+  Future<void> init() async {
+    await _run(['init']);
+  }
+
+  /// Add a remote to the repository.
+  Future<void> addRemote(String name, String url) async {
+    await _run(['remote', 'add', name, url]);
+  }
+
+  /// Returns the root directory of the repository.
+  ///
+  /// Returns `null` if not inside a git repository.
+  Future<String?> detectRootDir() async {
+    try {
+      final pr = await _run(['rev-parse', '--show-toplevel']);
+      return pr.stdout.asString.trim();
+    } on GitToolException catch (_) {
+      return null;
+    }
+  }
+
+  /// Detect the default branch name of a remote (typically 'master' or 'main').
+  ///
+  /// Throws [GitToolException] if the branch cannot be detected or has an unexpected format.
+  Future<String> detectDefaultBranch(String remote) async {
+    final pr = await _runWithRetry(['remote', 'show', remote]);
+    final output = pr.stdout.asString;
+    final lines = output.split('\n');
+
+    final branchNameRegExp = RegExp(r'^[a-z0-9]+$');
+
+    for (final line in lines) {
+      final parts = line.trim().split(':');
+      if (parts.length == 2 && parts[0].trim() == 'HEAD branch') {
+        final branch = parts[1].trim();
+        if (branchNameRegExp.matchAsPrefix(branch) != null) {
+          return branch;
+        } else {
+          throw GitToolException('Could not accept branch name: `$branch`.');
+        }
+      }
+    }
+    throw GitToolException('Could not find HEAD branch.', output);
+  }
+
+  /// Fetch a branch from a remote.
+  Future<void> fetch(String remote, String branch, {int? depth}) async {
+    await _runWithRetry([
+      'fetch',
+      if (depth != null) ...['--depth', '$depth'],
+      '--no-recurse-submodules',
+      remote,
+      branch,
+    ]);
+  }
+
+  /// Read the content of a file at a specific ref (e.g., 'origin/main:path/to/file').
+  Future<String> showFile(String ref, String path) async {
+    final pr = await _runWithRetry([
+      'show',
+      '$ref:$path',
+    ], createException: (_) => GitToolException('Could not read `$path`.'));
+    return pr.stdout.asString;
+  }
+
+  /// List all files at a specific ref (e.g., 'origin/main').
+  Future<List<String>> listFiles(String ref) async {
+    final pr = await _runWithRetry(
+      ['ls-tree', '-r', '--name-only', '--full-tree', ref],
+      createException: (pr) =>
+          GitToolException('Could not list `$ref`.', pr.asTrimmedOutput),
+    );
+    return pr.stdout
+        .toString()
+        .split('\n')
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty)
+        .toList();
+  }
 }
 
 class GitToolException implements Exception {


### PR DESCRIPTION
- Wraps the sandbox runner and the home/working directories, which remain the same while processing.
- Moves the commands behind high-level methods.
- Simpler, easier to follow git local repository checks.