### PR TITLE
Allow some safe symbols to be imported from dart:io while keeping platform-support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Re-run `pub` commands with `--verbose` after a failure.
 - Updated end2end tests to latest dartdoc.
 - Use `-z` (zero-byte separator) for git listing.
+- Allow some safe symbols to be imported from `dart:io` while keeping platform-support.
 
 ## 0.23.10
 

--- a/lib/src/tag/_graphs.dart
+++ b/lib/src/tag/_graphs.dart
@@ -10,6 +10,7 @@ import '../logging.dart';
 import '../pubspec.dart';
 import '../pubspec_io.dart' show pubspecFromDir;
 import '_common.dart';
+import 'safe_imports.dart';
 
 abstract class DirectedGraph<T> {
   Set<T> directSuccessors(T t);
@@ -145,6 +146,11 @@ class LibraryGraph implements DirectedGraph<Uri> {
               dependency = uri.resolve(configuration.uri.stringValue!);
               break; // Always pick the first satisfied configuration.
             }
+          }
+
+          // Skip if this is a safe import
+          if (isSafeImport(directive, dependency)) {
+            continue;
           }
 
           dependencies.add(dependency);

--- a/lib/src/tag/safe_imports.dart
+++ b/lib/src/tag/safe_imports.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+
+/// Maps dart: library URIs to their safe symbols.
+const _safeSymbolsByLibrary = {
+  /// Symbols from dart:io that are safe to use on all platforms
+  /// because they don't require actual IO operations.
+  'dart:io': {
+    'ContentType',
+    'Cookie',
+    'HeaderValue',
+    'HttpDate',
+    'HttpHeaders',
+    'HttpStatus',
+  },
+};
+
+/// Checks if a namespace directive (import/export) only uses safe symbols
+/// from an otherwise platform-specific library.
+///
+/// Returns `true` if:
+/// - The directive has at least one `show` combinator
+/// - All shown symbols are in the safe list for that library
+/// - The directive has no `hide` combinators (for simpler rules)
+///
+/// Returns `false` otherwise, including when:
+/// - The dependency is not a restricted library with safe symbols
+/// - The directive has no combinators (imports everything)
+/// - The directive has `hide` combinators
+/// - Any shown symbol is not in the safe list
+bool isSafeImport(NamespaceDirective directive, Uri dependency) {
+  final safeSymbols = _safeSymbolsByLibrary[dependency.toString()];
+  if (safeSymbols == null) {
+    return false;
+  }
+
+  // Must have at least one `show` combinator
+  final showCombinators = directive.combinators
+      .whereType<ShowCombinator>()
+      .toList();
+  if (showCombinators.isEmpty) {
+    return false;
+  }
+
+  // Must not have any `hide` combinators (too complex to analyze)
+  if (directive.combinators.any((c) => c is HideCombinator)) {
+    return false;
+  }
+
+  // Check all shown symbols from all `show` combinators
+  for (final combinator in showCombinators) {
+    for (final identifier in combinator.shownNames) {
+      if (!safeSymbols.contains(identifier.name)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}

--- a/test/tag/safe_imports_end2end_test.dart
+++ b/test/tag/safe_imports_end2end_test.dart
@@ -1,0 +1,86 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:pana/src/tag/pana_tags.dart';
+import 'package:pana/src/tag/tagger.dart';
+import 'package:pana/src/tool/run_constrained.dart';
+import 'package:pana/src/utils.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('Safe imports end2end', () {
+    test('package with safe symbols is wasm-ready', () async {
+      await withTempDir((tempDir) async {
+        await _createAndInitTestPackage(
+          tempDir,
+          "import 'dart:io' show HttpStatus, HttpHeaders, HttpDate;\n\nclass MyClass {}\n",
+        );
+
+        final tagger = Tagger(tempDir);
+        final tags = <String>[];
+        final explanations = <Explanation>[];
+
+        tagger.wasmReadyTag(tags, explanations);
+        expect(tags, contains(PanaTags.isWasmReady));
+        expect(
+          explanations.where((e) => e.tag == PanaTags.isWasmReady),
+          isEmpty,
+        );
+
+        tagger.platformTags(tags, explanations);
+        expect(tags, contains(PanaTags.platformWeb));
+      });
+    });
+
+    test('package with unsafe File import is not wasm-ready', () async {
+      await withTempDir((tempDir) async {
+        await _createAndInitTestPackage(
+          tempDir,
+          "import 'dart:io' show File;\n\nclass MyClass {}\n",
+        );
+
+        final tagger = Tagger(tempDir);
+        final tags = <String>[];
+        final explanations = <Explanation>[];
+
+        tagger.wasmReadyTag(tags, explanations);
+        expect(tags, isNot(contains(PanaTags.isWasmReady)));
+        expect(
+          explanations.where((e) => e.tag == PanaTags.isWasmReady),
+          isNotEmpty,
+          reason: 'Should have violation for unsafe File import',
+        );
+
+        tagger.platformTags(tags, explanations);
+        expect(tags, isNot(contains(PanaTags.platformWeb)));
+      });
+    });
+  });
+}
+
+Future<void> _createAndInitTestPackage(
+  String packageDir,
+  String libraryCode,
+) async {
+  final libDir = Directory(p.join(packageDir, 'lib'));
+  await libDir.create(recursive: true);
+
+  final pubspecContent = '''name: foo
+publish_to: none
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+''';
+  await File(p.join(packageDir, 'pubspec.yaml')).writeAsString(pubspecContent);
+
+  await File(p.join(libDir.path, 'foo.dart')).writeAsString(libraryCode);
+
+  await runConstrained(
+    ['dart', 'pub', 'get'],
+    workingDirectory: packageDir,
+    throwOnError: true,
+  );
+}

--- a/test/tag/safe_imports_test.dart
+++ b/test/tag/safe_imports_test.dart
@@ -1,0 +1,122 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:pana/src/tag/_common.dart';
+import 'package:pana/src/tag/safe_imports.dart';
+import 'package:pana/src/utils.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+void main() {
+  group('isSafeImport', () {
+    test('returns true for safe dart:io symbols only', () async {
+      final directive = await _parseDirective(
+        "import 'dart:io' show HttpStatus;",
+      );
+      expect(isSafeImport(directive, Uri.parse('dart:io')), isTrue);
+    });
+
+    test('returns true for multiple safe dart:io symbols', () async {
+      final directive = await _parseDirective(
+        "import 'dart:io' show HttpStatus, HttpHeaders, HttpDate;",
+      );
+      expect(isSafeImport(directive, Uri.parse('dart:io')), isTrue);
+    });
+
+    test('returns false for unsafe dart:io symbols', () async {
+      final directive = await _parseDirective("import 'dart:io' show File;");
+      expect(isSafeImport(directive, Uri.parse('dart:io')), isFalse);
+    });
+
+    test('returns false for mixed safe and unsafe symbols', () async {
+      final directive = await _parseDirective(
+        "import 'dart:io' show HttpStatus, File;",
+      );
+      expect(isSafeImport(directive, Uri.parse('dart:io')), isFalse);
+    });
+
+    test('returns false for import without show clause', () async {
+      final directive = await _parseDirective("import 'dart:io';");
+      expect(isSafeImport(directive, Uri.parse('dart:io')), isFalse);
+    });
+
+    test('returns false for import with hide clause', () async {
+      final directive = await _parseDirective("import 'dart:io' hide File;");
+      expect(isSafeImport(directive, Uri.parse('dart:io')), isFalse);
+    });
+
+    test('returns false for import with both show and hide clauses', () async {
+      final directive = await _parseDirective(
+        "import 'dart:io' show HttpStatus hide File;",
+      );
+      expect(isSafeImport(directive, Uri.parse('dart:io')), isFalse);
+    });
+
+    test('returns false for unspecified libraries', () async {
+      final directive = await _parseDirective(
+        "import 'dart:html' show Window;",
+      );
+      expect(isSafeImport(directive, Uri.parse('dart:html')), isFalse);
+    });
+
+    test('returns false for package imports', () async {
+      final directive = await _parseDirective(
+        "import 'package:http/http.dart' show Client;",
+      );
+      expect(
+        isSafeImport(directive, Uri.parse('package:http/http.dart')),
+        isFalse,
+      );
+    });
+
+    test('works with export directives', () async {
+      final directive = await _parseDirective(
+        "export 'dart:io' show HttpStatus;",
+      );
+      expect(isSafeImport(directive, Uri.parse('dart:io')), isTrue);
+    });
+
+    test('returns false for export without show clause', () async {
+      final directive = await _parseDirective("export 'dart:io';");
+      expect(isSafeImport(directive, Uri.parse('dart:io')), isFalse);
+    });
+
+    test('handles multiple show combinators (union)', () async {
+      // Note: This syntax is unusual but valid in Dart
+      final directive = await _parseDirective(
+        "import 'dart:io' show HttpStatus show HttpHeaders;",
+      );
+      expect(isSafeImport(directive, Uri.parse('dart:io')), isTrue);
+    });
+
+    test(
+      'returns false for multiple show combinators with unsafe symbol',
+      () async {
+        final directive = await _parseDirective(
+          "import 'dart:io' show HttpStatus show File;",
+        );
+        expect(isSafeImport(directive, Uri.parse('dart:io')), isFalse);
+      },
+    );
+  });
+}
+
+/// Parses the [code] and returns the first namespace directive.
+Future<NamespaceDirective> _parseDirective(String code) async {
+  return await withTempDir((tempDir) async {
+    final testFile = path.join(tempDir, 'test.dart');
+    await File(testFile).writeAsString(code);
+
+    final collection = AnalysisContextCollection(includedPaths: [tempDir]);
+    final session = collection.contextFor(tempDir).currentSession;
+    final fileUri = Uri.file(testFile);
+    final unit = parsedUnitFromUri(session, fileUri);
+
+    return unit!.directives.whereType<NamespaceDirective>().first;
+  });
+}


### PR DESCRIPTION
- Fixes #1571.
- The import (or export) cause is skipped if: (1) there are `show` clauses, and (2) the shown symbols are allow-listed, and (3) there is no `hide` clauses.
- While this is focusing on a narrow subset of the `dart:io` library (see also https://github.com/dart-lang/http/issues/1887), it is possible to expand on it later if needed.
