### PR TITLE
Reject screenshot paths with colons and validate sandbox output folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.23.17-wip
 
 - Delete symlinks before writing `dartdoc_options.yaml` and `analysis_options.yaml` to prevent out-of-tree file writes.
+- Reject screenshot paths containing colons and validate sandbox output folders.
 
 ## 0.23.16
 

--- a/lib/src/sandbox_runner.dart
+++ b/lib/src/sandbox_runner.dart
@@ -35,6 +35,9 @@ class SandboxRunner {
   ///
   /// The script will restrict network access, unless
   /// `SANDBOX_NETWORK_ENABLED=true` is specified.
+  ///
+  /// It is an error if any directory path in [outputFolder], [outputFolders],
+  /// or derived writable directories contains a colon (`:`).
   Future<PanaProcessResult> runSandboxed(
     List<String> arguments, {
     String? workingDirectory,
@@ -57,6 +60,15 @@ class SandboxRunner {
       ?(writablePubCacheDir ? environment['PUB_CACHE'] : null),
       ?(writableCurrentDir ? workingDirectory : null),
     };
+    for (final folder in allOutputFolders) {
+      if (folder.contains(':')) {
+        throw ArgumentError.value(
+          folder,
+          'outputFolder',
+          'Sandbox output folder must not contain ":"',
+        );
+      }
+    }
     return await runConstrained(
       [?_executable, ...arguments],
       workingDirectory: workingDirectory,

--- a/lib/src/screenshots.dart
+++ b/lib/src/screenshots.dart
@@ -119,6 +119,10 @@ List<String> _validateScreenshot(p.Screenshot screenshot, String pkgDir) {
   }
   if (screenshot.path.isEmpty) {
     problems.add('${screenshot.path}: Screenshot `path` property is missing.');
+  } else if (screenshot.path.contains(':')) {
+    problems.add(
+      '${screenshot.path}: Screenshot `path` must not contain a colon (`:`).',
+    );
   }
 
   final fullPath = path.join(pkgDir, screenshot.path);

--- a/test/sandbox_runner_test.dart
+++ b/test/sandbox_runner_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:pana/src/sandbox_runner.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SandboxRunner', () {
+    test('rejects outputFolder with colon', () async {
+      final runner = SandboxRunner(null);
+      expect(
+        () => runner.runSandboxed([
+          'echo',
+          'hello',
+        ], outputFolder: '/tmp/gen/a:/home:'),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('must not contain ":"'),
+          ),
+        ),
+      );
+    });
+
+    test('rejects outputFolders with colon', () async {
+      final runner = SandboxRunner(null);
+      expect(
+        () => runner.runSandboxed(
+          ['echo', 'hello'],
+          outputFolders: ['/tmp/valid', '/tmp/a:/b'],
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('must not contain ":"'),
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/screenshot_test.dart
+++ b/test/screenshot_test.dart
@@ -74,6 +74,25 @@ void main() {
       contains('Screenshot `path` property is missing.'),
     );
   });
+  test('validates path with colon', () async {
+    final pkgDir = 'my_pkg';
+
+    final s = Screenshot('d', 'a:/home:/x.png');
+    final declared = <Screenshot>[s];
+    final r = await processAllScreenshots(
+      declared,
+      pkgDir,
+      WebpTool(SandboxRunner(null)),
+    );
+
+    expect(r.length, 1);
+    expect(r.first.processedScreenshot, isNull);
+    expect(r.first.problems, isNotEmpty);
+    expect(
+      r.first.problems.first,
+      contains('Screenshot `path` must not contain a colon (`:`).'),
+    );
+  });
   test('validates long description', () async {
     final pkgDir = 'my_pkg';
 


### PR DESCRIPTION
- Reject screenshot paths containing colons (`:`) during validation.
- Validate that output directory paths passed to `SandboxRunner.runSandboxed` do not contain colons.