### PR TITLE
Widen analyzer constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '^3.11.0'
 
 dependencies:
-  analyzer: ^14.1.0
+  analyzer: '>=13.0.0 <15.0.0'
   args: ^2.7.0
   async: ^2.13.0
   cli_util: ^0.5.0


### PR DESCRIPTION
Widens the `analyzer` dependency constraint to `>=13.0.0 <15.0.0` to support both 13.x and 14.x.