### PR TITLE
Validate repository URL reachability before creating local git repository

### DIFF
--- a/lib/src/repository/check_repository.dart
+++ b/lib/src/repository/check_repository.dart
@@ -83,11 +83,27 @@ Future<VerifiedRepository> checkRepository({
     log.info(message, error, st);
   }
 
+  final cloneUrl = parsedSourceUrl.cloneUrl;
+  final urlStatus = await sharedContext.checkUrlStatus(cloneUrl);
+  if (urlStatus.isInvalid) {
+    return VerifiedRepository(
+      status: RepositoryStatus.invalid,
+      verificationFailure: 'Repository URL `$cloneUrl` is not valid or secure.',
+    );
+  }
+  if (!urlStatus.exists) {
+    return VerifiedRepository(
+      status: RepositoryStatus.missing,
+      verificationFailure:
+          'Repository URL `$cloneUrl` does not exist or is not reachable.',
+    );
+  }
+
   late GitLocalRepository repo;
   try {
     repo = await GitLocalRepository.createLocalRepository(
       sharedContext.toolEnvironment.sandboxRunner,
-      parsedSourceUrl.cloneUrl,
+      cloneUrl,
     );
     branch = await repo.detectDefaultBranch();
 

--- a/test/goldens/end2end/gg-1.0.12.json
+++ b/test/goldens/end2end/gg-1.0.12.json
@@ -160,7 +160,7 @@
   "screenshots": [],
   "result": {
     "repositoryUrl": "https://github.com/inlavigo/gg.git",
-    "repositoryStatus": "inconclusive",
+    "repositoryStatus": "missing",
     "licenses": [
       {
         "spdxIdentifier": "MIT",

--- a/test/repository/check_repository_test.dart
+++ b/test/repository/check_repository_test.dart
@@ -1,0 +1,105 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pana/pana.dart';
+import 'package:pana/src/package_context.dart';
+import 'package:pana/src/repository/check_repository.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('checkRepository', () {
+    late ToolEnvironment toolEnv;
+
+    setUpAll(() async {
+      toolEnv = await ToolEnvironment.create();
+    });
+
+    test('missing URL', () async {
+      final result = await checkRepository(
+        sharedContext: SharedAnalysisContext(toolEnvironment: toolEnv),
+        packageName: 'pana',
+        sourceUrl: null,
+      );
+      expect(result.status, RepositoryStatus.missing);
+      expect(result.verificationFailure, 'Repository URL is missing.');
+    });
+
+    test('empty URL', () async {
+      final result = await checkRepository(
+        sharedContext: SharedAnalysisContext(toolEnvironment: toolEnv),
+        packageName: 'pana',
+        sourceUrl: '   ',
+      );
+      expect(result.status, RepositoryStatus.missing);
+      expect(result.verificationFailure, 'Repository URL is missing.');
+    });
+
+    test('invalid URL', () async {
+      final result = await checkRepository(
+        sharedContext: SharedAnalysisContext(toolEnvironment: toolEnv),
+        packageName: 'pana',
+        sourceUrl: 'https://example.com/not/github/repo',
+      );
+      expect(result.status, RepositoryStatus.invalid);
+      expect(
+        result.verificationFailure,
+        contains('Could not recognize URL segments'),
+      );
+    });
+
+    test(
+      'private/loopback URL is rejected without git access (SSRF)',
+      () async {
+        final result = await checkRepository(
+          sharedContext: SharedAnalysisContext(toolEnvironment: toolEnv),
+          packageName: 'pana',
+          sourceUrl: 'https://127.0.0.1/dart-lang/pana.git',
+        );
+        expect(result.status, RepositoryStatus.missing);
+        expect(
+          result.verificationFailure,
+          contains('does not exist or is not reachable'),
+        );
+      },
+    );
+
+    test('non-existent repository URL', () async {
+      final result = await checkRepository(
+        sharedContext: SharedAnalysisContext(toolEnvironment: toolEnv),
+        packageName: 'pana',
+        sourceUrl:
+            'https://github.com/dart-lang/non-existing-repository-1234567',
+      );
+      expect(result.status, RepositoryStatus.missing);
+      expect(
+        result.verificationFailure,
+        contains('does not exist or is not reachable'),
+      );
+    });
+
+    test('verified repository', () async {
+      final result = await checkRepository(
+        sharedContext: SharedAnalysisContext(toolEnvironment: toolEnv),
+        packageName: 'pana',
+        sourceUrl: 'https://github.com/dart-lang/pana',
+      );
+      expect(result.status, RepositoryStatus.verified);
+      expect(result.verificationFailure, isNull);
+      expect(result.repository?.repository, 'dart-lang/pana');
+    });
+
+    test('package name mismatch in repository', () async {
+      final result = await checkRepository(
+        sharedContext: SharedAnalysisContext(toolEnvironment: toolEnv),
+        packageName: 'non_existing_pkg_name',
+        sourceUrl: 'https://github.com/dart-lang/pana',
+      );
+      expect(result.status, RepositoryStatus.failed);
+      expect(
+        result.verificationFailure,
+        'Repository has no matching `pubspec.yaml` with `name: non_existing_pkg_name`.',
+      );
+    });
+  });
+}


### PR DESCRIPTION
This PR prevents SSRF(Server-Side Request Forgery) during repository verification by pre-validating the repository URL before creating the local git repository and running `git` commands:

1. Calls `sharedContext.checkUrlStatus(cloneUrl)` (using `package:safe_url_check`) in `checkRepository` prior to `GitLocalRepository.createLocalRepository`.
2. Rejects private, loopback, link-local, and metadata URLs as well as unreachable hosts with `RepositoryStatus.missing` or `invalid`, avoiding spawning `git` subprocesses against arbitrary internal addresses.
3. Adds unit tests verifying that loopback and private repository URLs are rejected before Git operations.