### PR TITLE
Prevent following symlinks when listing package files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.23.18-wip
+
+- Prevent following symlinks when listing and inspecting files in a package directory.
+
 ## 0.23.17
 
 - Parallelize end-to-end golden tests with a shared test environment and concurrency pool.

--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -430,7 +430,7 @@ class PackageContext {
       return <String>[];
     }
     final executables = <String>[];
-    final entries = await binDir.list().toList();
+    final entries = await binDir.list(followLinks: false).toList();
     for (final file in entries.whereType<File>()) {
       if (!file.path.endsWith('.dart')) {
         continue;

--- a/lib/src/report/documentation.dart
+++ b/lib/src/report/documentation.dart
@@ -23,7 +23,7 @@ Future<Subsection> _exampleSubsection(PackageContext context) async {
   //
   // This should work on case-preserving but insensitive file-systems.
   final files = Directory(packageDir)
-      .listSync(recursive: true)
+      .listSync(recursive: true, followLinks: false)
       .map(
         (e) => p.posix.joinAll(p.split(p.relative(e.path, from: packageDir))),
       );

--- a/lib/src/tag/tagger.dart
+++ b/lib/src/tag/tagger.dart
@@ -164,7 +164,7 @@ class Tagger {
     final binDir = Directory(path.join(packageDir, 'bin'));
     final allBinFiles = binDir.existsSync()
         ? binDir
-              .listSync(recursive: true)
+              .listSync(recursive: true, followLinks: false)
               .where((e) => e is File && e.path.endsWith('.dart'))
               .map((f) => path.relative(f.path, from: binDir.path))
               .toList()

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -13,6 +13,14 @@ import 'package:yaml/yaml.dart';
 
 import 'logging.dart';
 
+/// Lists all regular files in [directory] recursively without following symlinks.
+///
+/// If [endsWith] is provided, only files ending with the specified string are returned.
+///
+/// If [deleteBadExtracted] is `true`, files whose names start with `._` (such as
+/// AppleDouble resource forks) are deleted and excluded from the stream.
+///
+/// Paths are returned relative to [directory].
 Stream<String> listFiles(
   String directory, {
   String? endsWith,
@@ -20,7 +28,7 @@ Stream<String> listFiles(
 }) {
   var dir = Directory(directory);
   return dir
-      .list(recursive: true)
+      .list(recursive: true, followLinks: false)
       .where((fse) => fse is File)
       .where((fse) {
         if (deleteBadExtracted) {
@@ -46,7 +54,7 @@ List<String> dartFilesFromLib(String packageDir) {
   final libDirExists = libDir.existsSync();
   final dartFiles = libDirExists
       ? libDir
-            .listSync(recursive: true)
+            .listSync(recursive: true, followLinks: false)
             .where((e) => e is File && e.path.endsWith('.dart'))
             .map((f) => p.relative(f.path, from: libDir.path))
             .toList()
@@ -255,7 +263,9 @@ Future<T> withTempDir<T>(FutureOr<T> Function(String path) fn) async {
 }
 
 Future<void> copyDir(String from, String to) async {
-  await for (final fse in Directory(from).list(recursive: true)) {
+  await for (final fse in Directory(
+    from,
+  ).list(recursive: true, followLinks: false)) {
     final relativePath = p.relative(fse.path, from: from);
     // The following file is used by `git-fsmonitor` and copying is blocked.
     // https://git-scm.com/docs/git-fsmonitor--daemon

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.23.17';
+const packageVersion = '0.23.18-wip';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pana
 description: PAckage aNAlyzer - produce a report summarizing the health and quality of a Dart package.
-version: 0.23.17
+version: 0.23.18-wip
 repository: https://github.com/dart-lang/pana
 topics:
   - tool

--- a/test/utils_test.dart
+++ b/test/utils_test.dart
@@ -3,8 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:pana/src/utils.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
@@ -155,6 +157,165 @@ b: [6, 7, 8, 9, 10]
 
     test('non-ascii text', () {
       expect(nonAsciiRuneRatio('封装http业务接口'), 0.6);
+    });
+  });
+
+  group('listFiles', () {
+    test('lists files in directory and subdirectories', () async {
+      await withTempDir((dir) async {
+        File(p.join(dir, 'a.txt')).writeAsStringSync('a');
+        final subDir = Directory(p.join(dir, 'sub'))..createSync();
+        File(p.join(subDir.path, 'b.txt')).writeAsStringSync('b');
+        final nestedDir = Directory(p.join(subDir.path, 'nested'))
+          ..createSync();
+        File(p.join(nestedDir.path, 'c.dart')).writeAsStringSync('c');
+
+        final files = await listFiles(dir).toList();
+        expect(
+          files,
+          unorderedEquals([
+            'a.txt',
+            p.join('sub', 'b.txt'),
+            p.join('sub', 'nested', 'c.dart'),
+          ]),
+        );
+      });
+    });
+
+    test('filters by endsWith', () async {
+      await withTempDir((dir) async {
+        File(p.join(dir, 'a.txt')).writeAsStringSync('a');
+        final subDir = Directory(p.join(dir, 'sub'))..createSync();
+        File(p.join(subDir.path, 'b.dart')).writeAsStringSync('b');
+
+        final files = await listFiles(dir, endsWith: '.dart').toList();
+        expect(files, [p.join('sub', 'b.dart')]);
+      });
+    });
+
+    test(
+      'deletes invalid AppleDouble files when deleteBadExtracted is true',
+      () async {
+        await withTempDir((dir) async {
+          final badFile = File(p.join(dir, '._bad.txt'))
+            ..writeAsStringSync('bad');
+          final subDir = Directory(p.join(dir, 'sub'))..createSync();
+          final nestedBadFile = File(p.join(subDir.path, '._nested.dart'))
+            ..writeAsStringSync('bad');
+          File(p.join(dir, 'good.txt')).writeAsStringSync('good');
+
+          expect(badFile.existsSync(), isTrue);
+          expect(nestedBadFile.existsSync(), isTrue);
+
+          final files = await listFiles(dir, deleteBadExtracted: true).toList();
+          expect(files, ['good.txt']);
+          expect(badFile.existsSync(), isFalse);
+          expect(nestedBadFile.existsSync(), isFalse);
+        });
+      },
+    );
+
+    test(
+      'does not follow directory symlinks and does not delete out-of-tree files',
+      () async {
+        await withTempDir((dir) async {
+          final outsideDir = await Directory.systemTemp.createTemp('outside_');
+          try {
+            final outsideBadFile = File(
+              p.join(outsideDir.path, '._outside.txt'),
+            )..writeAsStringSync('secret');
+            final outsideGoodFile = File(
+              p.join(outsideDir.path, 'outside.dart'),
+            )..writeAsStringSync('code');
+
+            // Create a symlink to outsideDir inside dir
+            final link = Link(p.join(dir, 'symlink_dir'));
+            await link.create(outsideDir.path);
+
+            File(p.join(dir, 'local.dart')).writeAsStringSync('local');
+
+            final files = await listFiles(
+              dir,
+              deleteBadExtracted: true,
+            ).toList();
+
+            // Only local file should be returned
+            expect(files, ['local.dart']);
+
+            // Out-of-tree files should be intact
+            expect(outsideBadFile.existsSync(), isTrue);
+            expect(outsideGoodFile.existsSync(), isTrue);
+          } finally {
+            await outsideDir.delete(recursive: true);
+          }
+        });
+      },
+    );
+
+    test(
+      'does not follow file symlinks and does not delete out-of-tree target file',
+      () async {
+        await withTempDir((dir) async {
+          final outsideDir = await Directory.systemTemp.createTemp('outside_');
+          try {
+            final outsideBadFile = File(p.join(outsideDir.path, '._target.txt'))
+              ..writeAsStringSync('secret');
+
+            // Create a file symlink inside dir pointing to outside bad file
+            final link = Link(p.join(dir, 'symlink_file'));
+            await link.create(outsideBadFile.path);
+
+            final files = await listFiles(
+              dir,
+              deleteBadExtracted: true,
+            ).toList();
+
+            expect(files, isEmpty);
+            expect(outsideBadFile.existsSync(), isTrue);
+          } finally {
+            await outsideDir.delete(recursive: true);
+          }
+        });
+      },
+    );
+
+    test('handles cyclic directory symlinks safely', () async {
+      await withTempDir((dir) async {
+        final subDir = Directory(p.join(dir, 'sub'))..createSync();
+        File(p.join(dir, 'a.txt')).writeAsStringSync('a');
+
+        // Create a cyclic symlink: sub/loop -> dir
+        final link = Link(p.join(subDir.path, 'loop'));
+        await link.create(dir);
+
+        final files = await listFiles(dir).toList();
+        expect(files, ['a.txt']);
+      });
+    });
+  });
+
+  group('dartFilesFromLib', () {
+    test('does not follow symlinks outside package lib', () async {
+      await withTempDir((dir) async {
+        final outsideDir = await Directory.systemTemp.createTemp('outside_');
+        try {
+          File(
+            p.join(outsideDir.path, 'outside.dart'),
+          ).writeAsStringSync('void f() {}');
+          final libDir = Directory(p.join(dir, 'lib'))..createSync();
+          File(
+            p.join(libDir.path, 'local.dart'),
+          ).writeAsStringSync('void g() {}');
+
+          final link = Link(p.join(libDir.path, 'outside_lib'));
+          await link.create(outsideDir.path);
+
+          final dartFiles = dartFilesFromLib(dir);
+          expect(dartFiles, ['local.dart']);
+        } finally {
+          await outsideDir.delete(recursive: true);
+        }
+      });
     });
   });
 }


### PR DESCRIPTION
Disables following symlinks in `listFiles`, `dartFilesFromLib`, `copyDir`, and package directory file inspections (`followLinks: false`).

This prevents directory traversal out of tree when analyzing untrusted packages that contain directory symlinks, avoiding unexpected file scanning or deletion of out-of-tree `._*` files when `deleteBadExtracted: true`.