### PR TITLE
Scope static analysis to lib/, bin/ and pubspec.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Detect legacy Kotlin Gradle Plugin application and `kotlinOptions` in Android plugins.
 - Upgraded dependencies to the latest.
+- Run static analysis on `lib/` and `bin/` instead of the whole package, so a large `test/` 
+  directory can no longer exceed the analyzer output limit and fail analysis.
 
 ## 0.23.12
 

--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -32,7 +32,7 @@ import 'tag/pana_tags.dart';
 import 'tag/tagger.dart';
 import 'tool/run_constrained.dart';
 import 'tool/webp_tool.dart';
-import 'utils.dart' show isAnalysisTarget, listFiles;
+import 'utils.dart' show analysisTargetPaths, isAnalysisTarget, listFiles;
 
 /// Shared (intermediate) results between different packages or versions.
 /// External systems that may be independent of the archive content may be
@@ -324,7 +324,7 @@ class PackageContext {
   }) async {
     final output = await toolEnvironment.runAnalyzer(
       packageDir,
-      '.',
+      analysisTargetPaths(packageDir),
       usesFlutter,
       inspectOptions: options,
     );

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -262,13 +262,13 @@ class ToolEnvironment {
 
   Future<String> runAnalyzer(
     String packageDir,
-    String dir,
+    List<String> analysisTargets,
     bool usesFlutter, {
     required InspectOptions inspectOptions,
   }) async {
     return await _withRestrictedAnalysisOptions(packageDir, () async {
       final proc = await _sandboxRunner.runSandboxed(
-        [..._dartSdk.dartAnalyzeCmd, '--format', 'machine', dir],
+        [..._dartSdk.dartAnalyzeCmd, '--format', 'machine', ...analysisTargets],
         environment: _dartSdk.environment,
         workingDirectory: packageDir,
         timeout: const Duration(minutes: 5),
@@ -284,7 +284,7 @@ class ToolEnvironment {
         throw ToolException('Running `dart analyze` timed out.', proc);
       }
       if ('\n$output'.contains('\nUnhandled exception:\n')) {
-        if (output.contains('No dart files found at: .')) {
+        if (output.contains('No dart files found at:')) {
           log.warning('`dart analyze` found no files to analyze.');
         } else {
           log.severe('Bad input?: $output');

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -206,11 +206,7 @@ bool isAnalysisTarget(String path) {
 /// This is used to scope `dart analyze`.
 List<String> analysisTargetPaths(String packageDir) {
   return [
-    ..._topLevelTargets.where(
-      (t) => File(p.join(packageDir, t)).existsSync(),
-    ),
-    ..._binOrLibSet.where(
-      (d) => Directory(p.join(packageDir, d)).existsSync(),
-    ),
+    ..._topLevelTargets.where((t) => File(p.join(packageDir, t)).existsSync()),
+    ..._binOrLibSet.where((d) => Directory(p.join(packageDir, d)).existsSync()),
   ];
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -201,3 +201,16 @@ bool isAnalysisTarget(String path) {
   final parts = p.split(path);
   return parts.isNotEmpty && _binOrLibSet.contains(parts.first);
 }
+
+/// The existing analysis targets in [packageDir].
+/// This is used to scope `dart analyze`.
+List<String> analysisTargetPaths(String packageDir) {
+  return [
+    ..._topLevelTargets.where(
+      (t) => File(p.join(packageDir, t)).existsSync(),
+    ),
+    ..._binOrLibSet.where(
+      (d) => Directory(p.join(packageDir, d)).existsSync(),
+    ),
+  ];
+}

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -3,8 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:pana/src/utils.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
@@ -36,6 +38,34 @@ void main() {
 
     test('non-ascii text', () {
       expect(nonAsciiRuneRatio('封装http业务接口'), 0.6);
+    });
+  });
+
+  group('analysisTargetPaths', () {
+    late Directory dir;
+
+    setUp(() {
+      dir = Directory.systemTemp.createTempSync('pana-analysis-targets');
+      File(p.join(dir.path, 'pubspec.yaml')).writeAsStringSync('name: x\n');
+    });
+
+    tearDown(() => dir.deleteSync(recursive: true));
+
+    test('only existing targets are returned', () {
+      expect(analysisTargetPaths(dir.path), ['pubspec.yaml']);
+
+      Directory(p.join(dir.path, 'lib')).createSync();
+      expect(analysisTargetPaths(dir.path), ['pubspec.yaml', 'lib']);
+
+      Directory(p.join(dir.path, 'bin')).createSync();
+      expect(analysisTargetPaths(dir.path), ['pubspec.yaml', 'bin', 'lib']);
+    });
+
+    test('non-target directories are excluded', () {
+      Directory(p.join(dir.path, 'lib')).createSync();
+      Directory(p.join(dir.path, 'test')).createSync();
+      Directory(p.join(dir.path, 'example')).createSync();
+      expect(analysisTargetPaths(dir.path), ['pubspec.yaml', 'lib']);
     });
   });
 }


### PR DESCRIPTION
pana runs `dart analyze .`, which also scans test/. Dev dependencies are stripped before analysis, so the test files can't resolve their imports and thus report errors. A package with a large test suite produces enough of these errors to exceed the analyzer's output limit, and that fails static analysis completely. Limiting analysis to those paths avoids the problem.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.

**Note**: The Dart team is trialing Gemini Code Assist. Don't take its comments as final Dart team feedback. Use the suggestions if they're helpful; otherwise, wait for a human reviewer.

</details>
