### PR TITLE
Prevent following symlinks when writing dartdoc_options.yaml and analysis_options.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
+## 0.23.17-wip
+
+- Delete symlinks before writing `dartdoc_options.yaml` and `analysis_options.yaml` to prevent out-of-tree file writes.
+
 ## 0.23.16
 
 - Protect against YAML alias expansion bombs (Billion Laughs), cyclic references, and extreme nesting depth in `yamlToJson`.
-- Delete symlinks before writing `dartdoc_options.yaml` and `analysis_options.yaml` to prevent out-of-tree file writes.
 
 ## 0.23.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.23.16
 
 - Protect against YAML alias expansion bombs (Billion Laughs), cyclic references, and extreme nesting depth in `yamlToJson`.
+- Delete symlinks before writing `dartdoc_options.yaml` and `analysis_options.yaml` to prevent out-of-tree file writes.
 
 ## 0.23.15
 

--- a/lib/src/dartdoc/dartdoc_options.dart
+++ b/lib/src/dartdoc/dartdoc_options.dart
@@ -20,6 +20,10 @@ Future<void> normalizeDartdocOptionsYaml(String packageDir) async {
     // pass, ignore broken file
   }
   final updatedContent = _customizeDartdocOptions(originalContent);
+  if (await FileSystemEntity.type(optionsFile.path, followLinks: false) ==
+      FileSystemEntityType.link) {
+    await Link(optionsFile.path).delete();
+  }
   await optionsFile.writeAsString(json.encode(updatedContent));
 }
 

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -238,8 +238,14 @@ class ToolEnvironment {
     final analysisOptionsFile = File(
       p.join(packageDir, 'analysis_options.yaml'),
     );
+    final isLink =
+        await FileSystemEntity.type(
+          analysisOptionsFile.path,
+          followLinks: false,
+        ) ==
+        FileSystemEntityType.link;
     String? originalOptions;
-    if (await analysisOptionsFile.exists()) {
+    if (!isLink && await analysisOptionsFile.exists()) {
       originalOptions = await analysisOptionsFile.readAsString();
     }
     final rawOptionsContent = await getDefaultAnalysisOptionsYaml();
@@ -248,12 +254,17 @@ class ToolEnvironment {
       custom: rawOptionsContent,
       useAnalysisIncludes: _useAnalysisIncludes,
     );
+    if (isLink) {
+      await Link(analysisOptionsFile.path).delete();
+    }
     try {
       await analysisOptionsFile.writeAsString(customOptionsContent);
       return await fn();
     } finally {
       if (originalOptions == null) {
-        await analysisOptionsFile.delete();
+        if (await analysisOptionsFile.exists()) {
+          await analysisOptionsFile.delete();
+        }
       } else {
         await analysisOptionsFile.writeAsString(originalOptions);
       }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.23.16';
+const packageVersion = '0.23.17-wip';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.23.16
+version: 0.23.17-wip
 repository: https://github.com/dart-lang/pana
 topics:
   - tool

--- a/test/dartdoc/dartdoc_options_test.dart
+++ b/test/dartdoc/dartdoc_options_test.dart
@@ -1,0 +1,119 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:pana/src/dartdoc/dartdoc_options.dart';
+import 'package:pana/src/utils.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('normalizeDartdocOptionsYaml', () {
+    test('normalizes existing dartdoc_options.yaml', () async {
+      await withTempDir((dir) async {
+        final file = File(p.join(dir, 'dartdoc_options.yaml'));
+        await file.writeAsString('''
+dartdoc:
+  include: ['lib/foo.dart']
+  custom_flag: true
+''');
+
+        await normalizeDartdocOptionsYaml(dir);
+
+        final content =
+            json.decode(await file.readAsString()) as Map<String, dynamic>;
+        expect(content, {
+          'dartdoc': {
+            'include': ['lib/foo.dart'],
+            'showUndocumentedCategories': true,
+          },
+        });
+      });
+    });
+
+    test('creates default options if file does not exist', () async {
+      await withTempDir((dir) async {
+        final file = File(p.join(dir, 'dartdoc_options.yaml'));
+        expect(await file.exists(), isFalse);
+
+        await normalizeDartdocOptionsYaml(dir);
+
+        expect(await file.exists(), isTrue);
+        final content =
+            json.decode(await file.readAsString()) as Map<String, dynamic>;
+        expect(content, {
+          'dartdoc': {'showUndocumentedCategories': true},
+        });
+      });
+    });
+
+    test(
+      'replaces dangling symlink without creating out-of-tree target',
+      () async {
+        await withTempDir((dir) async {
+          final outsideDir = await Directory.systemTemp.createTemp('outside_');
+          try {
+            final outsideTarget = p.join(outsideDir.path, 'canary.txt');
+            final symlink = Link(p.join(dir, 'dartdoc_options.yaml'));
+            await symlink.create(outsideTarget);
+
+            expect(await File(outsideTarget).exists(), isFalse);
+
+            await normalizeDartdocOptionsYaml(dir);
+
+            // Target file outside should not be created.
+            expect(await File(outsideTarget).exists(), isFalse);
+
+            // Options file in package dir should now be a regular file.
+            final optionsFile = File(p.join(dir, 'dartdoc_options.yaml'));
+            expect(
+              await FileSystemEntity.type(optionsFile.path, followLinks: false),
+              FileSystemEntityType.file,
+            );
+            final content =
+                json.decode(await optionsFile.readAsString())
+                    as Map<String, dynamic>;
+            expect(content, {
+              'dartdoc': {'showUndocumentedCategories': true},
+            });
+          } finally {
+            await outsideDir.delete(recursive: true);
+          }
+        });
+      },
+    );
+
+    test(
+      'replaces symlink to existing file without modifying target',
+      () async {
+        await withTempDir((dir) async {
+          final outsideDir = await Directory.systemTemp.createTemp('outside_');
+          try {
+            final outsideTarget = File(p.join(outsideDir.path, 'target.yaml'));
+            await outsideTarget.writeAsString('original: content\n');
+
+            final symlink = Link(p.join(dir, 'dartdoc_options.yaml'));
+            await symlink.create(outsideTarget.path);
+
+            await normalizeDartdocOptionsYaml(dir);
+
+            // Target file outside should be unchanged.
+            expect(await outsideTarget.readAsString(), 'original: content\n');
+
+            // Options file in package dir should now be a regular file.
+            final optionsFile = File(p.join(dir, 'dartdoc_options.yaml'));
+            expect(
+              await FileSystemEntity.type(optionsFile.path, followLinks: false),
+              FileSystemEntityType.file,
+            );
+          } finally {
+            await outsideDir.delete(recursive: true);
+          }
+        });
+      },
+    );
+  });
+}

--- a/test/sdk_env_test.dart
+++ b/test/sdk_env_test.dart
@@ -2,7 +2,12 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:pana/src/package_analyzer.dart';
 import 'package:pana/src/sdk_env.dart';
+import 'package:pana/src/utils.dart';
+import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
@@ -49,4 +54,45 @@ void main() {
       throwsA(isA<FormatException>()),
     );
   });
+
+  test(
+    'runAnalyzer handles dangling symlink analysis_options.yaml safely',
+    () async {
+      final toolEnv = await ToolEnvironment.create();
+      await withTempDir((dir) async {
+        final outsideDir = await Directory.systemTemp.createTemp('outside_');
+        try {
+          final outsideTarget = p.join(outsideDir.path, 'canary.txt');
+          final symlink = Link(p.join(dir, 'analysis_options.yaml'));
+          await symlink.create(outsideTarget);
+
+          final pubspec = File(p.join(dir, 'pubspec.yaml'));
+          await pubspec.writeAsString('''
+name: test_pkg
+version: 1.0.0
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+''');
+          final libDir = Directory(p.join(dir, 'lib'))..createSync();
+          File(
+            p.join(libDir.path, 'test_pkg.dart'),
+          ).writeAsStringSync('void main() {}\n');
+
+          expect(await File(outsideTarget).exists(), isFalse);
+
+          await toolEnv.runAnalyzer(
+            dir,
+            'lib',
+            false,
+            inspectOptions: InspectOptions(),
+          );
+
+          // Target file outside should not be created.
+          expect(await File(outsideTarget).exists(), isFalse);
+        } finally {
+          await outsideDir.delete(recursive: true);
+        }
+      });
+    },
+  );
 }

--- a/test/sdk_env_test.dart
+++ b/test/sdk_env_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io';
 
-import 'package:pana/src/package_analyzer.dart';
 import 'package:pana/src/sdk_env.dart';
 import 'package:pana/src/utils.dart';
 import 'package:path/path.dart' as p;
@@ -56,7 +55,7 @@ void main() {
   });
 
   test(
-    'runAnalyzer handles dangling symlink analysis_options.yaml safely',
+    'filesNeedingFormat handles dangling symlink analysis_options.yaml safely',
     () async {
       final toolEnv = await ToolEnvironment.create();
       await withTempDir((dir) async {
@@ -80,12 +79,7 @@ environment:
 
           expect(await File(outsideTarget).exists(), isFalse);
 
-          await toolEnv.runAnalyzer(
-            dir,
-            'lib',
-            false,
-            inspectOptions: InspectOptions(),
-          );
+          await toolEnv.filesNeedingFormat(dir, false);
 
           // Target file outside should not be created.
           expect(await File(outsideTarget).exists(), isFalse);


### PR DESCRIPTION
When normalizing `dartdoc_options.yaml` or writing restricted `analysis_options.yaml`, delete any existing symlink at that path beforehand so `File.writeAsString` writes to a regular file inside the package directory instead of traversing the link.