### PR TITLE
fix(tagger): check web plugin implementations for is:wasm-ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.23.18-wip
 
 - Prevent following symlinks when listing and inspecting files in a package directory.
+- Tagger now checks web plugin implementations for `is:wasm-ready`.
 - `--project-root` CLI option to specify the project's root directory.
   When specified, `pana` copies the entire tree for analysis.  
   **BREAKING CHANGE**: the git-based detection is no longer used, users

--- a/lib/src/tag/tagger.dart
+++ b/lib/src/tag/tagger.dart
@@ -358,6 +358,9 @@ class Tagger {
     return TaggingResult(innerTags, innerExplanations);
   }
 
+  /// Returns the declared web plugin platform implementation library URIs
+  /// from `pubspec.yaml` (under `flutter.plugin.platforms.web.fileName`,
+  /// defaulting to `<package_name>_web.dart`), if the file exists.
   List<Uri> _getWebPluginLibraries() {
     final pubspec = _pubspecCache.pubspecOfPackage(packageName);
     if (!pubspec.hasFlutterPluginKey) return const <Uri>[];
@@ -371,7 +374,7 @@ class Tagger {
     final webConfig = platforms['web'];
     if (webConfig is! Map) return const <Uri>[];
 
-    String fileName = '${packageName}_web.dart';
+    var fileName = '${packageName}_web.dart';
     if (webConfig['fileName'] is String) {
       fileName = webConfig['fileName'] as String;
     }

--- a/lib/src/tag/tagger.dart
+++ b/lib/src/tag/tagger.dart
@@ -278,6 +278,12 @@ class Tagger {
     final innerTags = <String>{};
     final innerExplanations = <Explanation>[];
     try {
+      final webPluginLibraries =
+          (platform.name == 'Web' || runtime.name == 'web')
+          ? _getWebPluginLibraries()
+          : const <Uri>[];
+      final librariesToCheck = [..._topLibraries, ...webPluginLibraries];
+
       final libraryGraph = LibraryGraph(_session, runtime.declaredVariables);
       final declaredPlatformDetector = DeclaredPlatformDetector(_pubspecCache);
       final violationFinder = PlatformViolationFinder(
@@ -330,7 +336,7 @@ class Tagger {
       // Report only the first non-pruned violation as Explanation
       final firstNonPrunedViolation = violationFinder.firstViolation(
         packageName,
-        _topLibraries,
+        librariesToCheck,
       );
       if (firstNonPrunedViolation != null) {
         innerExplanations.add(firstNonPrunedViolation);
@@ -339,7 +345,7 @@ class Tagger {
       // Tag is supported, if there is no pruned violations
       final firstPrunedViolation = prunedViolationFinder.firstViolation(
         packageName,
-        _topLibraries,
+        librariesToCheck,
       );
       if (firstPrunedViolation == null) {
         innerTags.add(platform.tag);
@@ -350,6 +356,32 @@ class Tagger {
       );
     }
     return TaggingResult(innerTags, innerExplanations);
+  }
+
+  List<Uri> _getWebPluginLibraries() {
+    final pubspec = _pubspecCache.pubspecOfPackage(packageName);
+    if (!pubspec.hasFlutterPluginKey) return const <Uri>[];
+
+    final plugin = pubspec.originalYaml['flutter'];
+    if (plugin is! Map || plugin['plugin'] is! Map) return const <Uri>[];
+
+    final platforms = plugin['plugin']['platforms'];
+    if (platforms is! Map) return const <Uri>[];
+
+    final webConfig = platforms['web'];
+    if (webConfig is! Map) return const <Uri>[];
+
+    String fileName = '${packageName}_web.dart';
+    if (webConfig['fileName'] is String) {
+      fileName = webConfig['fileName'] as String;
+    }
+
+    final fileUri = Uri.parse('package:$packageName/$fileName');
+    final path = _session.uriConverter.uriToPath(fileUri);
+    if (path != null && File(path).existsSync()) {
+      return <Uri>[fileUri];
+    }
+    return const <Uri>[];
   }
 
   /// Adds tags for Flutter plugins.
@@ -373,7 +405,7 @@ class Tagger {
       ),
     );
     var supports = true;
-    for (final lib in _topLibraries) {
+    for (final lib in [..._topLibraries, ..._getWebPluginLibraries()]) {
       final violationResult = finder.findViolation(lib);
       if (violationResult != null) {
         explanations.add(violationResult);

--- a/lib/src/tag/tagger.dart
+++ b/lib/src/tag/tagger.dart
@@ -379,7 +379,8 @@ class Tagger {
       fileName = webConfig['fileName'] as String;
     }
 
-    final fileUri = Uri.parse('package:$packageName/$fileName');
+    final fileUri = Uri.tryParse('package:$packageName/$fileName');
+    if (fileUri == null) return const <Uri>[];
     final path = _session.uriConverter.uriToPath(fileUri);
     if (path != null && File(path).existsSync()) {
       return <Uri>[fileUri];

--- a/test/tag/tag_end2end_test.dart
+++ b/test/tag/tag_end2end_test.dart
@@ -773,6 +773,53 @@ name: my_package
   });
 
   group('wasm tag', () {
+    test('Excluded by web plugin using dart:html', () async {
+      final descriptor = d.dir('cache', [
+        packageWithPathDeps(
+          'my_package',
+          lib: [
+            d.file('my_package.dart', '''
+int fourtyTwo() => 42;
+'''),
+            d.file('my_package_web.dart', '''
+import 'dart:html';
+int fourtyThree() => 43;
+'''),
+          ],
+          pubspecExtras: {
+            'environment': {'flutter': '>=1.2.0<=2.0.0'},
+            'flutter': {
+              'plugin': {
+                'platforms': {
+                  'web': <String, dynamic>{
+                    'pluginClass': 'MyPackageWeb',
+                    'fileName': 'my_package_web.dart',
+                  },
+                },
+              },
+            },
+          },
+        ),
+      ]);
+
+      await descriptor.create();
+      final tagger = Tagger('${descriptor.io.path}/my_package');
+      _expectTagging(
+        tagger.wasmReadyTag,
+        tags: isNot(contains('is:wasm-ready')),
+        explanations: [
+          _explanation(
+            finding: 'Package not compatible with runtime wasm',
+            explanation: '''
+Because:
+* `package:my_package/my_package_web.dart` that imports:
+* `dart:html`''',
+            tag: 'is:wasm-ready',
+          ),
+        ],
+      );
+    });
+
     test('Excluded with dart:js', () async {
       final descriptor = d.dir('cache', [
         packageWithPathDeps(


### PR DESCRIPTION
This fixes false positive `is:wasm-ready` tags for Flutter web plugins that import `dart:html` or `package:js` in their web implementations (e.g. `ua_client_hints`) by explicitly evaluating web plugin `fileName` definitions during web runtime verification.
