### PR TITLE
Updated dev_dependency handling: keep for analysis, remove for upgradability.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.23.18-wip
 
 - Prevent following symlinks when listing and inspecting files in a package directory.
+- Updated `dev_dependency` handling: keep for analysis, remove for upgradability.
 - `--project-root` CLI option to specify the project's root directory.
   When specified, `pana` copies the entire tree for analysis.  
   **BREAKING CHANGE**: the git-based detection is no longer used, users

--- a/lib/src/package_context.dart
+++ b/lib/src/package_context.dart
@@ -191,11 +191,20 @@ class PackageContext {
     try {
       log.info('Analyzing pub downgrade...');
       final tool = usesFlutter ? 'flutter' : 'dart';
-      final pr = await toolEnvironment.runPub(
+      var pr = await toolEnvironment.runPub(
         packageDir,
         usesFlutter: usesFlutter,
         command: 'downgrade',
       );
+      // try to downgrade without the dev-dependencies
+      if (pr.wasError) {
+        pr = await toolEnvironment.runPub(
+          packageDir,
+          usesFlutter: usesFlutter,
+          command: 'downgrade',
+          stripAllDevDependencies: true,
+        );
+      }
       if (pr.wasError) {
         log.info('[pub-downgrade-error]');
         log.info(pr.asJoinedOutput);
@@ -205,6 +214,7 @@ class PackageContext {
           usesFlutter: usesFlutter,
           command: 'downgrade',
           verbose: true,
+          stripAllDevDependencies: true,
         );
         log.info(rerun.asJoinedOutput);
         return '`$tool pub downgrade` failed with:\n\n```\n${pr.asTrimmedOutput}\n```\n';

--- a/lib/src/sdk_env.dart
+++ b/lib/src/sdk_env.dart
@@ -397,6 +397,7 @@ class ToolEnvironment {
     required String command,
     bool verbose = false,
     bool throwOnError = false,
+    bool stripAllDevDependencies = false,
   }) async {
     return await _withStripAndAugmentPubspecYaml(packageDir, () async {
       return await _sandboxRunner.runSandboxed(
@@ -412,7 +413,7 @@ class ToolEnvironment {
         writableCurrentDir: true,
         throwOnError: throwOnError,
       );
-    });
+    }, stripAllDevDependencies: stripAllDevDependencies);
   }
 
   Future<Outdated> runPubOutdated(
@@ -516,7 +517,7 @@ class ToolEnvironment {
               .toList(),
         );
       }
-    });
+    }, stripAllDevDependencies: true);
   }
 
   Future<PanaProcessResult> dartdoc(
@@ -610,10 +611,14 @@ class ToolEnvironment {
   /// original content upon return.
   Future<R> _withStripAndAugmentPubspecYaml<R>(
     String packageDir,
-    FutureOr<R> Function() fn,
-  ) async {
+    FutureOr<R> Function() fn, {
+    required bool stripAllDevDependencies,
+  }) async {
     final now = DateTime.now();
-    final pubspecBackup = await _stripAndAugmentPubspecYaml(packageDir);
+    final pubspecBackup = await _stripAndAugmentPubspecYaml(
+      packageDir,
+      stripAllDevDependencies: stripAllDevDependencies,
+    );
 
     // Create a backup of the pubspec_overrides.yaml file.
     final pubspecOverridesFile = File(
@@ -646,44 +651,21 @@ class ToolEnvironment {
   ///   its own.
   ///
   /// Returns the backup file with the original content.
-  Future<File> _stripAndAugmentPubspecYaml(String packageDir) async {
+  Future<File> _stripAndAugmentPubspecYaml(
+    String packageDir, {
+    required bool stripAllDevDependencies,
+  }) async {
     final now = DateTime.now();
     final backup = File(
       p.join(packageDir, 'pana-${now.millisecondsSinceEpoch}-pubspec.yaml'),
     );
 
-    // extract the package name from the `include: package:<package>/path.yaml` entry in analysis options:
-    final includedPackages = <String>{};
-    final analysisOptionsFile = File(
-      p.join(packageDir, 'analysis_options.yaml'),
-    );
-    if (await analysisOptionsFile.exists()) {
-      void addPackageInclude(String includeValue) {
-        final include = includeValue.trim();
-        if (include.startsWith('package:')) {
-          includedPackages.add(
-            include.substring('package:'.length).split('/').first,
-          );
-        }
-      }
-
-      final analysisOptions = await analysisOptionsFile.readAsString();
-      final parsed = yamlToJson(analysisOptions);
-      final includeValue = parsed?['include'];
-      if (includeValue is String) {
-        addPackageInclude(includeValue);
-      } else if (includeValue is List) {
-        for (final v in includeValue.whereType<String>()) {
-          addPackageInclude(v);
-        }
-      }
-    }
-
     final pubspec = File(p.join(packageDir, 'pubspec.yaml'));
     final original = await pubspec.readAsString();
     final parsed = yamlToJson(original) ?? <String, dynamic>{};
     final oldDevDependencies = parsed.remove('dev_dependencies');
-    if (oldDevDependencies is Map<String, dynamic>) {
+    if (!stripAllDevDependencies &&
+        oldDevDependencies is Map<String, dynamic>) {
       final keptDevDependencies = <String, dynamic>{};
       for (final name in oldDevDependencies.keys) {
         final value = oldDevDependencies[name];
@@ -713,17 +695,8 @@ class ToolEnvironment {
           continue;
         }
 
-        // keep SDK dependencies
-        if (value is Map && value.containsKey('sdk')) {
-          keptDevDependencies[name] = value;
-          continue;
-        }
-
-        // keep included dependencies from analysis options
-        if (includedPackages.contains(name)) {
-          keptDevDependencies[name] = value;
-          continue;
-        }
+        // keeping the dependency otherwise
+        keptDevDependencies[name] = value;
       }
       if (keptDevDependencies.isNotEmpty) {
         parsed['dev_dependencies'] = keptDevDependencies;

--- a/test/goldens/end2end/audio_service-0.18.17.json
+++ b/test/goldens/end2end/audio_service-0.18.17.json
@@ -173,10 +173,10 @@
       {
         "id": "analysis",
         "title": "Pass static analysis",
-        "grantedPoints": 40,
+        "grantedPoints": 50,
         "maxPoints": 50,
-        "status": "partial",
-        "summary": "### [~] 40/50 points: code has no errors, warnings, lints, or formatting issues\n\n<details>\n<summary>\nINFO: The parameter name 'newQueue' doesn't match the name 'queue' in the overridden method.\n</summary>\n\n`lib/audio_service.dart:3321:44`\n\n```\n     ╷\n3321 │   Future<void> updateQueue(List<MediaItem> newQueue) async {\n     │                                            ^^^^^^^^\n     ╵\n```\n\nTo reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/audio_service.dart`\n</details>\n"
+        "status": "passed",
+        "summary": "### [*] 50/50 points: code has no errors, warnings, lints, or formatting issues\n"
       },
       {
         "id": "dependency",
@@ -215,7 +215,7 @@
         ]
       }
     ],
-    "grantedPoints": 120,
+    "grantedPoints": 130,
     "maxPoints": 150
   },
   "urlProblems": []

--- a/test/goldens/end2end/audio_service-0.18.17.json_report.md
+++ b/test/goldens/end2end/audio_service-0.18.17.json_report.md
@@ -91,26 +91,9 @@ Because:
 **Built-in Kotlin-ready:** This Android plugin supports built-in Kotlin. See https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors for details.
 
 
-## 40/50 Pass static analysis
+## 50/50 Pass static analysis
 
-### [~] 40/50 points: code has no errors, warnings, lints, or formatting issues
-
-<details>
-<summary>
-INFO: The parameter name 'newQueue' doesn't match the name 'queue' in the overridden method.
-</summary>
-
-`lib/audio_service.dart:3321:44`
-
-```
-     ╷
-3321 │   Future<void> updateQueue(List<MediaItem> newQueue) async {
-     │                                            ^^^^^^^^
-     ╵
-```
-
-To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `flutter analyze lib/audio_service.dart`
-</details>
+### [*] 50/50 points: code has no errors, warnings, lints, or formatting issues
 
 
 ## 30/40 Support up-to-date dependencies

--- a/test/goldens/end2end/gg-1.0.12.json
+++ b/test/goldens/end2end/gg-1.0.12.json
@@ -143,10 +143,10 @@
       {
         "id": "analysis",
         "title": "Pass static analysis",
-        "grantedPoints": 40,
+        "grantedPoints": 50,
         "maxPoints": 50,
-        "status": "partial",
-        "summary": "### [~] 40/50 points: code has no errors, warnings, lints, or formatting issues\n\n<details>\n<summary>\nINFO: The member 'get' overrides an inherited member but isn't annotated with '@override'.\n</summary>\n\n`lib/src/tools/did_command.dart:59:16`\n\n```\n   ╷\n59 │   Future<bool> get({\n   │                ^^^\n   ╵\n```\n\nTo reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/src/tools/did_command.dart`\n</details>\n"
+        "status": "passed",
+        "summary": "### [*] 50/50 points: code has no errors, warnings, lints, or formatting issues\n"
       },
       {
         "id": "dependency",
@@ -176,7 +176,7 @@
         ]
       }
     ],
-    "grantedPoints": 110,
+    "grantedPoints": 120,
     "maxPoints": 150
   },
   "urlProblems": []

--- a/test/goldens/end2end/gg-1.0.12.json_report.md
+++ b/test/goldens/end2end/gg-1.0.12.json_report.md
@@ -59,26 +59,9 @@ Because:
 </details>
 
 
-## 40/50 Pass static analysis
+## 50/50 Pass static analysis
 
-### [~] 40/50 points: code has no errors, warnings, lints, or formatting issues
-
-<details>
-<summary>
-INFO: The member 'get' overrides an inherited member but isn't annotated with '@override'.
-</summary>
-
-`lib/src/tools/did_command.dart:59:16`
-
-```
-   ╷
-59 │   Future<bool> get({
-   │                ^^^
-   ╵
-```
-
-To reproduce make sure you are using the [lints_core](https://pub.dev/packages/lints) and run `dart analyze lib/src/tools/did_command.dart`
-</details>
+### [*] 50/50 points: code has no errors, warnings, lints, or formatting issues
 
 
 ## 10/40 Support up-to-date dependencies

--- a/test/goldens/end2end/skiplist-0.1.0.json
+++ b/test/goldens/end2end/skiplist-0.1.0.json
@@ -76,8 +76,15 @@
   },
   "screenshots": [],
   "result": {
-    "homepageUrl": "https://github.com/stevenroose/dart-skiplist",
-    "repositoryStatus": "inconclusive",
+    "repositoryUrl": "https://github.com/stevenroose/dart-skiplist",
+    "issueTrackerUrl": "https://github.com/stevenroose/dart-skiplist/issues",
+    "repositoryStatus": "verified",
+    "repository": {
+      "provider": "github",
+      "host": "github.com",
+      "repository": "stevenroose/dart-skiplist",
+      "branch": "master"
+    },
     "licenses": [
       {
         "spdxIdentifier": "MIT",

--- a/test/goldens/end2end/skiplist-0.1.0.json
+++ b/test/goldens/end2end/skiplist-0.1.0.json
@@ -76,15 +76,8 @@
   },
   "screenshots": [],
   "result": {
-    "repositoryUrl": "https://github.com/stevenroose/dart-skiplist",
-    "issueTrackerUrl": "https://github.com/stevenroose/dart-skiplist/issues",
-    "repositoryStatus": "verified",
-    "repository": {
-      "provider": "github",
-      "host": "github.com",
-      "repository": "stevenroose/dart-skiplist",
-      "branch": "master"
-    },
+    "homepageUrl": "https://github.com/stevenroose/dart-skiplist",
+    "repositoryStatus": "inconclusive",
     "licenses": [
       {
         "spdxIdentifier": "MIT",


### PR DESCRIPTION
Note: I've added a fallback logic for `pub downgrade` - it tries regular downgrade, then it tries it without dev-dependencies, to prevent a regression which was revealed by the end2end tests.