### PR TITLE
Protect against YAML alias expansion bombs in yamlToJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.23.16
+
+- Protect against YAML alias expansion bombs (Billion Laughs), cyclic references, and extreme nesting depth in `yamlToJson`.
+
 ## 0.23.15
 
 - Set `PANA_OPT_OUT_DARTDOC_SANITIZE_HTML` environment variable to `true`

--- a/lib/src/analysis_options.dart
+++ b/lib/src/analysis_options.dart
@@ -90,14 +90,16 @@ String updatePassthroughOptions({
   if (original != null) {
     try {
       origMap = yamlToJson(original);
-    } catch (_) {}
+    } on FormatException {
+      // pass, ignore broken YAML
+    }
   }
   origMap ??= {};
 
   Map customMap;
   try {
     customMap = yamlToJson(custom) ?? <String, dynamic>{};
-  } catch (_) {
+  } on FormatException {
     customMap = <String, dynamic>{};
   }
 

--- a/lib/src/analysis_options.dart
+++ b/lib/src/analysis_options.dart
@@ -9,7 +9,8 @@ import 'dart:isolate';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 import 'package:retry/retry.dart';
-import 'package:yaml/yaml.dart' as yaml;
+
+import 'utils.dart' show yamlToJson;
 
 final _logger = Logger('analysis_options');
 
@@ -88,14 +89,17 @@ String updatePassthroughOptions({
   Map? origMap;
   if (original != null) {
     try {
-      origMap = yaml.loadYaml(original) as Map;
+      origMap = yamlToJson(original);
     } catch (_) {}
   }
   origMap ??= {};
 
-  final customMap =
-      (json.decode(json.encode(yaml.loadYaml(custom))) as Map?) ??
-      <String, dynamic>{};
+  Map customMap;
+  try {
+    customMap = yamlToJson(custom) ?? <String, dynamic>{};
+  } catch (_) {
+    customMap = <String, dynamic>{};
+  }
 
   final appliedCustomRules = _extractAppliedRules(customMap);
 

--- a/lib/src/batch/batch_compare_command.dart
+++ b/lib/src/batch/batch_compare_command.dart
@@ -6,11 +6,10 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:yaml/yaml.dart' as yaml;
 
 import '../package_analyzer.dart';
 import '../sdk_env.dart' show SdkConfig, ToolEnvironment;
-import '../utils.dart' show withTempDir;
+import '../utils.dart' show withTempDir, yamlToJson;
 import 'batch_model.dart';
 
 /// Compares pana outcomes on the selected packages.
@@ -114,7 +113,11 @@ class BatchCompareCommand extends Command<void> {
     if (file.existsSync()) {
       var content = await file.readAsString();
       if (file.path.endsWith('.yaml')) {
-        content = json.encode(yaml.loadYaml(content));
+        final parsed = yamlToJson(content);
+        if (parsed == null) {
+          throw ArgumentError('Unable to load config: `$arg`.');
+        }
+        return BatchConfig.fromJson(parsed);
       }
       return BatchConfig.fromJson(json.decode(content) as Map<String, dynamic>);
     }

--- a/lib/src/batch/batch_run_command.dart
+++ b/lib/src/batch/batch_run_command.dart
@@ -6,11 +6,10 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:yaml/yaml.dart' as yaml;
 
 import '../package_analyzer.dart';
 import '../sdk_env.dart' show SdkConfig, ToolEnvironment;
-import '../utils.dart' show withTempDir;
+import '../utils.dart' show withTempDir, yamlToJson;
 import 'batch_model.dart';
 
 /// Runs pana on the selected packages.
@@ -86,7 +85,11 @@ class BatchRunCommand extends Command<void> {
     if (file.existsSync()) {
       var content = await file.readAsString();
       if (file.path.endsWith('.yaml')) {
-        content = json.encode(yaml.loadYaml(content));
+        final parsed = yamlToJson(content);
+        if (parsed == null) {
+          throw ArgumentError('Unable to load config: `$arg`.');
+        }
+        return BatchConfig.fromJson(parsed);
       }
       return BatchConfig.fromJson(json.decode(content) as Map<String, dynamic>);
     }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:collection';
-import 'dart:convert';
 import 'dart:io' hide BytesBuilder;
 
 import 'package:http/http.dart' as http;
@@ -61,14 +60,14 @@ List<String> dartFilesFromLib(String packageDir) {
 
 @visibleForTesting
 Object? sortedJson(Object? obj) {
-  final fullJson = json.decode(json.encode(obj));
-  return _toSortedMap(fullJson);
+  return _toSortedMap(obj);
 }
 
 Object? _toSortedMap(Object? item) {
   if (item is Map) {
     return SplayTreeMap<String, Object?>.fromIterable(
       item.keys,
+      key: (k) => k.toString(),
       value: (k) => _toSortedMap(item[k]),
     );
   } else if (item is List) {
@@ -78,7 +77,24 @@ Object? _toSortedMap(Object? item) {
   }
 }
 
-Map<String, Object?>? yamlToJson(String? yamlContent) {
+/// Converts a YAML-formatted string [yamlContent] into a JSON-compatible map
+/// with alphabetically sorted keys.
+///
+/// Returns `null` if [yamlContent] is `null` or if the parsed YAML root is not a [Map].
+///
+/// Throws a [FormatException] if the YAML contains cyclic references, exceeds
+/// the maximum allowed nesting depth ([maxDepth], default `64`), or exceeds the
+/// maximum allowed node count ([maxNodes], default `10000`) during expansion.
+///
+/// Throws a [YamlException] if the YAML syntax is invalid.
+///
+/// Performance: Runs in $O(N \log K)$ time where $N$ is the number of expanded
+/// nodes (capped by [maxNodes]) and $K$ is the average number of keys per map.
+Map<String, Object?>? yamlToJson(
+  String? yamlContent, {
+  int maxDepth = 64,
+  int maxNodes = 10000,
+}) {
   if (yamlContent == null) {
     return null;
   }
@@ -87,9 +103,115 @@ Map<String, Object?>? yamlToJson(String? yamlContent) {
     return null;
   }
 
-  // A bit paranoid, but I want to make sure this is valid JSON before we got to
-  // the encode phase.
-  return sortedJson(json.decode(json.encode(yamlMap))) as Map<String, Object?>;
+  final converter = _YamlConverter(maxDepth: maxDepth, maxNodes: maxNodes);
+  final converted = converter.convert(yamlMap, 0);
+  if (converted is! Map<String, Object?>) {
+    return null;
+  }
+  return converted;
+}
+
+final class _YamlConverter {
+  final int maxDepth;
+  final int maxNodes;
+  int _nodeCount = 0;
+  final Set<Object> _ancestors = Set<Object>.identity();
+
+  _YamlConverter({required this.maxDepth, required this.maxNodes});
+
+  Object? convert(Object? node, int depth) {
+    if (depth > maxDepth) {
+      throw const FormatException(
+        'YAML structure exceeds maximum allowed depth.',
+      );
+    }
+    _nodeCount++;
+    if (_nodeCount > maxNodes) {
+      throw const FormatException(
+        'YAML structure exceeds maximum allowed node count.',
+      );
+    }
+
+    if (node is YamlScalar) {
+      return _convertScalar(node.value);
+    } else if (node is YamlMap) {
+      if (!_ancestors.add(node)) {
+        throw const FormatException('Cyclic reference detected in YAML.');
+      }
+      try {
+        final result = SplayTreeMap<String, Object?>();
+        for (final entry in node.nodes.entries) {
+          final keyStr = _convertKey(entry.key);
+          result[keyStr] = convert(entry.value, depth + 1);
+        }
+        return result;
+      } finally {
+        _ancestors.remove(node);
+      }
+    } else if (node is YamlList) {
+      if (!_ancestors.add(node)) {
+        throw const FormatException('Cyclic reference detected in YAML.');
+      }
+      try {
+        final result = <Object?>[];
+        for (final item in node.nodes) {
+          result.add(convert(item, depth + 1));
+        }
+        return result;
+      } finally {
+        _ancestors.remove(node);
+      }
+    } else if (node is Map) {
+      if (!_ancestors.add(node)) {
+        throw const FormatException('Cyclic reference detected in YAML.');
+      }
+      try {
+        final result = SplayTreeMap<String, Object?>();
+        for (final entry in node.entries) {
+          final keyStr = _convertKey(entry.key);
+          result[keyStr] = convert(entry.value, depth + 1);
+        }
+        return result;
+      } finally {
+        _ancestors.remove(node);
+      }
+    } else if (node is List) {
+      if (!_ancestors.add(node)) {
+        throw const FormatException('Cyclic reference detected in YAML.');
+      }
+      try {
+        final result = <Object?>[];
+        for (final item in node) {
+          result.add(convert(item, depth + 1));
+        }
+        return result;
+      } finally {
+        _ancestors.remove(node);
+      }
+    } else {
+      return _convertScalar(node);
+    }
+  }
+
+  String _convertKey(Object? key) {
+    if (key is YamlScalar) {
+      key = key.value;
+    }
+    if (key == null) {
+      return 'null';
+    }
+    if (key is String || key is num || key is bool) {
+      return key.toString();
+    }
+    throw FormatException('Unsupported key type in YAML: ${key.runtimeType}');
+  }
+
+  Object? _convertScalar(Object? value) {
+    if (value == null || value is String || value is num || value is bool) {
+      return value;
+    }
+    return value.toString();
+  }
 }
 
 /// Returns the ratio of non-ASCII runes (Unicode characters) in a given text:

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:collection';
 import 'dart:io' hide BytesBuilder;
 
 import 'package:http/http.dart' as http;
@@ -65,11 +64,12 @@ Object? sortedJson(Object? obj) {
 
 Object? _toSortedMap(Object? item) {
   if (item is Map) {
-    return SplayTreeMap<String, Object?>.fromIterable(
-      item.keys,
-      key: (k) => k.toString(),
-      value: (k) => _toSortedMap(item[k]),
-    );
+    final sortedKeys = item.keys.map((k) => k.toString()).toList()..sort();
+    final result = <String, Object?>{};
+    for (final k in sortedKeys) {
+      result[k] = _toSortedMap(item[k]);
+    }
+    return result;
   } else if (item is List) {
     return item.map(_toSortedMap).toList();
   } else {
@@ -139,10 +139,13 @@ final class _YamlConverter {
         throw const FormatException('Cyclic reference detected in YAML.');
       }
       try {
-        final result = SplayTreeMap<String, Object?>();
-        for (final entry in node.nodes.entries) {
-          final keyStr = _convertKey(entry.key);
-          result[keyStr] = convert(entry.value, depth + 1);
+        final entries = [
+          for (final entry in node.nodes.entries)
+            MapEntry(_convertKey(entry.key), entry.value),
+        ]..sort((a, b) => a.key.compareTo(b.key));
+        final result = <String, Object?>{};
+        for (final entry in entries) {
+          result[entry.key] = convert(entry.value, depth + 1);
         }
         return result;
       } finally {
@@ -166,10 +169,13 @@ final class _YamlConverter {
         throw const FormatException('Cyclic reference detected in YAML.');
       }
       try {
-        final result = SplayTreeMap<String, Object?>();
-        for (final entry in node.entries) {
-          final keyStr = _convertKey(entry.key);
-          result[keyStr] = convert(entry.value, depth + 1);
+        final entries = [
+          for (final entry in node.entries)
+            MapEntry(_convertKey(entry.key), entry.value),
+        ]..sort((a, b) => a.key.compareTo(b.key));
+        final result = <String, Object?>{};
+        for (final entry in entries) {
+          result[entry.key] = convert(entry.value, depth + 1);
         }
         return result;
       } finally {

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.23.15';
+const packageVersion = '0.23.16';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.23.15
+version: 0.23.16
 repository: https://github.com/dart-lang/pana
 topics:
   - tool

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -22,6 +22,125 @@ void main() {
     );
   });
 
+  group('yamlToJson', () {
+    test('null or non-map input returns null', () {
+      expect(yamlToJson(null), isNull);
+      expect(yamlToJson(''), isNull);
+      expect(yamlToJson('   '), isNull);
+      expect(yamlToJson('123'), isNull);
+      expect(yamlToJson('"hello"'), isNull);
+      expect(yamlToJson('- a\n- b'), isNull);
+    });
+
+    test('valid yaml map with sorted keys', () {
+      final yaml = '''
+b:
+  d: 4
+  c: 3
+a: 2
+''';
+      expect(yamlToJson(yaml), {
+        'a': 2,
+        'b': {'c': 3, 'd': 4},
+      });
+    });
+
+    test('valid yaml with reasonable alias expansion', () {
+      final yaml = '''
+default: &default
+  timeout: 30
+service1:
+  <<: *default
+  name: s1
+service2:
+  <<: *default
+  name: s2
+''';
+      expect(yamlToJson(yaml), {
+        'default': {'timeout': 30},
+        'service1': {
+          '<<': {'timeout': 30},
+          'name': 's1',
+        },
+        'service2': {
+          '<<': {'timeout': 30},
+          'name': 's2',
+        },
+      });
+    });
+
+    test('rejects YAML alias expansion bomb (billion laughs)', () {
+      final bomb = '''
+a: &a ["lol","lol","lol","lol","lol","lol","lol","lol","lol","lol"]
+b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a,*a]
+c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b,*b]
+d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c,*c]
+e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d,*d]
+f: &f [*e,*e,*e,*e,*e,*e,*e,*e,*e,*e]
+g: &g [*f,*f,*f,*f,*f,*f,*f,*f,*f,*f]
+h: &h [*g,*g,*g,*g,*g,*g,*g,*g,*g,*g]
+''';
+      expect(
+        () => yamlToJson(bomb),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('maximum allowed node count'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects cyclic YAML references', () {
+      final cyclic = '''
+a: &a
+  b: *a
+''';
+      expect(
+        () => yamlToJson(cyclic),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('Cyclic reference detected'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects YAML exceeding max depth', () {
+      final deep = '${List.generate(70, (i) => '${'  ' * i}a:').join('\n')} 1';
+      expect(
+        () => yamlToJson(deep, maxDepth: 64),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('maximum allowed depth'),
+          ),
+        ),
+      );
+    });
+
+    test('respects custom maxNodes limit', () {
+      final yaml = '''
+a: [1, 2, 3, 4, 5]
+b: [6, 7, 8, 9, 10]
+''';
+      expect(
+        () => yamlToJson(yaml, maxNodes: 5),
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            contains('maximum allowed node count'),
+          ),
+        ),
+      );
+    });
+  });
+
   group('runes', () {
     test('empty', () {
       expect(nonAsciiRuneRatio(null), 0.0);


### PR DESCRIPTION
Replaces `json.decode(json.encode(yamlMap))` with a bounded recursive converter in `yamlToJson`.

The converter guards against entity expansion bombs (Billion Laughs), cyclic references, and extreme nesting depth by enforcing `maxNodes` (default 10,000) and `maxDepth` (default 64) limits while sorting map keys directly without intermediate JSON stringification.