### PR TITLE
Enable PR comments from forks via post_summaries workflow

### DIFF
--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -1,0 +1,18 @@
+# A CI configuration to write comments on PRs.
+
+name: Comment on the pull request
+
+on:
+  # Trigger this workflow after the Publish workflow completes. This workflow will have permissions to
+  # do things like create comments on the PR, even if the original workflow couldn't.
+  workflow_run:
+    workflows:
+      - Publish
+    types:
+      - completed
+
+jobs:
+  upload:
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@d8c8a4c2f96165be9764025e29fbfb2069558809 # main
+    permissions:
+      pull-requests: write

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -2,10 +2,13 @@
 
 name: Comment on the pull request
 
+permissions:
+  contents: read
+
 on:
   # Trigger this workflow after the Publish workflow completes. This workflow will have permissions to
   # do things like create comments on the PR, even if the original workflow couldn't.
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows:
       - Publish
     types:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,3 +19,4 @@ jobs:
     with:
       environment: pub-dev
       tag-prefix: ""
+      write-comments: false


### PR DESCRIPTION
Sets `write-comments: false` in `publish.yaml` and adds `post_summaries.yaml` to post publication analysis comments on pull requests from forks.