### PR TITLE
Fix conditional export configuration keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.23.14
+
+- Fix: use `lexeme` in `package:analyzer` to properly detect conditional imports.
+
 ## 0.23.13
 
 - Detect legacy Kotlin Gradle Plugin application and `kotlinOptions` in Android plugins.

--- a/lib/src/tag/_graphs.dart
+++ b/lib/src/tag/_graphs.dart
@@ -134,8 +134,10 @@ class LibraryGraph implements DirectedGraph<Uri> {
           var dependency = uri.resolve(directive.uri.stringValue!);
 
           for (final configuration in directive.configurations) {
+            // Use lexemes to preserve source spelling of keywords such as
+            // `library` in `dart.library.js_interop`.
             final dottedName = configuration.name.tokens
-                .map((i) => i.value())
+                .map((i) => i.lexeme)
                 .join();
 
             final testValue = configuration.value?.stringValue ?? 'true';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.23.13';
+const packageVersion = '0.23.14-dev';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.23.13
+version: 0.23.14-dev
 repository: https://github.com/dart-lang/pana
 topics:
   - tool

--- a/test/tag/tag_end2end_test.dart
+++ b/test/tag/tag_end2end_test.dart
@@ -854,6 +854,32 @@ import 'dart:js_interop_unsafe';
         _expectTagging(tagger.wasmReadyTag, tags: contains('is:wasm-ready'));
       },
     );
+
+    test('Included with dart.library.js_interop conditional export', () async {
+      final descriptor = d.dir('cache', [
+        packageWithPathDeps(
+          'my_package',
+          lib: [
+            d.file('my_package.dart', '''
+export 'src/native.dart'
+    if (dart.library.js_interop) 'src/web.dart';
+'''),
+            d.dir('src', [
+              d.file('native.dart', '''
+import 'dart:io';
+'''),
+              d.file('web.dart', '''
+import 'dart:js_interop';
+'''),
+            ]),
+          ],
+        ),
+      ]);
+
+      await descriptor.create();
+      final tagger = Tagger('${descriptor.io.path}/my_package');
+      _expectTagging(tagger.wasmReadyTag, tags: contains('is:wasm-ready'));
+    });
   });
 
   group('kotlin plugin tag', () {


### PR DESCRIPTION
## Summary
- Preserve conditional import/export configuration names with token lexemes instead of token values.
- Add a WASM tag regression for `dart.library.js_interop` conditional exports that select a web-safe implementation over an IO fallback.

## Root cause
With analyzer 13, `Token.value()` canonicalizes the `library` token in `dart.library.js_interop` to `LIBRARY`, so pana looks up `dart.LIBRARY.js_interop` instead of the declared runtime key `dart.library.js_interop`. That makes the conditional export resolver miss the web branch and follow the default IO export path.

Using `Token.lexeme` preserves the source spelling and matches the runtime declared variables.

## Validation
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos`
- `dart test test/tag/tag_end2end_test.dart --name "dart.library.js_interop conditional export"`
- `dart test --platform vm -j 1 test/tag/tag_end2end_test.dart`
- `dart test --platform vm test/tag/tag_detection_test.dart`
- `dart test`
